### PR TITLE
Pulling from the latest tag for LMS and Studio

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,7 +99,7 @@ services:
       - mysql
       - memcached
       - mongo
-    image: edxops/edxapp:devstack
+    image: edxops/edxapp:latest
     ports:
       - "18000:18000"
 
@@ -110,7 +110,7 @@ services:
         - mysql
         - memcached
         - mongo
-      image: edxops/edxapp:devstack
+      image: edxops/edxapp:latest
       ports:
         - "18010:18010"
 


### PR DESCRIPTION
The configuration changes for these images has been merged to the master
branch of edx/configuration. We can now pull from the "official" latest
tag rather than devstack.