### PR TITLE
Provisioning demo data for ecommerce

### DIFF
--- a/provision-ecommerce.sh
+++ b/provision-ecommerce.sh
@@ -6,3 +6,4 @@
 # Configure ecommerce
 docker exec -t edx.devstack.ecommerce bash -c 'source /edx/app/ecommerce/ecommerce_env && python /edx/app/ecommerce/ecommerce/manage.py create_or_update_site --site-id=1 --site-domain=localhost:18130 --partner-code=edX --partner-name="Open edX" --lms-url-root=http://edx.devstack.lms:18000 --client-side-payment-processor=cybersource --payment-processors=cybersource,paypal --client-id=ecommerce-key --client-secret=ecommerce-secret --from-email staff@example.com'
 docker exec -t edx.devstack.ecommerce bash -c 'source /edx/app/ecommerce/ecommerce_env && python /edx/app/ecommerce/ecommerce/manage.py oscar_populate_countries --initial-only'
+docker exec -t edx.devstack.ecommerce bash -c 'source /edx/app/ecommerce/ecommerce_env && pip install zeep && python /edx/app/ecommerce/ecommerce/manage.py create_demo_data --partner=edX'


### PR DESCRIPTION
The create_demo_data management command is now run for the E-Commerce Service. This creates a verified seat for the demo course, allowing developers to get started testing payments with minimal effort.

LEARNER-1375