### PR TITLE
Add Makefile command to print logs of specific container.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,9 @@ destroy: ## Remove all devstack-related containers, networks, and volumes
 logs: ## View logs from containers running in detached mode
 	docker-compose logs -f
 
+%-logs: ## View the logs of the specified service container
+	docker-compose logs -f | grep edx.devstack.$*
+
 pull: ## Update Docker images
 	docker-compose pull
 

--- a/README.rst
+++ b/README.rst
@@ -107,6 +107,13 @@ following:
 
     make logs
 
+To view the logs of a specific service container run ``make <service>-logs``.
+For example to access the logs for Ecommerce, you can run:
+
+.. code:: sh
+
+    make ecommerce-logs
+
 To reset your environment and start provisioning from scratch, you can run:
 
 .. code:: sh


### PR DESCRIPTION
Instead of listing all the logs, or having to append the grep command each time, this command will allow outputting the logs of a specific container only. Particularly useful if you want to read the traceback of an error that has been intertwined with lines of logs from other services.

Thoughts @edx/docker-devstack-working-group ?