### PR TITLE
Disabled removal of Python libs on LMS and Studio

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,6 +99,8 @@ services:
       - mysql
       - memcached
       - mongo
+    environment:
+      NO_PYTHON_UNINSTALL: 1
     image: edxops/edxapp:latest
     ports:
       - "18000:18000"
@@ -110,6 +112,8 @@ services:
       - mysql
       - memcached
       - mongo
+    environment:
+      NO_PYTHON_UNINSTALL: 1
     image: edxops/edxapp:latest
     ports:
       - "18010:18010"


### PR DESCRIPTION
This environment variable instructs edxapp to NOT remove old Python libs when install prerequisites since our images/containers will never have the older versions.