### PR TITLE
Add SQL for creating users and databases

### DIFF
--- a/.dev/sql/init.sql
+++ b/.dev/sql/init.sql
@@ -1,0 +1,11 @@
+CREATE DATABASE IF NOT EXISTS credentials;
+GRANT ALL ON credentials.* TO 'credentials001'@'%' IDENTIFIED BY 'password';
+
+CREATE DATABASE IF NOT EXISTS discovery;
+GRANT ALL ON discovery.* TO 'discov001'@'%' IDENTIFIED BY 'password';
+
+CREATE DATABASE IF NOT EXISTS ecommerce;
+GRANT ALL ON ecommerce.* TO 'ecomm001'@'%' IDENTIFIED BY 'password';
+
+CREATE DATABASE IF NOT EXISTS programs;
+GRANT ALL ON programs.* TO 'programs001'@'%' IDENTIFIED BY 'password';

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       - "3306:3306"
     volumes:
       - ./.dev/volumes/mysql:/var/lib/mysql
+      - ./.dev/sql:/docker-entrypoint-initdb.d
 
   # edX services
   credentials:


### PR DESCRIPTION
The included script is idempotent, executed when the mysql container is initialized. This approach is borrowed from https://github.com/docker-library/mysql/pull/18.

ECOM-6563

@clintonb @jmbowman @davec-edx 