### PR TITLE
Make clone script more portable

### DIFF
--- a/clone.sh
+++ b/clone.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Script for cloning Git repos housing edX services. These repos are mounted as
 # data volumes into their corresponding Docker containers to facilitate development.


### PR DESCRIPTION
Bash won't always be at /bin/bash.