### PR TITLE
Restart runserver when it dies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
 
   # edX services
   credentials:
-    command: bash -c 'python /edx/app/credentials/credentials/manage.py runserver 0.0.0.0:18150'
+    command: bash -c 'while true; do python /edx/app/credentials/credentials/manage.py runserver 0.0.0.0:18150; sleep 2; done'
     container_name: edx.devstack.credentials
     depends_on:
       - mysql
@@ -70,7 +70,7 @@ services:
       - "18150:18150"
 
   discovery:
-    command: bash -c 'source /edx/app/discovery/discovery_env && python /edx/app/discovery/discovery/manage.py runserver 0.0.0.0:18381'
+    command: bash -c 'source /edx/app/discovery/discovery_env && while true; do python /edx/app/discovery/discovery/manage.py runserver 0.0.0.0:18381; sleep 2; done'
     container_name: edx.devstack.discovery
     depends_on:
       - mysql
@@ -84,7 +84,7 @@ services:
       - "18381:18381"
 
   ecommerce:
-    command: bash -c 'source /edx/app/ecommerce/ecommerce_env && python /edx/app/ecommerce/ecommerce/manage.py runserver 0.0.0.0:18130'
+    command: bash -c 'source /edx/app/ecommerce/ecommerce_env && while true; do python /edx/app/ecommerce/ecommerce/manage.py runserver 0.0.0.0:18130; sleep 2; done'
     container_name: edx.devstack.ecommerce
     depends_on:
       - mysql
@@ -96,7 +96,7 @@ services:
       - "18130:18130"
 
   lms:
-    command: bash -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms runserver 0.0.0.0:18000 --settings devstack_docker'
+    command: bash -c 'source /edx/app/edxapp/edxapp_env && while true; do python /edx/app/edxapp/edx-platform/manage.py lms runserver 0.0.0.0:18000 --settings devstack_docker; sleep 2; done'
     container_name: edx.devstack.lms
     depends_on:
       - mysql
@@ -109,7 +109,7 @@ services:
       - "18000:18000"
 
   studio:
-    command: bash -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py cms runserver 0.0.0.0:18010 --settings devstack_docker'
+    command: bash -c 'source /edx/app/edxapp/edxapp_env && while true; do python /edx/app/edxapp/edx-platform/manage.py cms runserver 0.0.0.0:18010 --settings devstack_docker; sleep 2; done'
     container_name: edx.devstack.studio
     depends_on:
       - mysql


### PR DESCRIPTION
We had previously set the `NO_PYTHON_UNINSTALL` environment variable to avoid a package uninstallation triggering a runserver restart which would terminate the Docker container.  More recently, updating the requirements in edx-platform's `github.txt` requirements file has occasionally been having the same effect (I just had another PR's Travis run fail because of this).  To resolve this, I've put each of the `runserver` commands inside an infinite loop which pauses for 2 seconds and then restarts the service if it exits for any reason.  This allows us to run scripts that make invasive changes which may restart or terminate the `runserver` process, and have them run through to completion without being canceled by the container abruptly exiting.

If the runserver process is killed by an error of some sort, the exception is typically logged and can be found via `make logs`.