### PR TITLE
Update make SERVICE-logs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ logs: ## View logs from containers running in detached mode
 	docker-compose logs -f
 
 %-logs: ## View the logs of the specified service container
-	docker-compose logs -f --tail=500 | grep edx.devstack.$*
+	docker-compose logs -f --tail=500 $*
 
 pull: ## Update Docker images
 	docker-compose pull


### PR DESCRIPTION
Looks like compose can just take the service in this command.

FYI: @edx/docker-devstack-working-group 