### PR TITLE
PLAT-1683 Run e2e tests in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,5 @@ script:
   - sleep 60 # LMS needs like 60 seconds to come up
   - make healthchecks
   - make validate-lms-volume
+  - make e2e-tests
   - make up-marketing-detached

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,9 @@ studio-shell: ## Run a shell on the Studio container
 healthchecks: ## Run a curl against all services' healthcheck endpoints to make sure they are up. This will eventually be parameterized
 	./healthchecks.sh
 
+e2e-tests: ## Run the end-to-end tests against the service containers
+	docker run -t --network=devstack_default -v ${DEVSTACK_WORKSPACE}/edx-e2e-tests:/edx-e2e-tests -v ${DEVSTACK_WORKSPACE}/edx-platform:/edx-e2e-tests/lib/edx-platform --env-file ${DEVSTACK_WORKSPACE}/edx-e2e-tests/devstack_env edxops/e2e env TERM=$(TERM)  bash -c 'paver e2e_test --exclude="whitelabel\|enterprise"'
+
 validate-lms-volume: ## Validate that changes to the local workspace are reflected in the LMS container
 	touch $(DEVSTACK_WORKSPACE)/edx-platform/testfile
 	docker exec edx.devstack.lms ls /edx/app/edxapp/edx-platform/testfile

--- a/README.rst
+++ b/README.rst
@@ -407,17 +407,24 @@ use Firefox instead, prefix the test command with
 Running End-to-End Tests
 ------------------------
 
-To run the end-to-end tests for edx-platform, start a shell for the e2e
-container and run the tests via paver:
+To run the base set of end-to-end tests for edx-platform, run the following
+make target:
+
+.. code:: sh
+
+   make e2e-tests
+
+If you want to use some of the other testing options described in the
+`edx-e2e-tests README`_, you can instead start a shell for the e2e container
+and run the tests manually via paver:
 
 .. code:: sh
 
     make e2e-shell
     paver e2e_test --exclude="whitelabel\|enterprise"
 
-Additional testing options are available as described in the
-`edx-e2e-tests README`_.  The browser running the tests can be seen and
-interacted with via VNC as described above (Chrome is used by default).
+The browser running the tests can be seen and interacted with via VNC as
+described above (Chrome is used by default).
 
 Troubleshooting: General Tips
 -----------------------------


### PR DESCRIPTION
Added a make target for running the standard set of end-to-end tests, and run it as part of the Travis tests.