### PR TITLE
Add curl health checks for ecomm, studio and LMS to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,4 @@ before_install:
 
 script:
   - make provision
+  - make healthchecks

--- a/Makefile
+++ b/Makefile
@@ -55,3 +55,6 @@ lms-shell: ## Run a shell on the LMS container
 
 studio-shell: ## Run a shell on the Studio container
 	docker exec -it edx.devstack.studio env TERM=$(TERM) /edx/app/edxapp/devstack.sh open
+
+healthchecks: ## Run a curl against all services' healthcheck endpoints to make sure they are up. This will eventually be parameterized
+	./healthchecks.sh

--- a/healthchecks.sh
+++ b/healthchecks.sh
@@ -1,0 +1,11 @@
+set -e
+set -x
+
+echo "Checking LMS heartbeat:"
+curl http://localhost:18000/heartbeat # LMS
+echo
+echo "Checking Studio heartbeat:"
+curl http://localhost:18010/heartbeat # Studio
+echo
+echo "Checking ecommerce health:"
+curl http://localhost:18130/health/ # Ecommerce


### PR DESCRIPTION
Create 'make healthchecks' to run healthchecks against active services. Still need to add credentials (not currently running on my machine for some reason) and discovery (once it's been fixed).