### PR TITLE
docker compose version

### DIFF
--- a/docker-compose-host.yml
+++ b/docker-compose-host.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "2.1"
 
 services:
   credentials:

--- a/docker-compose-marketing-site-host.yml
+++ b/docker-compose-marketing-site-host.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "2.1"
 
 services:
   marketing:

--- a/docker-compose-marketing-site-sync.yml
+++ b/docker-compose-marketing-site-sync.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "2.1"
 
 services:
   marketing:

--- a/docker-compose-marketing-site.yml
+++ b/docker-compose-marketing-site.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "2.1"
 
 services:
   lms:

--- a/docker-compose-sync.yml
+++ b/docker-compose-sync.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "2.1"
 
 services:
   credentials:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@
 # - Every service's container name should be prefixed with "edx.devstack." to avoid conflicts with other containers
 #   that might be running for the same service.
 
-version: "3"
+version: "2.1"
 
 services:
   # Third-party services


### PR DESCRIPTION
Returns the docker compose files to 2.1.  3.0 is not currently supported by PyCharm and not needed.