### PR TITLE
PLAT-1620 Containers for latest Chrome and Firefox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,10 @@ validate-lms-volume: ## Validate that changes to the local workspace are reflect
 	docker exec edx.devstack.lms ls /edx/app/edxapp/edx-platform/testfile
 	rm $(DEVSTACK_WORKSPACE)/edx-platform/testfile
 
+vnc-passwords: ## Get the VNC passwords for the Chrome and Firefox Selenium containers
+	@docker logs edx.devstack.chrome 2>&1 | grep "VNC password" | tail -1
+	@docker logs edx.devstack.firefox 2>&1 | grep "VNC password" | tail -1
+
 mysql-shell: ## Run a shell on the mysql container
 	docker-compose exec mysql bash
 

--- a/README.rst
+++ b/README.rst
@@ -369,6 +369,17 @@ Vagrant. Example:
 You can also add the ``test_docker`` settings flag to the other examples detailed
 in the testing documentation.
 
+If you want to see the browser being automated for JavaScript or bok-choy
+tests, you can connect to the container running it via VNC.  Most tests are
+run in Firefox by default, and the container running it can be accessed on
+port 25900 (for example, by entering ``vnc://0.0.0.0:25900`` in Safari on
+macOS).  There is also a Docker container driving Chrome via Selenium, for
+which VNC is available on port 15900.  The VNC passwords for both of these are
+randomly generated and logged at container startup, and can be found by
+running ``make vnc-passwords``.  To use Chrome for tests that normally
+use Firefox instead, prefix the test command with
+``SELENIUM_BROWSER=chrome SELENIUM_HOST=edx.devstack.chrome``.
+
 Troubleshooting: General Tips
 -----------------------------
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,15 @@ version: "2.1"
 
 services:
   # Third-party services
+  chrome:
+    container_name: edx.devstack.chrome
+    image: edxops/chrome:latest
+    shm_size: 2g
+    ports:
+      - "15900:5900"
+    volumes:
+      - ../edx-platform:/edx/app/edxapp/edx-platform  # for file uploads
+
   elasticsearch:
     container_name: edx.devstack.elasticsearch
     image: edxops/elasticsearch:devstack
@@ -25,7 +34,12 @@ services:
 
   firefox:
     container_name: edx.devstack.firefox
-    image: selenium/standalone-firefox:2.53.1-beryllium
+    image: edxops/firefox:latest
+    shm_size: 2g
+    ports:
+      - "25900:5900"
+    volumes:
+      - ../edx-platform:/edx/app/edxapp/edx-platform  # for file uploads
 
   memcached:
     container_name: edx.devstack.memcached
@@ -114,6 +128,7 @@ services:
     image: edxops/edxapp:latest
     ports:
       - "18000:18000"
+      - "19876:19876" # JS test debugging
       # - "18003:18003"
       # - "18031:18031"
 
@@ -132,6 +147,7 @@ services:
     image: edxops/edxapp:latest
     ports:
       - "18010:18010"
+      - "19877:19877" # JS test debugging
       # - "18103:18103"
       # - "18131:18131"
 


### PR DESCRIPTION
* Update the Firefox container to use the latest upstream version
* Add a container for the latest Chrome version
* Expose VNC ports to observe and interact with both browsers, with randomized passwords
* Expose the LMS and Studio ports needed to use browsers on the host to run the karma JS tests