### PR TITLE
Removed cross-service dependencies on discovery

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,6 @@ services:
     depends_on:
       - mysql
       - memcached
-      - discovery
     environment:
       ENABLE_DJANGO_TOOLBAR: 1
     image: edxops/credentials:devstack
@@ -87,7 +86,6 @@ services:
     depends_on:
       - mysql
       - memcached
-      - discovery
     environment:
       ENABLE_DJANGO_TOOLBAR: 1
     image: edxops/ecommerce:devstack


### PR DESCRIPTION
The dependency on the discovery service by credentials and ecommerce is not necessary. Having this dependency unnecessarily brings up the discovery and elasticsearch services when we want to run a single service.