### PR TITLE
Add custom shell env variables file.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,4 +2,3 @@
 XDEBUG_IP_ADDRESS=127.0.0.1
 # Provides local environment overrides if used.  See docker.settings.private.php.example for details
 DRUPAL_EXTRA_SETTINGS=/var/www/html/sites/default/docker.settings.private.php
-

--- a/.gitignore
+++ b/.gitignore
@@ -96,4 +96,4 @@ ENV/
 # Docker
 .docker-sync/
 .env
-
+.term_envs

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ OS := $(shell uname)
 export DEVSTACK_WORKSPACE
 
 include *.mk
+CUSTOM_TERM_ENVS := $(shell cat .term_envs)
+
 
 # Generates a help message. Borrowed from https://github.com/pydanny/cookiecutter-djangopackage.
 help: ## Display this help message
@@ -74,16 +76,16 @@ restore:  ## Restore all data volumes from the host. WARNING: THIS WILL OVERWRIT
 # TODO: Print out help for this target. Even better if we can iterate over the
 # services in docker-compose.yml, and print the actual service names.
 %-shell: ## Run a shell on the specified service container
-	docker exec -it edx.devstack.$* env TERM=$(TERM) /edx/app/$*/devstack.sh open
+	docker exec -it edx.devstack.$* env TERM=$(TERM) $(CUSTOM_TERM_ENVS) /edx/app/$*/devstack.sh open
 
 credentials-shell: ## Run a shell on the credentials container
-	docker exec -it edx.devstack.credentials env TERM=$(TERM) bash
+	docker exec -it edx.devstack.credentials env TERM=$(TERM) $(CUSTOM_TERM_ENVS) bash
 
 lms-shell: ## Run a shell on the LMS container
-	docker exec -it edx.devstack.lms env TERM=$(TERM) /edx/app/edxapp/devstack.sh open
+	docker exec -it edx.devstack.lms env TERM=$(TERM) $(CUSTOM_TERM_ENVS) /edx/app/edxapp/devstack.sh open
 
 studio-shell: ## Run a shell on the Studio container
-	docker exec -it edx.devstack.studio env TERM=$(TERM) /edx/app/edxapp/devstack.sh open
+	docker exec -it edx.devstack.studio env TERM=$(TERM) $(CUSTOM_TERM_ENVS) /edx/app/edxapp/devstack.sh open
 
 healthchecks: ## Run a curl against all services' healthcheck endpoints to make sure they are up. This will eventually be parameterized
 	./healthchecks.sh

--- a/README.rst
+++ b/README.rst
@@ -99,6 +99,10 @@ Catalog/Course Discovery Service, you can run:
 
     make discovery-shell
 
+If you would like to use your own custom environment variables for the shell
+you can set them in the ``.term_envs.example`` file. More information can be
+found in that file.
+
 To see logs from containers running in detached mode, you can either use
 "Kitematic" (available from the "Docker for Mac" menu), or by running the
 following:

--- a/marketing.mk
+++ b/marketing.mk
@@ -1,5 +1,5 @@
 marketing-shell: ## Run a shell on the marketing site container
-	docker exec -it edx.devstack.marketing env TERM=$(TERM) bash
+	docker exec -it edx.devstack.marketing env TERM=$(TERM) $(CUSTOM_TERM_ENVS) bash
 
 up-marketing:   ## Bring up all services (including the marketing site) with host volumes
 	docker-compose -f docker-compose.yml -f docker-compose-host.yml -f docker-compose-marketing-site.yml -f docker-compose-marketing-site-host.yml up


### PR DESCRIPTION
This is more of a suggestion PR, so the implementation could probably be improved. For example, to do small edits I use `nano` instead of `vim` so instead of editing the default bash text editor each time I enter the shell, I thought it would be useful to have a file with the settings and other environmental variables that someone would like to use throughout the container list.

What do you think @edx/docker-devstack-working-group ?