### PR TITLE
Mem check and e2e command updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,5 +113,5 @@ create-course-ecommerce: ## Generates a course on ecommerce using the configurat
 	./course-generator/create-course-ecommerce.sh ./course-generator/test-course.json
 
 check-memory:
-	@if [ `docker info --format '{{json .}}' | python -c "import sys, json; print json.load(sys.stdin)['MemTotal']"` -lt 2147483648 ]; then echo "\033[0;31mWarning, System Memory is set too low!!! Increase Docker memory to be at least 2 Gigs\033[0m"; fi || exit 0
+	@if [ `docker info --format '{{json .}}' | python -c "from __future__ import print_function; import sys, json; print(json.load(sys.stdin)['MemTotal'])"` -lt 2147483648 ]; then echo "\033[0;31mWarning, System Memory is set too low!!! Increase Docker memory to be at least 2 Gigs\033[0m"; fi || exit 0
 	

--- a/README.rst
+++ b/README.rst
@@ -413,7 +413,7 @@ container and run the tests via paver:
 .. code:: sh
 
     make e2e-shell
-    paver e2e_test --exclude=whitelabel
+    paver e2e_test --exclude="whitelabel\|enterprise"
 
 Additional testing options are available as described in the
 `edx-e2e-tests README`_.  The browser running the tests can be seen and


### PR DESCRIPTION
* I noticed that the check-memory target was failing under Python 3.5 in Travis; updated it to work with Python 2 and 3. This shouldn't be causing any real trouble, but it's an obvious error in the job output that can be distracting when trying to debug other issues.
* A couple of basic enterprise e2e tests were recently added which aren't meant to be run as part of the main test suite; updated the recommended command for running the e2e tests to match what that repo is now using.