### PR TITLE
Exit provisioning scripts on any error

### DIFF
--- a/load-db.sh
+++ b/load-db.sh
@@ -7,6 +7,9 @@
 #
 # This will load the edxapp database from a file named exapp.sql.
 
+set -e
+set -o pipefail
+
 if [ -z "$1" ]
 then
     echo "You must supply a database name!"

--- a/provision.sh
+++ b/provision.sh
@@ -8,6 +8,9 @@
 # 4. Static assets compiled/collected.
 
 
+set -e
+set -o pipefail
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[0;33m'


### PR DESCRIPTION
I haven't played around with timeouts, but I was definitely missing tables after student_.. in alphabetical order, so I assume there was a timeout that the shell scripts plowed through. This should hopefully make the scripts exit on any error rather than pushing ahead.