### PR TITLE
Revert asset watching containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ lms-shell: ## Run a shell on the LMS container
 	docker exec -it edx.devstack.lms env TERM=$(TERM) /edx/app/edxapp/devstack.sh open
 
 lms-attach: ## Attach to the LMS container process to use the debugger & see logs.
-	docker attach `docker ps -aqf "name=edx.devstack.lms$$"`
+	docker attach `docker ps -aqf "name=edx.devstack.lms"`
 
 studio-shell: ## Run a shell on the Studio container
 	docker exec -it edx.devstack.studio env TERM=$(TERM) /edx/app/edxapp/devstack.sh open
@@ -115,7 +115,7 @@ studio-static: ## Rebuild static assets for the Studio container
 static: | credentials-static discovery-static ecommerce-static lms-static studio-static ## Rebuild static assets for all service containers
 
 studio-attach: ## Attach to the Studio container process to use the debugger & see logs.
-	docker attach `docker ps -aqf "name=edx.devstack.studio$$"`
+	docker attach `docker ps -aqf "name=edx.devstack.studio"`
 
 healthchecks: ## Run a curl against all services' healthcheck endpoints to make sure they are up. This will eventually be parameterized
 	./healthchecks.sh

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ lms-shell: ## Run a shell on the LMS container
 	docker exec -it edx.devstack.lms env TERM=$(TERM) /edx/app/edxapp/devstack.sh open
 
 lms-attach: ## Attach to the LMS container process to use the debugger & see logs.
-	docker attach `docker ps -aqf "name=edx.devstack.lms"`
+	docker attach `docker ps -aqf "name=edx.devstack.lms$$"`
 
 studio-shell: ## Run a shell on the Studio container
 	docker exec -it edx.devstack.studio env TERM=$(TERM) /edx/app/edxapp/devstack.sh open
@@ -115,7 +115,7 @@ studio-static: ## Rebuild static assets for the Studio container
 static: | credentials-static discovery-static ecommerce-static lms-static studio-static ## Rebuild static assets for all service containers
 
 studio-attach: ## Attach to the Studio container process to use the debugger & see logs.
-	docker attach `docker ps -aqf "name=edx.devstack.studio"`
+	docker attach `docker ps -aqf "name=edx.devstack.studio$$"`
 
 healthchecks: ## Run a curl against all services' healthcheck endpoints to make sure they are up. This will eventually be parameterized
 	./healthchecks.sh

--- a/docker-compose-host.yml
+++ b/docker-compose-host.yml
@@ -14,16 +14,10 @@ services:
     volumes:
       - ${DEVSTACK_WORKSPACE}/edx-platform:/edx/app/edxapp/edx-platform:cached
       - ${DEVSTACK_WORKSPACE}/src:/edx/src:cached
-  lms_watcher:
-    volumes:
-      - ${DEVSTACK_WORKSPACE}/edx-platform:/edx/app/edxapp/edx-platform:cached
   studio:
     volumes:
       - ${DEVSTACK_WORKSPACE}/edx-platform:/edx/app/edxapp/edx-platform:cached
       - ${DEVSTACK_WORKSPACE}/src:/edx/src:cached
-  studio_watcher:
-    volumes:
-      - ${DEVSTACK_WORKSPACE}/edx-platform:/edx/app/edxapp/edx-platform:cached
   forum:
     volumes:
       - ${DEVSTACK_WORKSPACE}/cs_comments_service:/edx/app/forum/cs_comments_service:cached

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -149,15 +149,6 @@ services:
     volumes:
       - edxapp_lms_assets:/edx/var/edxapp/staticfiles/
 
-  lms_watcher:
-    command: bash -c 'cd /edx/app/edxapp/edx-platform && source ../edxapp_env && while true; do paver watch_assets; sleep 2; done'
-    container_name: edx.devstack.lms_watcher
-    environment:
-      BOK_CHOY_HOSTNAME: edx.devstack.lms_watcher
-    image: edxops/edxapp:latest
-    volumes:
-      - edxapp_lms_assets:/edx/var/edxapp/staticfiles/
-
   studio:
     command: bash -c 'source /edx/app/edxapp/edxapp_env && while true; do python /edx/app/edxapp/edx-platform/manage.py cms runserver 0.0.0.0:18010 --settings devstack_docker; sleep 2; done'
     container_name: edx.devstack.studio
@@ -180,15 +171,6 @@ services:
       - "19877:19877" # JS test debugging
       # - "18103:18103"
       # - "18131:18131"
-    volumes:
-      - edxapp_studio_assets:/edx/var/edxapp/staticfiles/
-
-  studio_watcher:
-    command: bash -c 'cd /edx/app/edxapp/edx-platform && source ../edxapp_env && while true; do paver watch_assets; sleep 2; done'
-    container_name: edx.devstack.studio_watcher
-    environment:
-      BOK_CHOY_HOSTNAME: edx.devstack.studio_watcher
-    image: edxops/edxapp:latest
     volumes:
       - edxapp_studio_assets:/edx/var/edxapp/staticfiles/
 


### PR DESCRIPTION
These are crushing CPU usage, we ought to not do that.
```
NAME                          CPU %               MEM USAGE / LIMIT
edx.devstack.studio_watcher   53.66%              180.3MiB / 9.743GiB
edx.devstack.lms_watcher      39.92%              174.5MiB / 9.743GiB
```

Also included is a commit (and its revert) that fixes an oversight - the `lms-attach` command searches for a process named `edx.devstack.lms`, with no terminating character. Of course, that means `edx.devstack.lms_watcher` *also* matches, sending 2 results from `docker ps` into `docker attach` and failing there.

When un-reverting, go ahead and squash that fix into the main commit.