### PR TITLE
PLAT-1590 Add e2e tests container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-DEVSTACK_WORKSPACE ?= ..
+DEVSTACK_WORKSPACE ?= $(shell pwd)/..
 
 OS := $(shell uname)
 
@@ -81,6 +81,9 @@ restore:  ## Restore all data volumes from the host. WARNING: THIS WILL OVERWRIT
 
 credentials-shell: ## Run a shell on the credentials container
 	docker exec -it edx.devstack.credentials env TERM=$(TERM) bash
+
+e2e-shell: ## Start the end-to-end tests container with a shell
+	docker run -it --network=devstack_default -v ${DEVSTACK_WORKSPACE}/edx-e2e-tests:/edx-e2e-tests -v ${DEVSTACK_WORKSPACE}/edx-platform:/edx-e2e-tests/lib/edx-platform --env-file ${DEVSTACK_WORKSPACE}/edx-e2e-tests/devstack_env edxops/e2e env TERM=$(TERM) bash
 
 lms-shell: ## Run a shell on the LMS container
 	docker exec -it edx.devstack.lms env TERM=$(TERM) /edx/app/edxapp/devstack.sh open

--- a/README.rst
+++ b/README.rst
@@ -403,6 +403,21 @@ running ``make vnc-passwords``.  To use Chrome for tests that normally
 use Firefox instead, prefix the test command with
 ``SELENIUM_BROWSER=chrome SELENIUM_HOST=edx.devstack.chrome``.
 
+Running End-to-End Tests
+------------------------
+
+To run the end-to-end tests for edx-platform, start a shell for the e2e
+container and run the tests via paver:
+
+.. code:: sh
+
+    make e2e-shell
+    paver e2e_test --exclude=whitelabel
+
+Additional testing options are available as described in the
+`edx-e2e-tests README`_.  The browser running the tests can be seen and
+interacted with via VNC as described above (Chrome is used by default).
+
 Troubleshooting: General Tips
 -----------------------------
 
@@ -607,6 +622,7 @@ GitHub issue which explains the `current status of implementing delegated consis
 .. _current status of implementing delegated consistency mode: https://github.com/docker/for-mac/issues/1592
 .. _configuring Docker for Mac: https://docs.docker.com/docker-for-mac/#/advanced
 .. _feature added in Docker 17.05: https://github.com/edx/configuration/pull/3864
+.. _edx-e2e-tests README: https://github.com/edx/edx-e2e-tests/#how-to-run-lms-and-studio-tests
 .. _edxops Docker image: https://hub.docker.com/r/edxops/
 .. _Docker Hub: https://hub.docker.com/
 .. _Pycharm Integration documentation: docs/pycharm_integration.rst

--- a/clone.sh
+++ b/clone.sh
@@ -18,6 +18,7 @@ repos=(
     "https://github.com/edx/course-discovery.git"
     "https://github.com/edx/credentials.git"
     "https://github.com/edx/ecommerce.git"
+    "https://github.com/edx/edx-e2e-tests.git"
     "https://github.com/edx/edx-platform.git"
 )
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,9 @@ services:
     shm_size: 2g
     ports:
       - "15900:5900"
-    volumes:
-      - ../edx-platform:/edx/app/edxapp/edx-platform  # for file uploads
+    volumes:  # for file uploads
+      - ../edx-e2e-tests/upload_files:/edx/app/e2e/edx-e2e-tests/upload_files
+      - ../edx-platform/common/test/data:/edx/app/edxapp/edx-platform/common/test/data
 
   elasticsearch:
     container_name: edx.devstack.elasticsearch
@@ -38,8 +39,9 @@ services:
     shm_size: 2g
     ports:
       - "25900:5900"
-    volumes:
-      - ../edx-platform:/edx/app/edxapp/edx-platform  # for file uploads
+    volumes:  # for file uploads
+      - ../edx-e2e-tests/upload_files:/edx/app/e2e/edx-e2e-tests/upload_files
+      - ../edx-platform/common/test/data:/edx/app/edxapp/edx-platform/common/test/data
 
   memcached:
     container_name: edx.devstack.memcached

--- a/provision-e2e.sh
+++ b/provision-e2e.sh
@@ -1,0 +1,23 @@
+set -e
+set -o pipefail
+set -x
+
+if [ -z "$DEVSTACK_WORKSPACE" ]; then
+    DEVSTACK_WORKSPACE=..
+elif [ ! -d "$DEVSTACK_WORKSPACE" ]; then
+    echo "Workspace directory $DEVSTACK_WORKSPACE doesn't exist"
+    exit 1
+fi
+
+# Copy the test course tarball into the studio container
+docker cp ${DEVSTACK_WORKSPACE}/edx-e2e-tests/upload_files/course.tar.gz edx.devstack.studio:/tmp/
+
+# Extract the test course tarball
+docker-compose exec studio bash -c 'cd /tmp && tar xzf course.tar.gz'
+
+# Import the course content
+docker-compose exec studio bash -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py cms --settings=devstack_docker import /tmp course'
+
+# Clean up the temp files
+docker-compose exec studio bash -c 'rm /tmp/course.tar.gz'
+docker-compose exec studio bash -c 'rm -r /tmp/course'

--- a/provision.sh
+++ b/provision.sh
@@ -45,6 +45,7 @@ docker-compose $DOCKER_COMPOSE_FILES up -d studio
 ./provision-ecommerce.sh
 ./provision-discovery.sh
 ./provision-credentials.sh
+./provision-e2e.sh
 
 docker image prune -f
 


### PR DESCRIPTION
Add a new container for the end-to-end edx-platform tests (which live in their own repo).  It maps in volumes for both its own git checkout and one for edx-platform.  Provisioning is extended to include adding a course used for these tests; the tests are destructive of the course data and include a browser-automated 1-by-1 removal of file uploads from the course, so the demo course doesn't serve well for this (it includes over 1,000 file uploads).  Tests can be run with the same Chrome and Firefox containers which are used for the edx-platform browser automation tests, and take about 5 minutes in Chrome.

Before this is merged, PRs in [edx-e2e-tests](https://github.com/edx/edx-e2e-tests/pull/204) and [configuration](https://github.com/edx/configuration/pull/4020) need to be merged and a container image needs to be built and uploaded.