### PR TITLE
Revert: Fix exposed studio port.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,7 @@ services:
       NO_PYTHON_UNINSTALL: 1
     image: edxops/edxapp:latest
     ports:
-      - "18001:18001"
+      - "18010:18010"
       # - "18103:18103"
       # - "18131:18131"
 


### PR DESCRIPTION
Oops.  Turns out @clintonb was trying to make the port 18010 more consistent with edx/configuration than with the old devstack (8001) for Studio.