### PR TITLE
Excluding static asset directories from volume sharing

### DIFF
--- a/docker-compose-host.yml
+++ b/docker-compose-host.yml
@@ -3,13 +3,26 @@ version: "2.1"
 services:
   credentials:
     volumes:
+      - /edx/app/credentials/credentials/credentials/assets/
+      - /edx/app/credentials/credentials/credentials/static/bundles/
+      - /edx/app/credentials/credentials/node_modules/
       - ../credentials:/edx/app/credentials/credentials
   discovery:
       volumes:
+      - /edx/app/discovery/discovery/course_discovery/assets/
+      - /edx/app/discovery/discovery/course_discovery/static/bower_components/
+      - /edx/app/discovery/discovery/course_discovery/static/build/
+      - /edx/app/discovery/discovery/node_modules/
       - ../course-discovery:/edx/app/discovery/discovery
   ecommerce:
     volumes:
+      - /edx/app/ecommerce/ecommerce/assets/
+      - /edx/app/ecommerce/ecommerce/ecommerce/static/bower_components/
+      - /edx/app/ecommerce/ecommerce/ecommerce/static/build/
+      - /edx/app/ecommerce/ecommerce/node_modules/
       - ../ecommerce:/edx/app/ecommerce/ecommerce
   edxapp:
     volumes:
+      - /edx/app/edxapp/edx-platform/.prereqs_cache/
+      - /edx/app/edxapp/edx-platform/node_modules/
       - ../edx-platform:/edx/app/edxapp/edx-platform

--- a/docker-sync.yml
+++ b/docker-sync.yml
@@ -9,6 +9,7 @@ syncs:
     src: '../credentials/'
     dest: '/edx/app/credentials/credentials'
     sync_args: '-v --copy-links --hard-links'
+    sync_excludes: [ '.git', '.idea', 'node_modules', 'credentials/assets', 'credentials/static/bundles' ]
     sync_host_ip: 'localhost'
     sync_host_port: 10872
     sync_strategy: 'rsync'
@@ -17,6 +18,7 @@ syncs:
     src: '../course-discovery/'
     dest: '/edx/app/discovery/discovery'
     sync_args: '-v --copy-links --hard-links'
+    sync_excludes: [ '.git', '.idea', 'node_modules', 'course_discovery/assets', 'course_discovery/static/bower_components', 'course_discovery/static/build' ]
     sync_host_ip: 'localhost'
     sync_host_port: 10873
     sync_strategy: 'rsync'
@@ -25,6 +27,7 @@ syncs:
     src: '../ecommerce/'
     dest: '/edx/app/ecommerce/ecommerce'
     sync_args: '-v --copy-links --hard-links'
+    sync_excludes: [ '.git', '.idea', 'node_modules', 'assets', 'ecommerce/static/bower_components', 'ecommerce/static/build' ]
     sync_host_ip: 'localhost'
     sync_host_port: 10874
     sync_strategy: 'rsync'
@@ -33,6 +36,7 @@ syncs:
     src: '../edx-platform/'
     dest: '/edx/app/edxapp/edx-platform'
     sync_args: '-v --copy-links --hard-links'
+    sync_excludes: [ '.git', '.idea', 'node_modules', '.prereqs_cache' ]
     sync_host_ip: 'localhost'
     sync_host_port: 10875
     sync_strategy: 'rsync'


### PR DESCRIPTION
Static assets are installed/compiled when the images are built. Sharing
these files from the host usually results in assets needing to be
recompiled unnecessarily. Excluding them eliminates confusion around
this process and ensures only the source code is shared.