### PR TITLE
Initial support for bok-choy tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,10 @@ services:
       - elasticsearch_data:/usr/share/elasticsearch/data
       - elasticsearch_data:/usr/share/elasticsearch/logs
 
+  firefox:
+    container_name: edx.devstack.firefox
+    image: selenium/standalone-firefox:2.53.1-beryllium
+
   memcached:
     container_name: edx.devstack.memcached
     image: memcached:1.4.24
@@ -103,10 +107,15 @@ services:
       - memcached
       - mongo
     environment:
+      BOK_CHOY_HOSTNAME: edx.devstack.lms
+      BOK_CHOY_LMS_PORT: 18003
+      BOK_CHOY_CMS_PORT: 18031
       NO_PYTHON_UNINSTALL: 1
     image: edxops/edxapp:latest
     ports:
       - "18000:18000"
+      # - "18003:18003"
+      # - "18031:18031"
 
   studio:
     command: bash -c 'source /edx/app/edxapp/edxapp_env && while true; do python /edx/app/edxapp/edx-platform/manage.py cms runserver 0.0.0.0:18010 --settings devstack_docker; sleep 2; done'
@@ -116,10 +125,15 @@ services:
       - memcached
       - mongo
     environment:
+      BOK_CHOY_HOSTNAME: edx.devstack.studio
+      BOK_CHOY_LMS_PORT: 18103
+      BOK_CHOY_CMS_PORT: 18131
       NO_PYTHON_UNINSTALL: 1
     image: edxops/edxapp:latest
     ports:
       - "18010:18010"
+      # - "18103:18103"
+      # - "18131:18131"
 
 volumes:
   elasticsearch_data:

--- a/docker-sync.yml
+++ b/docker-sync.yml
@@ -23,4 +23,4 @@ syncs:
   edxapp-sync:
     host_disk_mount_mode: 'cached'
     src: '../edx-platform/'
-    sync_excludes: [ '.git', '.idea' ]
+    sync_excludes: [ '.idea' ]


### PR DESCRIPTION
Changes needed so far for running bok-choy tests in Docker Devstack:

* Add a stock image for a standalone Selenium 2.53.1 server driving Firefox 45.0.2.  This doesn't need to change as often as edxapp, is tested and routinely updated upstream, and avoids greatly increasing the size of the edxapp containers.  There are newer images for this container which use newer versions of Selenium and Firefox, but this one best matches our current Vagrant and Jenkins configuration; updating it will require some test updates.
* Set environment variables in the lms and studio containers specifying which ports the bok-choy run should start CMS and LMS on
* Expose these ports so Firefox can reach them from the Selenium container.  They need to be different for the lms and studio containers so they don't conflict with each other.
* Set an environment variable specifying the container name, since that will be used as the hostname for browser URLs (and it's hard to discover this from inside the container otherwise)
* Sync the .git directory for the edxapp containers, since the bok-choy test setup currently performs some git operations.  We should refactor this later to avoid this sync burden, but that comes after just getting it working in the first place.