### PR TITLE
Watch edx-platform assets

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,7 +116,7 @@ services:
       - "18130:18130"
 
   lms:
-    command: bash -c 'source /edx/app/edxapp/edxapp_env && while true; do python /edx/app/edxapp/edx-platform/manage.py lms runserver 0.0.0.0:18000 --settings devstack_docker; sleep 2; done'
+    command: bash -c 'cd /edx/app/edxapp/edx-platform && source ../edxapp_env && (nohup paver watch_assets -b &) && while true; do python manage.py lms runserver 0.0.0.0:18000 --settings devstack_docker; sleep 2; done'
     container_name: edx.devstack.lms
     depends_on:
       - mysql
@@ -139,7 +139,7 @@ services:
       - edxapp_lms_assets:/edx/var/edxapp/staticfiles/
 
   studio:
-    command: bash -c 'source /edx/app/edxapp/edxapp_env && while true; do python /edx/app/edxapp/edx-platform/manage.py cms runserver 0.0.0.0:18010 --settings devstack_docker; sleep 2; done'
+    command: bash -c 'cd /edx/app/edxapp/edx-platform && source ../edxapp_env && (nohup paver watch_assets -b &) && while true; do python manage.py cms runserver 0.0.0.0:18000 --settings devstack_docker; sleep 2; done'
     container_name: edx.devstack.studio
     depends_on:
       - mysql


### PR DESCRIPTION
# [PLAT-1663](https://openedx.atlassian.net/browse/PLAT-1663)

Essentially, I'm modifying the launch command for both `lms` and `studio` to kick off a `paver watch_assets` background process.

Work in progress, pairs with https://github.com/edx/edx-platform/pull/15817. This seemingly works on my local setup.

FYI @arizzitano @macdiesel 