### PR TITLE
PLAT-1341 Use --parallel for faster, less verbose pulls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ before_install:
 
   - make requirements
   - make dev.clone
+  - make pull
 
 script:
   - make dev.provision

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ logs: ## View logs from containers running in detached mode
 	docker-compose logs -f --tail=500 $*
 
 pull: ## Update Docker images
-	docker-compose pull
+	docker-compose pull --parallel
 
 validate: ## Validate the devstack configuration
 	docker-compose config

--- a/README.rst
+++ b/README.rst
@@ -836,7 +836,7 @@ The performance improvements provided by `cached consistency mode for volume
 mounts`_ introduced in Docker CE Edge 17.04 are still not good enough. It's
 possible that the "delegated" consistency mode will be enough to no longer need
 docker-sync, but this feature hasn't been fully implemented yet (as of
-Docker 17.06.0-ce, "delegated" behaves the same as "cached").  There is a
+Docker 17.12.0-ce, "delegated" behaves the same as "cached").  There is a
 GitHub issue which explains the `current status of implementing delegated consistency mode`_.
 
 .. _Docker Compose: https://docs.docker.com/compose/
@@ -855,6 +855,8 @@ GitHub issue which explains the `current status of implementing delegated consis
 .. _edx-platform testing documentation: https://github.com/edx/edx-platform/blob/master/docs/testing.rst#running-python-unit-tests
 .. _docker-sync: #improve-mac-osx-performance-with-docker-sync
 .. |Build Status| image:: https://travis-ci.org/edx/devstack.svg?branch=master
+    :target: https://travis-ci.org/edx/devstack
+    :alt: Travis
 .. _Docker CI Jenkins Jobs: https://tools-edx-jenkins.edx.org/job/DockerCI
 .. _How do I build images?: https://github.com/edx/devstack/tree/master#how-do-i-build-images
    :target: https://travis-ci.org/edx/devstack


### PR DESCRIPTION
The `--quiet` option for pulls we had been waiting for is now available in a stable Docker release, but I also noticed that `--parallel` was added in docker-compose 1.12.0 (and hence is already included by Docker 17.06 CE, which is our current minimum requirement).  This both downloads all the necessary images in parallel *and* uses abbreviated output with no progress bars.

From looking at the Travis logs, it looks like recent Docker releases have stopped including the progress bar for non-interactive terminals anyway, but this should still be a performance and output simplicity win.  Instead of verbose output showing each layer of each image being independently downloaded and applied, it now shows something like this instead:

```
C02QX0W0FVH6:devstack jeremybowman$ make pull
docker-compose pull --parallel
Pulling firefox       ... done
Pulling mongo         ... done
Pulling chrome        ... done
Pulling elasticsearch ... done
Pulling mysql         ... done
Pulling memcached     ... done
Pulling credentials   ... done
Pulling studio        ... 
Pulling lms           ... 
Pulling forum         ... done
Pulling ecommerce     ... done
Pulling discovery     ... done
```

I also fixed the Travis badge in the README while I was at it; it correctly displayed the build status, but didn't link to the actual test results page.