### PR TITLE
Create shallow clones of edX repos

### DIFF
--- a/clone.sh
+++ b/clone.sh
@@ -25,7 +25,7 @@ do
     if [ -d "$name" ]; then
         printf "The [%s] repo is already checked out. Continuing.\n" $name
     else
-        git clone $repo
+        git clone --depth 1 $repo
     fi
     cd - &> /dev/null
 done


### PR DESCRIPTION
This brings the size of the edx-platform checkout down from 750 MB to 40 MB. @clintonb 