### PR TITLE
Use Docker's prune command for devstack destruction

### DIFF
--- a/destroy.sh
+++ b/destroy.sh
@@ -5,7 +5,5 @@ if [[ $REPLY =~ ^[Yy]$ ]]
 then
     echo
     docker-compose down
-    docker volume rm devstack_mysql_data
-    docker volume rm devstack_mongo_data
-    docker volume rm devstack_elasticsearch_data
+    docker system prune --force
 fi


### PR DESCRIPTION
No need to reinvent the wheel here. I'm using `--force` since the script already prompts for confirmation.