### PR TITLE
Starting LMS and Studio with manage.py

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
       - "18130:18130"
 
   lms:
-    command: bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform && NO_PREREQ_INSTALL=1 paver lms --port 18000 --fast --settings devstack_docker'
+    command: bash -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms runserver 0.0.0.0:18000 --settings devstack_docker'
     container_name: edx.devstack.lms
     depends_on:
       - mysql
@@ -104,15 +104,15 @@ services:
       - "18000:18000"
 
   studio:
-      command: bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform && NO_PREREQ_INSTALL=1 paver studio --port 18010 --fast --settings devstack_docker'
-      container_name: edx.devstack.studio
-      depends_on:
-        - mysql
-        - memcached
-        - mongo
-      image: edxops/edxapp:latest
-      ports:
-        - "18010:18010"
+    command: bash -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py cms runserver 0.0.0.0:18010 --settings devstack_docker'
+    container_name: edx.devstack.studio
+    depends_on:
+      - mysql
+      - memcached
+      - mongo
+    image: edxops/edxapp:latest
+    ports:
+      - "18010:18010"
 
 volumes:
   elasticsearch_data:

--- a/provision-lms.sh
+++ b/provision-lms.sh
@@ -9,7 +9,7 @@ set -x
 # Bring LMS online
 docker-compose $DOCKER_COMPOSE_FILES up -d lms
 
-docker-compose exec lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform && paver install_prereqs'
+docker-compose exec lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform && NO_PYTHON_UNINSTALL=1 paver install_prereqs'
 
 #Installing prereqs crashes the process
 docker-compose restart lms


### PR DESCRIPTION
Despite the environment variable overrides, Paver still seems to be
doing more than is necessary to start LMS and Studio. Skip Paver, and
run the server directly via Django's manage.py, like every other
service.