### PR TITLE
Split prerequisite installation from database updates for edxapp

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -46,7 +46,8 @@ docker-compose up -d
 ./load-db.sh edxapp_csmh
 
 # Run edxapp migrations first since they are needed for the service users and OAuth clients
-docker exec -t edx.devstack.edxapp  bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform && paver update_db --settings devstack_docker'
+docker exec -t edx.devstack.edxapp  bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform && paver install_prereqs'
+docker exec -t edx.devstack.edxapp  bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform && NO_PREREQ_INSTALL=1 paver update_db --settings devstack_docker'
 
 # Create a superuser for edxapp
 docker exec -t edx.devstack.edxapp  bash -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker manage_user edx edx@example.com --superuser --staff'


### PR DESCRIPTION
The merging of these two steps causes confusion when the prereq installation fails, preventing migrations from being run, yet the provisioning process continues. Splitting them out will ensure that users are aware when provisioning fails.

See #72