### PR TITLE
Updated for compatibility with Docker Sync 0.4.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ dev.up: ## Bring up all services with host volumes
 	docker-compose -f docker-compose.yml -f docker-compose-host.yml up -d
 
 dev.sync.daemon.start: ## Start the docker-sycn daemon
-	docker-sync-daemon start
+	docker-sync start
 
 dev.sync.provision: | dev.sync.daemon.start dev.provision ## Provision with docker-sync enabled
 
@@ -42,11 +42,11 @@ provision: ## Provision all services using the Docker volume
 	./provision.sh
 
 stop: ## Stop all services
-	(test -d .docker-sync && docker-sync-daemon stop) || true ## Ignore failure here
+	(test -d .docker-sync && docker-sync stop) || true ## Ignore failure here
 	docker-compose stop
 
 down: ## Remove all service containers and networks
-	test -d .docker-sync && docker-sync-daemon clean
+	test -d .docker-sync && docker-sync clean
 	docker-compose down
 
 destroy: ## Remove all devstack-related containers, networks, and volumes

--- a/destroy.sh
+++ b/destroy.sh
@@ -8,8 +8,8 @@ then
     echo
     if [[ "$OSTYPE" == "darwin"* ]]; then
         set +e
-        docker-sync-daemon stop
-        docker-sync-daemon clean
+        docker-sync stop
+        docker-sync clean
         set -e
     fi
     docker-compose down -v

--- a/docker-compose-marketing-site-sync.yml
+++ b/docker-compose-marketing-site-sync.yml
@@ -3,7 +3,7 @@ version: "2.1"
 services:
   marketing:
     volumes:
-      - marketing-sync:/var/www/html:rw
+      - marketing-sync:/var/www/html:nocopy
 
 volumes:
   marketing-sync:

--- a/docker-compose-sync.yml
+++ b/docker-compose-sync.yml
@@ -3,19 +3,19 @@ version: "2.1"
 services:
   credentials:
     volumes:
-      - credentials-sync:/edx/app/credentials/credentials:rw
+      - credentials-sync:/edx/app/credentials/credentials:nocopy
   discovery:
     volumes:
-      - discovery-sync:/edx/app/discovery/discovery:rw
+      - discovery-sync:/edx/app/discovery/discovery:nocopy
   ecommerce:
     volumes:
-      - ecommerce-sync:/edx/app/ecommerce/ecommerce:rw
+      - ecommerce-sync:/edx/app/ecommerce/ecommerce:nocopy
   lms:
     volumes:
-      - edxapp-sync:/edx/app/edxapp/edx-platform:rw
+      - edxapp-sync:/edx/app/edxapp/edx-platform:nocopy
   studio:
     volumes:
-      - edxapp-sync:/edx/app/edxapp/edx-platform:rw
+      - edxapp-sync:/edx/app/edxapp/edx-platform:nocopy
 
 volumes:
   credentials-sync:

--- a/docker-sync-marketing-site.yml
+++ b/docker-sync-marketing-site.yml
@@ -11,47 +11,21 @@ options:
 syncs:
   credentials-sync:
     src: '../credentials/'
-    dest: '/edx/app/credentials/credentials'
-    sync_args: '-v --copy-links --hard-links'
     sync_excludes: [ '.git', '.idea', 'node_modules', 'credentials/assets', 'credentials/static/bundles' ]
-    sync_host_ip: 'localhost'
-    sync_host_port: 10872
-    sync_strategy: 'rsync'
 
   discovery-sync:
     src: '../course-discovery/'
-    dest: '/edx/app/discovery/discovery'
-    sync_args: '-v --copy-links --hard-links'
     sync_excludes: [ '.git', '.idea', 'node_modules', 'course_discovery/assets', 'course_discovery/static/bower_components', 'course_discovery/static/build' ]
-    sync_host_ip: 'localhost'
-    sync_host_port: 10873
-    sync_strategy: 'rsync'
 
   ecommerce-sync:
     src: '../ecommerce/'
-    dest: '/edx/app/ecommerce/ecommerce'
-    sync_args: '-v --copy-links --hard-links'
     sync_excludes: [ '.git', '.idea', 'node_modules', 'assets', 'ecommerce/static/bower_components', 'ecommerce/static/build' ]
-    sync_host_ip: 'localhost'
-    sync_host_port: 10874
-    sync_strategy: 'rsync'
 
   edxapp-sync:
     src: '../edx-platform/'
-    dest: '/edx/app/edxapp/edx-platform'
-    sync_args: '-v --copy-links --hard-links'
     sync_excludes: [ '.git', '.idea', 'node_modules', '.prereqs_cache' ]
-    sync_host_ip: 'localhost'
-    sync_host_port: 10875
-    sync_strategy: 'rsync'
 
   marketing-sync:
     src: '../edx-mktg/docroot/'
-    dest: '/var/www/html'
-    sync_args: '-v --copy-links --hard-links'
     sync_excludes: [ '.git', '.idea', 'node_modules', ]
-    sync_host_ip: 'localhost'
-    sync_host_port: 10876
-    sync_strategy: 'rsync'
-    sync_user: 'www-data'
     sync_userid: 33

--- a/docker-sync.yml
+++ b/docker-sync.yml
@@ -7,36 +7,16 @@ options:
 syncs:
   credentials-sync:
     src: '../credentials/'
-    dest: '/edx/app/credentials/credentials'
-    sync_args: '-v --copy-links --hard-links'
     sync_excludes: [ '.git', '.idea', 'node_modules', 'credentials/assets', 'credentials/static/bundles' ]
-    sync_host_ip: 'localhost'
-    sync_host_port: 10872
-    sync_strategy: 'rsync'
 
   discovery-sync:
     src: '../course-discovery/'
-    dest: '/edx/app/discovery/discovery'
-    sync_args: '-v --copy-links --hard-links'
     sync_excludes: [ '.git', '.idea', 'node_modules', 'course_discovery/assets', 'course_discovery/static/bower_components', 'course_discovery/static/build' ]
-    sync_host_ip: 'localhost'
-    sync_host_port: 10873
-    sync_strategy: 'rsync'
 
   ecommerce-sync:
     src: '../ecommerce/'
-    dest: '/edx/app/ecommerce/ecommerce'
-    sync_args: '-v --copy-links --hard-links'
     sync_excludes: [ '.git', '.idea', 'node_modules', 'assets', 'ecommerce/static/bower_components', 'ecommerce/static/build' ]
-    sync_host_ip: 'localhost'
-    sync_host_port: 10874
-    sync_strategy: 'rsync'
 
   edxapp-sync:
     src: '../edx-platform/'
-    dest: '/edx/app/edxapp/edx-platform'
-    sync_args: '-v --copy-links --hard-links'
     sync_excludes: [ '.git', '.idea', 'node_modules', '.prereqs_cache' ]
-    sync_host_ip: 'localhost'
-    sync_host_port: 10875
-    sync_strategy: 'rsync'


### PR DESCRIPTION
- Replaced calls to docker-sync-daemon with docker-sync, which is now daemon by default
- Moved from rsync strategy to native_osx, which is the new default
- Using :nocopy to avoid issues when syncing to named volumes

Fixes #110