### PR TITLE
Add devpi container to cache PyPI pkgs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ restore:  ## Restore all data volumes from the host. WARNING: THIS WILL OVERWRIT
 	docker run --rm --volumes-from edx.devstack.mongo -v $$(pwd)/.dev/backups:/backup debian:jessie tar zxvf /backup/mongo.tar.gz
 	docker run --rm --volumes-from edx.devstack.elasticsearch -v $$(pwd)/.dev/backups:/backup debian:jessie tar zxvf /backup/elasticsearch.tar.gz
 
-# TODO: Create a devstack.sh file in the devpi container to activate the devpi venv/clear the entire cache.
+# TODO: Create a devstack.sh file in the devpi container to activate the devpi venv within the shell.
 devpi-shell: ## Run a shell on the devpi container
 	docker exec -it edx.devstack.devpi env TERM=$(TERM) /bin/bash
 
@@ -202,6 +202,9 @@ validate-lms-volume: ## Validate that changes to the local workspace are reflect
 vnc-passwords: ## Get the VNC passwords for the Chrome and Firefox Selenium containers
 	@docker logs edx.devstack.chrome 2>&1 | grep "VNC password" | tail -1
 	@docker logs edx.devstack.firefox 2>&1 | grep "VNC password" | tail -1
+
+devpi-password: ## Get the root devpi password for the devpi container
+	docker-compose exec devpi bash -c "cat /data/server/.serverpassword"
 
 mysql-shell: ## Run a shell on the mysql container
 	docker-compose exec mysql bash

--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,10 @@ restore:  ## Restore all data volumes from the host. WARNING: THIS WILL OVERWRIT
 	docker run --rm --volumes-from edx.devstack.mongo -v $$(pwd)/.dev/backups:/backup debian:jessie tar zxvf /backup/mongo.tar.gz
 	docker run --rm --volumes-from edx.devstack.elasticsearch -v $$(pwd)/.dev/backups:/backup debian:jessie tar zxvf /backup/elasticsearch.tar.gz
 
+# TODO: Create a devstack.sh file in the devpi container to activate the devpi venv/clear the entire cache.
+devpi-shell: ## Run a shell on the devpi container
+	docker exec -it edx.devstack.devpi env TERM=$(TERM) /bin/bash
+
 # TODO: Print out help for this target. Even better if we can iterate over the
 # services in docker-compose.yml, and print the actual service names.
 %-shell: ## Run a shell on the specified service container

--- a/README.rst
+++ b/README.rst
@@ -487,6 +487,12 @@ PyCharm Integration
 
 See the `Pycharm Integration documentation`_.
 
+devpi Caching
+-------------
+
+LMS and Studio use a devpi container to cache PyPI dependencies, which speeds up several Devstack operations.
+See the `devpi documentation`_.
+
 Debugging using PDB
 -------------------
 
@@ -877,6 +883,7 @@ GitHub issue which explains the `current status of implementing delegated consis
 .. _edxops Docker image: https://hub.docker.com/r/edxops/
 .. _Docker Hub: https://hub.docker.com/
 .. _Pycharm Integration documentation: docs/pycharm_integration.rst
+.. _devpi documentation: docs/devpi.rst
 .. _edx-platform testing documentation: https://github.com/edx/edx-platform/blob/master/docs/testing.rst#running-python-unit-tests
 .. _docker-sync: #improve-mac-osx-performance-with-docker-sync
 .. |Build Status| image:: https://travis-ci.org/edx/devstack.svg?branch=master

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -189,8 +189,6 @@ services:
 
   devpi:
     container_name: edx.devstack.devpi
-    environment:
-      DEVPI_PASSWORD: supersecret
     image: edxops/devpi:latest
     ports:
       - "3141:3141"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -187,6 +187,15 @@ services:
     ports:
       - "44567:4567"
 
+  devpi:
+    container_name: edx.devstack.devpi
+    environment:
+      DEVPI_PASSWORD: supersecret
+    image: edxops/devpi:latest
+    ports:
+      - "3141:3141"
+    volumes:
+      - devpi_data:/data
 
 volumes:
   discovery_assets:
@@ -195,3 +204,4 @@ volumes:
   elasticsearch_data:
   mongo_data:
   mysql_data:
+  devpi_data:

--- a/docs/devpi.rst
+++ b/docs/devpi.rst
@@ -1,0 +1,65 @@
+devpi in Devstack
+=================
+
+Several tasks in Devstack require pulling fresh copies of Python packages
+from PyPI. Depending on the application you are working on this can take
+anywhere from a few seconds to several minutes. Additionally, those tasks
+could not be done while offline due to not being able to contact PyPI.
+
+To help speed up those tasks and bring us close to being able to use
+Devstack entirely offline we have introduced a devpi PyPI cache container
+to Devstack. Currently it is only configured as a package cache for LMS
+and Studio, but the hope is to expand its use to the other Devstack
+applications and to move to a state where it comes pre-populated with the
+requirements of all Devstack applications.
+
+In general the operation of devpi should be transparent. You may notice
+some significant speedup in tox testing and ``paver update_prereqs``
+operations after the first run. Container storage should persist through
+``make down`` and ``make dev.up`` operations.
+
+The devpi web interface can be browsed from the host at:
+http://localhost:3141/
+
+Documentation for devpi is at:
+https://www.devpi.net/
+
+
+What is cached?
+---------------
+
+devpi will cache anything that LMS or Studio pull from PyPI via pip,
+including things from the various requirements files. It will not cache
+requirements given as URLs (ex. ``git+https`` style links) or local
+packages (ex. ``-e common/lib/calc``). When these types of packages are
+encountered they bypass devpi.
+
+How is it tied into other Devstack components?
+----------------------------------------------
+
+devpi runs in a separate container started via the usual ``make``
+operations and controlled through Docker Compose. Devstack components
+can use the ``devpi_consumer`` role in edx-configuration to add devpi
+configuration to their containers, and override configuration
+variables as necessary.
+
+``devpi_consumer`` creates a pip.config file in the configured location
+that tells pip to use devpi as the primary package repository. If devpi
+does not have a requested package it will call through to PyPI and
+cache the result if something is found.
+
+Disabling devpi
+---------------
+
+To temporarily remove devpi caching from an edxapp container, start a
+shell (``lms-shell`` or ``studio-shell``) and move or delete
+``/root/.pip/pip.conf``. This will be undone on the next container
+restart unless the container state is persisted.
+
+Monitoring devpi
+----------------
+
+You can monitor the devpi logs by running this command on the host:
+``docker logs -f edx.devstack.devpi`` or looking at the output in
+Kitematic. You can also check the devpi server status by visiting:
+http://localhost:3141/+status


### PR DESCRIPTION
https://openedx.atlassian.net/browse/PLAT-1912

PR is dependent on this companion configuration PR: https://github.com/edx/configuration/pull/4309

devpi is a standalone caching layer in front of PyPI. This PR:
- adds the container to the Open edX Docker devstack container suite
- adds a target to shell into the devpi container
- adds documentation about the devpi container and its function