### PR TITLE
Ignore `local.mk` to store convenience make targets.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,5 @@ ENV/
 .docker-sync/
 .env
 
+# Personal makefile extensions
+local.mk

--- a/README.rst
+++ b/README.rst
@@ -208,6 +208,8 @@ simply use the ``docker-compose restart`` command:
 -  lms
 -  studio
 
+If you'd like to add some convenience make targets, you can add them to a `local.mk` file, ignored by git.
+
 Payments
 --------
 


### PR DESCRIPTION
I was getting tired of typing `docker-compose restart <service>` which is slightly longer than `make lms-restart` or just `make restart` for everything, so added these here.

Along with it, updated some relevant parts of the documentation (and very minor spacing issues that were causing bad rendering).