### PR TITLE
Remove shallow cloning as it causes issues for developers working with

### DIFF
--- a/clone.sh
+++ b/clone.sh
@@ -33,7 +33,7 @@ do
     if [ -d "$name" ]; then
         printf "The [%s] repo is already checked out. Continuing.\n" $name
     else
-        git clone --depth 1 $repo
+        git clone $repo
     fi
 done
 cd - &> /dev/null


### PR DESCRIPTION
existing feature branches

PR For https://github.com/edx/devstack/issues/122#event-1093586861

The shallow clone caused me to be unable to see my working branch.  Are there any objections to removing this option?