### PR TITLE
Add memory check warning before dev.up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ dev.clone: ## Clone service repos to the parent directory
 dev.provision.run: ## Provision all services with local mounted directories
 	DOCKER_COMPOSE_FILES="-f docker-compose.yml -f docker-compose-host.yml" ./provision.sh
 
-dev.provision: | dev.provision.run stop ## Provision dev environment with all services stopped
+dev.provision: | check-memory dev.provision.run stop ## Provision dev environment with all services stopped
 
 dev.up: | check-memory ## Bring up all services with host volumes
 	docker-compose -f docker-compose.yml -f docker-compose-host.yml up -d
@@ -38,7 +38,7 @@ dev.sync.requirements: ## Install requirements
 dev.sync.up: dev.sync.daemon.start ## Bring up all services with docker-sync enabled
 	docker-compose -f docker-compose.yml -f docker-compose-sync.yml up -d
 
-provision: ## Provision all services using the Docker volume
+provision: | check-memory ## Provision all services using the Docker volume
 	./provision.sh
 
 stop: ## Stop all services

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ dev.provision.run: ## Provision all services with local mounted directories
 
 dev.provision: | dev.provision.run stop ## Provision dev environment with all services stopped
 
-dev.up: ## Bring up all services with host volumes
+dev.up: | check-memory ## Bring up all services with host volumes
 	docker-compose -f docker-compose.yml -f docker-compose-host.yml up -d
 
 dev.sync.daemon.start: ## Start the docker-sycn daemon
@@ -108,3 +108,7 @@ create-course-studio: ## Generates a course on studio using the configurations i
 
 create-course-ecommerce: ## Generates a course on ecommerce using the configurations in test-course-ecommerce.json
 	./course-generator/create-course-ecommerce.sh
+
+check-memory:
+	@if [ `docker info --format '{{json .}}' | python -c "import sys, json; print json.load(sys.stdin)['MemTotal']"` -lt 2147483648 ]; then echo "\033[0;31mWarning, System Memory is set too low!!! Increase Docker memory to be at least 2 Gigs\033[0m"; fi || exit 0
+	


### PR DESCRIPTION
Print out a low memory warning before starting docker containers with make.