### PR TITLE
Using Django runserver to serve applications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,12 @@ devstack.destroy: ## Destroy all containers and volumes
 devstack.open.%: ## Open a shell into the specified service container
 	docker exec -it edx.devstack.$* env TERM=$(TERM) /edx/app/$*/devstack.sh open
 
+devstack.open.lms: ## Open a shell into the LMS container
+	docker exec -it edx.devstack.lms env TERM=$(TERM) /edx/app/edxapp/devstack.sh open
+
+devstack.open.studio: ## Open a shell into the Studio container
+	docker exec -it edx.devstack.studio env TERM=$(TERM) /edx/app/edxapp/devstack.sh open
+
 devstack.provision: ## Provision all services
 	./provision.sh
 

--- a/docker-compose-host.yml
+++ b/docker-compose-host.yml
@@ -21,7 +21,12 @@ services:
       - /edx/app/ecommerce/ecommerce/ecommerce/static/build/
       - /edx/app/ecommerce/ecommerce/node_modules/
       - ../ecommerce:/edx/app/ecommerce/ecommerce
-  edxapp:
+  lms:
+    volumes:
+      - /edx/app/edxapp/edx-platform/.prereqs_cache/
+      - /edx/app/edxapp/edx-platform/node_modules/
+      - ../edx-platform:/edx/app/edxapp/edx-platform
+  studio:
     volumes:
       - /edx/app/edxapp/edx-platform/.prereqs_cache/
       - /edx/app/edxapp/edx-platform/node_modules/

--- a/docker-compose-sync.yml
+++ b/docker-compose-sync.yml
@@ -10,7 +10,10 @@ services:
   ecommerce:
     volumes:
       - ecommerce-sync:/edx/app/ecommerce/ecommerce:rw
-  edxapp:
+  lms:
+    volumes:
+      - edxapp-sync:/edx/app/edxapp/edx-platform:rw
+  studio:
     volumes:
       - edxapp-sync:/edx/app/edxapp/edx-platform:rw
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
 
   # edX services
   credentials:
-    command: /edx/app/credentials/devstack.sh start
+    command: bash -c 'source /edx/app/credentials/credentials_env && python /edx/app/credentials/credentials/manage.py runserver 0.0.0.0:18150'
     container_name: edx.devstack.credentials
     depends_on:
       - mysql
@@ -68,7 +68,7 @@ services:
       - "18150:18150"
 
   discovery:
-    command: /edx/app/discovery/devstack.sh start
+    command: bash -c 'source /edx/app/discovery/discovery_env && python /edx/app/discovery/discovery/manage.py runserver 0.0.0.0:18381'
     container_name: edx.devstack.discovery
     depends_on:
       - mysql
@@ -82,7 +82,7 @@ services:
       - "18381:18381"
 
   ecommerce:
-    command: /edx/app/ecommerce/devstack.sh start
+    command: bash -c 'source /edx/app/ecommerce/ecommerce_env && python /edx/app/ecommerce/ecommerce/manage.py runserver 0.0.0.0:18130'
     container_name: edx.devstack.ecommerce
     depends_on:
       - mysql
@@ -94,9 +94,9 @@ services:
     ports:
       - "18130:18130"
 
-  edxapp:
-    command: /edx/app/edxapp/devstack.sh start
-    container_name: edx.devstack.edxapp
+  lms:
+    command: bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform && NO_PREREQ_INSTALL=1 paver lms --port 18000 --fast --settings devstack_docker'
+    container_name: edx.devstack.lms
     depends_on:
       - mysql
       - memcached
@@ -104,7 +104,17 @@ services:
     image: edxops/edxapp:devstack
     ports:
       - "18000:18000"
-      - "18010:18010"
+
+  studio:
+      command: bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform && NO_PREREQ_INSTALL=1 paver studio --port 18010 --fast --settings devstack_docker'
+      container_name: edx.devstack.studio
+      depends_on:
+        - mysql
+        - memcached
+        - mongo
+      image: edxops/edxapp:devstack
+      ports:
+        - "18010:18010"
 
 volumes:
   elasticsearch_data:


### PR DESCRIPTION
Our initial desire to make development look like production by using nginx and supervisor is conflicting with our goal of easing local development pains. Specifically, front-end development requires re-compiling/collecting static assets with every change. Using Django to serve the applications alleviates this pain and allows developers to maintain their current workflows.