### PR TITLE
First part of being able to start XQueue in docker devstack

### DIFF
--- a/docker-compose-xqueue.yml
+++ b/docker-compose-xqueue.yml
@@ -1,0 +1,17 @@
+version: "2.1"
+
+services:
+  rabbitmq:
+    image: rabbitmq:3.6.9
+    container_name: edx.devstack.rabbit
+
+  xqueue:
+    container_name: edx.devstack.xqueue
+    image: edxops/xqueue:latest
+    command: bash -c 'source /edx/app/xqueue/venvs/xqueue/bin/activate && while true; do SERVICE_VARIANT=xqueue python /edx/app/xqueue/xqueue/manage.py runserver 0.0.0.0:18040 --settings xqueue.devstack; sleep 2; done'
+    volumes:
+      - ${DEVSTACK_WORKSPACE}/xqueue:/edx/app/xqueue/xqueue:cached
+    depends_on: # even though we need mysql, we can't refer to it because it's started in the other compose file
+      - rabbitmq 
+    ports:
+      - 18040:18040

--- a/provision-xqueue.sh
+++ b/provision-xqueue.sh
@@ -1,0 +1,31 @@
+set -e
+set -o pipefail
+set -x
+
+# Bring up RabbitMQ and XQueue
+docker-compose $DOCKER_COMPOSE_FILES up -d rabbitmq
+docker-compose $DOCKER_COMPOSE_FILES up -d xqueue
+
+# This works in case you provision xqueue without having other services up
+# Bring the database online.
+docker-compose up -d mysql
+
+# Ensure the MySQL server is online and usable
+echo "Waiting for MySQL"
+until docker exec -i edx.devstack.mysql mysql -uroot -se "SELECT EXISTS(SELECT 1 FROM mysql.user WHERE user = 'root')" &> /dev/null
+do
+  printf "."
+  sleep 1
+done
+
+docker exec -i edx.devstack.mysql mysql -uroot mysql < provision-xqueue.sql
+# Run migrations
+docker-compose $DOCKER_COMPOSE_FILES exec xqueue bash -c 'source /edx/app/xqueue/venvs/xqueue/bin/activate && cd /edx/app/xqueue/xqueue && SERVICE_VARIANT=xqueue python manage.py migrate --settings=xqueue.devstack'
+# Add users that graders use to fetch data, there's one default user in Ansible which is part of our settings
+docker-compose $DOCKER_COMPOSE_FILES exec xqueue bash -c 'source /edx/app/xqueue/venvs/xqueue/bin/activate && cd /edx/app/xqueue/xqueue && SERVICE_VARIANT=xqueue python manage.py update_users --settings=xqueue.devstack'
+
+# Create a user that can be used by xqueue to create / manage queues
+docker-compose $DOCKER_COMPOSE_FILES exec rabbitmq bash -c 'rabbitmqctl delete_user guest'
+docker-compose $DOCKER_COMPOSE_FILES exec rabbitmq bash -c 'rabbitmqctl add_user edx edx'
+docker-compose $DOCKER_COMPOSE_FILES exec rabbitmq bash -c 'rabbitmqctl set_permissions edx ".*" ".*" ".*"'
+docker-compose $DOCKER_COMPOSE_FILES exec rabbitmq bash -c 'rabbitmqctl set_user_tags edx administrator'

--- a/provision-xqueue.sql
+++ b/provision-xqueue.sql
@@ -1,0 +1,4 @@
+CREATE DATABASE IF NOT EXISTS xqueue;
+GRANT ALL ON xqueue.* TO 'xqueue001'@'%' IDENTIFIED BY 'password';
+
+FLUSH PRIVILEGES;

--- a/repo.sh
+++ b/repo.sh
@@ -24,6 +24,7 @@ repos=(
     "https://github.com/edx/ecommerce.git"
     "https://github.com/edx/edx-e2e-tests.git"
     "https://github.com/edx/edx-platform.git"
+    "https://github.com/edx/xqueue.git"
 )
 
 name_pattern=".*edx/(.*).git"


### PR DESCRIPTION
This primarily covers
* using the existing XQueue docker image
* adding rabbitmq
* adding XQueue to MySQL
* Have provisioning set up the rabbit users needed
* Make a shell for rabbit/xqueue
  Since it lacks the devstack.sh for now, just run bash
* Change to the devstack settings file

Coming later
* Start a second container for the consumer, before this, the xqueue
  docker container rain rsyslogd, gunicorn and the consumer.  This
  simplifies to closer to the other IDAs