### PR TITLE
Drop the database(s) before running the sql load scripts

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,8 +58,8 @@ a minimum of 2 CPUs and 4GB of memory works well.
    services with superusers (for development without the auth service) and
    tenants (for multi-tenancy).
 
-   **Note** When running the provision command databases for all systems will be
-   dropped and recreated.
+   **Note** When running the provision command databases for ecommerce and edxapp
+   will be dropped and recreated.
 
    The username and password for the superusers are both "edx". You can access
    the services directly via Django admin at the ``/admin/`` path, or login via

--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,9 @@ a minimum of 2 CPUs and 4GB of memory works well.
    services with superusers (for development without the auth service) and
    tenants (for multi-tenancy).
 
+   **Note** When running the provision command databases for all systems will be
+   dropped and recreated.
+
    The username and password for the superusers are both "edx". You can access
    the services directly via Django admin at the ``/admin/`` path, or login via
    single sign-on at ``/login/``.
@@ -73,6 +76,7 @@ a minimum of 2 CPUs and 4GB of memory works well.
    .. code:: sh
 
        make dev.provision
+
 
 3. Start the services. This command will mount the repositories under the
    DEVSTACK\_WORKSPACE directory.

--- a/dump-db.sh
+++ b/dump-db.sh
@@ -14,5 +14,5 @@ then
 fi
 
 echo "Dumping the $1 database..."
-docker exec -i edx.devstack.mysql mysqldump --skip-add-drop-table -B $1 > $1.sql
+docker exec -i edx.devstack.mysql mysqldump --add-drop-database --skip-add-drop-table -B $1 > $1.sql
 echo "Finished dumping the $1 database!"

--- a/ecommerce.sql
+++ b/ecommerce.sql
@@ -19,6 +19,8 @@
 -- Current Database: `ecommerce`
 --
 
+DROP DATABASE /*!32312 IF EXISTS*/ `ecommerce`;
+
 CREATE DATABASE /*!32312 IF NOT EXISTS*/ `ecommerce` /*!40100 DEFAULT CHARACTER SET utf8 */;
 
 USE `ecommerce`;

--- a/edxapp.sql
+++ b/edxapp.sql
@@ -19,6 +19,8 @@
 -- Current Database: `edxapp`
 --
 
+DROP DATABASE /*!32312 IF EXISTS*/ `edxapp`;
+
 CREATE DATABASE /*!32312 IF NOT EXISTS*/ `edxapp` /*!40100 DEFAULT CHARACTER SET utf8 */;
 
 USE `edxapp`;

--- a/edxapp_csmh.sql
+++ b/edxapp_csmh.sql
@@ -19,6 +19,8 @@
 -- Current Database: `edxapp_csmh`
 --
 
+DROP DATABASE /*!32312 IF EXISTS*/ `edxapp_csmh`;
+
 CREATE DATABASE /*!32312 IF NOT EXISTS*/ `edxapp_csmh` /*!40100 DEFAULT CHARACTER SET utf8 */;
 
 USE `edxapp_csmh`;


### PR DESCRIPTION
Provisioning will fail if these databases have already been loaded or are partially loaded. Drop the table if it exists to avoid provisioning SQL load errors.