### PR TITLE
Removed host volumes for static assets and node_modules

### DIFF
--- a/docker-compose-host.yml
+++ b/docker-compose-host.yml
@@ -3,31 +3,16 @@ version: "2.1"
 services:
   credentials:
     volumes:
-      - /edx/app/credentials/credentials/credentials/assets/
-      - /edx/app/credentials/credentials/credentials/static/bundles/
-      - /edx/app/credentials/credentials/node_modules/
       - ${DEVSTACK_WORKSPACE}/credentials:/edx/app/credentials/credentials
   discovery:
       volumes:
-      - /edx/app/discovery/discovery/course_discovery/assets/
-      - /edx/app/discovery/discovery/course_discovery/static/bower_components/
-      - /edx/app/discovery/discovery/course_discovery/static/build/
-      - /edx/app/discovery/discovery/node_modules/
       - ${DEVSTACK_WORKSPACE}/course-discovery:/edx/app/discovery/discovery
   ecommerce:
     volumes:
-      - /edx/app/ecommerce/ecommerce/assets/
-      - /edx/app/ecommerce/ecommerce/ecommerce/static/bower_components/
-      - /edx/app/ecommerce/ecommerce/ecommerce/static/build/
-      - /edx/app/ecommerce/ecommerce/node_modules/
       - ${DEVSTACK_WORKSPACE}/ecommerce:/edx/app/ecommerce/ecommerce
   lms:
     volumes:
-      - /edx/app/edxapp/edx-platform/.prereqs_cache/
-      - /edx/app/edxapp/edx-platform/node_modules/
       - ${DEVSTACK_WORKSPACE}/edx-platform:/edx/app/edxapp/edx-platform
   studio:
     volumes:
-      - /edx/app/edxapp/edx-platform/.prereqs_cache/
-      - /edx/app/edxapp/edx-platform/node_modules/
       - ${DEVSTACK_WORKSPACE}/edx-platform:/edx/app/edxapp/edx-platform


### PR DESCRIPTION
I suspect these volumes retain outdated data between container creation instead of pulling the latest data from the image as intended. This results in services loading without assets.

Our usage of host volumes puts us in a weird position due to the fact that we want share code from the host while excluding certain directories, and pulling that information from the image itself. Docker doesn't seem to support such a configuration. We can resolve this issue by either rebuilding images completely with every change, using a separate container to build static assets, or explicitly sharing specific code directories rather than the entire directory.