### PR TITLE
PLAT-1661 Add static asset make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,20 @@ lms-shell: ## Run a shell on the LMS container
 studio-shell: ## Run a shell on the Studio container
 	docker exec -it edx.devstack.studio env TERM=$(TERM) /edx/app/edxapp/devstack.sh open
 
+%-static: ## Rebuild static assets for the specified service container
+	docker exec -t edx.devstack.$* bash -c 'source /edx/app/$*/$*_env && cd /edx/app/$*/$*/ && make static'
+
+credentials-static: ## Rebuild static assets for the credentials container
+	docker exec -t edx.devstack.credentials bash -c 'make static'
+
+lms-static: ## Rebuild static assets for the LMS container
+	docker exec -t edx.devstack.lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && paver update_assets'
+
+studio-static: ## Rebuild static assets for the Studio container
+	docker exec -t edx.devstack.studio bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && paver update_assets'
+
+static: | credentials-static discovery-static ecommerce-static lms-static studio-static ## Rebuild static assets for all service containers
+
 healthchecks: ## Run a curl against all services' healthcheck endpoints to make sure they are up. This will eventually be parameterized
 	./healthchecks.sh
 

--- a/README.rst
+++ b/README.rst
@@ -342,6 +342,24 @@ starts, you have a few options:
   reads ``...&& while true; do...`` could be changed to
   ``...&& pip install my-new-package && while true; do...``.
 
+How do I rebuild static assets?
+-------------------------------
+
+Optimized static assets are built for all the edX services during
+provisioning, but you may want to rebuild them for a particular service
+after changing some files without re-provisioning the entire devstack.  To
+do this, run the make target for the appropriate service.  For example:
+
+.. code:: sh
+
+   make credentials-static
+
+To rebuild static assets for all service containers:
+
+.. code:: sh
+
+   make static
+
 Switching branches
 ------------------
 


### PR DESCRIPTION
Add make targets to rebuild static assets in each container or for all containers.  The IDAs all store the built assets inside the source directory being mapped in from the host, so they don't need separate asset volumes like the ones we added for LMS and Studio.  The provisioning scripts for each service already build static assets, so nothing needs to be added there.