### PR TITLE
Mount code in /edx/src for local pip installs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -341,6 +341,11 @@ starts, you have a few options:
   container is started.  For example, the part of the studio command which
   reads ``...&& while true; do...`` could be changed to
   ``...&& pip install my-new-package && while true; do...``.
+* In order to work on locally pip-installed repos like edx-ora2, first clone
+  them into ../src (relative to this directory). Then, inside your lms shell,
+  you can ``pip install -e /edx/src/edx-ora2``. If you want to keep this code
+  installed across stop/starts, modify ``docker-compose.yml`` as mentioned
+  above.
 
 Switching branches
 ------------------

--- a/docker-compose-host.yml
+++ b/docker-compose-host.yml
@@ -13,9 +13,11 @@ services:
   lms:
     volumes:
       - ${DEVSTACK_WORKSPACE}/edx-platform:/edx/app/edxapp/edx-platform:cached
+      - ${DEVSTACK_WORKSPACE}/src:/edx/src:cached
   studio:
     volumes:
       - ${DEVSTACK_WORKSPACE}/edx-platform:/edx/app/edxapp/edx-platform:cached
+      - ${DEVSTACK_WORKSPACE}/src:/edx/src:cached
   forum:
     volumes:
       - ${DEVSTACK_WORKSPACE}/cs_comments_service:/edx/app/forum/cs_comments_service:cached


### PR DESCRIPTION
This is key to the development workflows of edx-proctoring and edx-ora2, among others. It more or less copies the Vagrant functionality seen here: https://github.com/edx/configuration/blob/master/vagrant/release/devstack/Vagrantfile#L35

Work in progress, will submit for review once I've confirmed this actually works as expected.