### PR TITLE
[WIP] pdb debug testing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,7 +114,7 @@ services:
       - "18130:18130"
 
   lms:
-    command: bash -c 'source /edx/app/edxapp/edxapp_env && while true; do python /edx/app/edxapp/edx-platform/manage.py lms runserver 0.0.0.0:18000 --settings devstack_docker; sleep 2; done'
+    command: bash -c 'source /edx/app/edxapp/edxapp_env && python -m pdb /edx/app/edxapp/edx-platform/manage.py lms runserver 0.0.0.0:18000 --settings devstack_docker'
     container_name: edx.devstack.lms
     depends_on:
       - mysql
@@ -133,6 +133,9 @@ services:
       # - "18031:18031"
     volumes:
       - edxapp_lms_assets:/edx/var/edxapp/staticfiles/
+    stdin_open: true
+    tty: true
+
 
   studio:
     command: bash -c 'source /edx/app/edxapp/edxapp_env && while true; do python /edx/app/edxapp/edx-platform/manage.py cms runserver 0.0.0.0:18010 --settings devstack_docker; sleep 2; done'


### PR DESCRIPTION
@MatthewPiatetsky 

```
➜  docker-devstack git:(bbeggs/pdb) docker ps
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
➜  docker-devstack git:(bbeggs/pdb) make dev.up
docker-compose -f docker-compose.yml -f docker-compose-host.yml up -d
Creating network "dockerdevstack_default" with the default driver
Creating edx.devstack.chrome ... 
Creating edx.devstack.mongo ... 
Creating edx.devstack.memcached ... 
Creating edx.devstack.mysql ... 
Creating edx.devstack.elasticsearch ... 
Creating edx.devstack.firefox ... 
Creating edx.devstack.mongo
Creating edx.devstack.chrome
Creating edx.devstack.memcached
Creating edx.devstack.mysql
Creating edx.devstack.elasticsearch
Creating edx.devstack.memcached ... done
Creating edx.devstack.ecommerce ... 
Creating edx.devstack.studio ... 
Creating edx.devstack.lms ... 
Creating edx.devstack.discovery ... 
Creating edx.devstack.credentials ... 
Creating edx.devstack.ecommerce
Creating edx.devstack.studio
Creating edx.devstack.credentials
Creating edx.devstack.lms
Creating edx.devstack.lms ... done
➜  docker-devstack git:(bbeggs/pdb) docker ps
CONTAINER ID        IMAGE                              COMMAND                  CREATED             STATUS              PORTS                                                           NAMES
0fb9b1e8ea49        edxops/discovery:latest            "bash -c 'source /..."   3 seconds ago       Up 1 second         0.0.0.0:18381->18381/tcp                                        edx.devstack.discovery
9641afdb6065        edxops/edxapp:latest               "bash -c 'source /..."   3 seconds ago       Up 1 second         0.0.0.0:18000->18000/tcp, 0.0.0.0:19876->19876/tcp, 18010/tcp   edx.devstack.lms
3a7df770d38c        edxops/credentials:devstack-slim   "/tini -- bash -c ..."   3 seconds ago       Up 1 second         0.0.0.0:18150->18150/tcp                                        edx.devstack.credentials
22cf560d4bf2        edxops/ecommerce:devstack          "bash -c 'source /..."   3 seconds ago       Up 1 second         0.0.0.0:18130->18130/tcp                                        edx.devstack.ecommerce
3a8ad7c7914d        edxops/edxapp:latest               "bash -c 'source /..."   3 seconds ago       Up 1 second         0.0.0.0:18010->18010/tcp, 18000/tcp, 0.0.0.0:19877->19877/tcp   edx.devstack.studio
e1383edd7c06        edxops/chrome:latest               "/bin/sh -c 'expor..."   6 seconds ago       Up 4 seconds        4444/tcp, 0.0.0.0:15900->5900/tcp                               edx.devstack.chrome
d70fdd0a86e5        edxops/firefox:latest              "/bin/sh -c 'expor..."   6 seconds ago       Up 4 seconds        4444/tcp, 0.0.0.0:25900->5900/tcp                               edx.devstack.firefox
bcf86edc5a5d        edxops/elasticsearch:devstack      "/docker-entrypoin..."   6 seconds ago       Up 4 seconds        9200/tcp, 9300/tcp                                              edx.devstack.elasticsearch
9855b62174e8        mysql:5.6                          "docker-entrypoint..."   6 seconds ago       Up 4 seconds        3306/tcp                                                        edx.devstack.mysql
895d06346362        memcached:1.4.24                   "/entrypoint.sh me..."   6 seconds ago       Up 3 seconds        11211/tcp                                                       edx.devstack.memcached
290d0dc3ec37        mongo:3.0.14                       "docker-entrypoint..."   6 seconds ago       Up 4 seconds        27017/tcp                                                       edx.devstack.mongo
➜  docker-devstack git:(bbeggs/pdb) docker attach 9641afdb6065
(Pdb) 
```