### PR TITLE
Restrict logs to tail last 500 lines.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ logs: ## View logs from containers running in detached mode
 	docker-compose logs -f
 
 %-logs: ## View the logs of the specified service container
-	docker-compose logs -f | grep edx.devstack.$*
+	docker-compose logs -f --tail=500 | grep edx.devstack.$*
 
 pull: ## Update Docker images
 	docker-compose pull


### PR DESCRIPTION
When opening the logs I would have to wait for several minutes until it scrolls down to the last logs. This will tail the last 500 right away. 500 is arbitrary set, but I believe it's enough for any debugging.

@edx/docker-devstack-working-group please review.