### PR TITLE
Using a smaller image for credentials

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,9 @@ restore:  ## Restore all data volumes from the host. WARNING: THIS WILL OVERWRIT
 %-shell: ## Run a shell on the specified service container
 	docker exec -it edx.devstack.$* env TERM=$(TERM) /edx/app/$*/devstack.sh open
 
+credentials-shell: ## Run a shell on the credentials container
+	docker exec -it edx.devstack.credentials env TERM=$(TERM) bash
+
 lms-shell: ## Run a shell on the LMS container
 	docker exec -it edx.devstack.lms env TERM=$(TERM) /edx/app/edxapp/devstack.sh open
 

--- a/README.rst
+++ b/README.rst
@@ -198,6 +198,8 @@ NOTES
 1. edxapp is the only service whose changes have been merged to the master
    branch.
 2. edxapp uses the ``latest`` tag. All other services use the ``devstack`` tag.
+3. We are experimenting with hosting a ``Dockerfile`` in the ``edx/credentials`` repository.
+   See that repo for more information.
 
 .. code:: sh
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,14 +55,17 @@ services:
 
   # edX services
   credentials:
-    command: bash -c 'source /edx/app/credentials/credentials_env && python /edx/app/credentials/credentials/manage.py runserver 0.0.0.0:18150'
+    command: bash -c 'python /edx/app/credentials/credentials/manage.py runserver 0.0.0.0:18150'
     container_name: edx.devstack.credentials
     depends_on:
       - mysql
       - memcached
     environment:
+      CACHE_LOCATION: edx.devstack.memcached:12211
+      DB_HOST: edx.devstack.mysql
+      SOCIAL_AUTH_EDX_OIDC_URL_ROOT: http://edx.devstack.lms:18000/oauth2
       ENABLE_DJANGO_TOOLBAR: 1
-    image: edxops/credentials:devstack
+    image: edxops/credentials:devstack-slim
     ports:
       - "18150:18150"
 

--- a/docker-sync-marketing-site.yml
+++ b/docker-sync-marketing-site.yml
@@ -11,7 +11,7 @@ options:
 syncs:
   credentials-sync:
     src: '../credentials/'
-    sync_excludes: [ '.git', '.idea', 'node_modules', 'credentials/assets', 'credentials/static/bundles' ]
+    sync_excludes: [ '.git', '.idea', 'node_modules', 'credentials/assets', 'credentials/static/bundles', 'webpack-stats.json' ]
 
   discovery-sync:
     src: '../course-discovery/'

--- a/docker-sync.yml
+++ b/docker-sync.yml
@@ -7,7 +7,7 @@ options:
 syncs:
   credentials-sync:
     src: '../credentials/'
-    sync_excludes: [ '.git', '.idea', 'node_modules', 'credentials/assets', 'credentials/static/bundles' ]
+    sync_excludes: [ '.git', '.idea', 'node_modules', 'credentials/assets', 'credentials/static/bundles', 'webpack-stats.json' ]
 
   discovery-sync:
     src: '../course-discovery/'

--- a/provision-credentials.sh
+++ b/provision-credentials.sh
@@ -1,1 +1,27 @@
-./provision-ida.sh credentials 18150
+#!/usr/bin/env bash
+
+# NOTE (CCB): We do NOT call provision-ida because it expects a virtualenv.
+# The new images for Credentials do not use virtualenv.
+
+name=credentials
+port=18150
+
+docker-compose $DOCKER_COMPOSE_FILES up -d $name
+
+echo -e "${GREEN}Installing requirements for ${name}...${NC}"
+docker exec -t edx.devstack.${name}  bash -c 'make requirements' -- "$name"
+
+echo -e "${GREEN}Running migrations for ${name}...${NC}"
+docker exec -t edx.devstack.${name}  bash -c 'make migrate' -- "$name"
+
+echo -e "${GREEN}Creating super-user for ${name}...${NC}"
+docker exec -t edx.devstack.${name}  bash -c 'echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser(\"edx\", \"edx@example.com\", \"edx\") if not User.objects.filter(username=\"edx\").exists() else None" | python /edx/app/$1/$1/manage.py shell' -- "$name"
+
+# TODO Create credentials tenant (ECOM-6566)
+
+./provision-ida-user.sh ${name} ${port}
+
+# Compile static assets last since they are absolutely necessary for all services. This will allow developers to get
+# started if they do not care about static assets
+echo -e "${GREEN}Compiling static assets for ${name}...${NC}"
+docker exec -t edx.devstack.${name}  bash -c ' make static' -- "$name"

--- a/provision.sh
+++ b/provision.sh
@@ -45,8 +45,6 @@ docker-compose $DOCKER_COMPOSE_FILES up -d studio
 
 ./provision-ecommerce.sh
 ./provision-discovery.sh
-./provision-ida.sh credentials 18150
-
-# TODO Create credentials tenant (ECOM-6566)
+./provision-credentials.sh
 
 echo -e "${GREEN}Provisioning complete!${NC}"


### PR DESCRIPTION
Devstack has been updated to use a smaller image for the Credentials Service. This image is built without Ansible.

Related: https://github.com/edx/credentials/pull/199