### PR TITLE
Update mongo image version to 3.2.16 OPS-2208

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     # See https://docs.mongodb.com/v3.0/reference/program/mongod/#options for complete details.
     command: mongod --smallfiles --nojournal --storageEngine wiredTiger
     container_name: edx.devstack.mongo
-    image: mongo:3.0.14
+    image: mongo:3.2.16
     # ports:
     #  - "27017:27017"
     volumes:


### PR DESCRIPTION
As part of the mongo 3.2 work I created a Dockerfile that installs Mongo 3.2 using edX ansible. I'll probably need help to do the switch and understand how it works.