### PR TITLE
FEDX-500 unblock everyone

### DIFF
--- a/docker-compose-host.yml
+++ b/docker-compose-host.yml
@@ -4,21 +4,31 @@ services:
   credentials:
     volumes:
       - ${DEVSTACK_WORKSPACE}/credentials:/edx/app/credentials/credentials:cached
+      - credentials_node_modules:/edx/app/credentials/credentials/node_modules
   discovery:
       volumes:
       - ${DEVSTACK_WORKSPACE}/course-discovery:/edx/app/discovery/discovery:cached
+      - discovery_node_modules:/edx/app/discovery/discovery/node_modules
   ecommerce:
     volumes:
       - ${DEVSTACK_WORKSPACE}/ecommerce:/edx/app/ecommerce/ecommerce:cached
+      - ecommerce_node_modules:/edx/app/ecommerce/ecommerce/node_modules
   lms:
     volumes:
       - ${DEVSTACK_WORKSPACE}/edx-platform:/edx/app/edxapp/edx-platform:cached
+      - edxapp_node_modules:/edx/app/edxapp/edx-platform/node_modules
       - ${DEVSTACK_WORKSPACE}/src:/edx/src:cached
   studio:
     volumes:
       - ${DEVSTACK_WORKSPACE}/edx-platform:/edx/app/edxapp/edx-platform:cached
+      - edxapp_node_modules:/edx/app/edxapp/edx-platform/node_modules
       - ${DEVSTACK_WORKSPACE}/src:/edx/src:cached
   forum:
     volumes:
       - ${DEVSTACK_WORKSPACE}/cs_comments_service:/edx/app/forum/cs_comments_service:cached
       
+volumes:
+  credentials_node_modules:
+  discovery_node_modules:
+  ecommerce_node_modules:
+  edxapp_node_modules:

--- a/provision-lms.sh
+++ b/provision-lms.sh
@@ -13,7 +13,6 @@ for app in "${apps[@]}"; do
     docker-compose $DOCKER_COMPOSE_FILES up -d $app
 done
 
-docker-compose exec lms bash -c 'rm -f /edx/app/edxapp/edx-platform/.prereqs_cache/Node_prereqs.sha1 && rm -Rf /edx/app/edxapp/edx-platform/node_modules'
 docker-compose exec lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform && NO_PYTHON_UNINSTALL=1 paver install_prereqs'
 
 #Installing prereqs crashes the process


### PR DESCRIPTION
Prevents the ENOENT error described in [FEDX-500](https://openedx.atlassian.net/browse/FEDX-500)

As outlined in https://docs.docker.com/compose/compose-file/compose-file-v2/#volumes, this will create a volume for node_modules that is not mounted in the host at all, which will hopefully resolve the weird filesystem issues were fighting ATM.

Early returns are positive on a clean install, I've made it past the initial `paver install_prereqs` step. Host reports an empty `node_modules/` under edx-platform, docker says it's fine (and I've confirmed in a separate shell that `edx-platform/node_modules/.bin/coffee` exists).

I'll let the full provision sequence finish before declaring this "good"