### PR TITLE
Set EDXAPP_TEST_MONGO_HOST for LMS and Studio

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,9 +138,8 @@ services:
       BOK_CHOY_HOSTNAME: edx.devstack.lms
       BOK_CHOY_LMS_PORT: 18003
       BOK_CHOY_CMS_PORT: 18031
+      EDXAPP_TEST_MONGO_HOST: edx.devstack.mongo
       NO_PYTHON_UNINSTALL: 1
-
-
     image: edxops/edxapp:latest
     ports:
       - "18000:18000"
@@ -164,6 +163,7 @@ services:
       BOK_CHOY_HOSTNAME: edx.devstack.studio
       BOK_CHOY_LMS_PORT: 18103
       BOK_CHOY_CMS_PORT: 18131
+      EDXAPP_TEST_MONGO_HOST: edx.devstack.mongo
       NO_PYTHON_UNINSTALL: 1
     image: edxops/edxapp:latest
     ports:


### PR DESCRIPTION
Setting this one environment variable to a default value is currently the only thing that the `test_docker` settings modules do differently from the `test` modules in edx-platform.  Setting it here instead will let us eliminate those duplicate modules and configure pytest to not require specifying a settings module on the command line (because it's always the same module, and can be set in pytest.ini files instead).