### PR TITLE
Testing improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,10 +162,10 @@ studio-restart: ## Kill the LMS Django development server. The watcher process w
 	docker exec -t edx.devstack.studio bash -c 'kill $$(ps aux | grep "manage.py cms" | egrep -v "while|grep" | awk "{print \$$2}")'
 
 xqueue-shell: ## Run a shell on the XQueue container
-	docker exec -it edx.devstack.xqueue env TERM=$(TERM) /bin/bash
+	docker exec -it edx.devstack.xqueue env TERM=$(TERM) /edx/app/xqueue/devstack.sh open
 
 xqueue_consumer-shell: ## Run a shell on the XQueue consumer container
-	docker exec -it edx.devstack.xqueue_consumer env TERM=$(TERM) /bin/bash
+	docker exec -it edx.devstack.xqueue_consumer env TERM=$(TERM) /edx/app/xqueue/devstack.sh open
 
 rabbit-shell: ## Run a shell on the RabbitMQ container
 	docker exec -it edx.devstack.rabbit env TERM=$(TERM) /bin/bash

--- a/provision-xqueue.sh
+++ b/provision-xqueue.sh
@@ -25,7 +25,6 @@ docker-compose $DOCKER_COMPOSE_FILES exec xqueue bash -c 'source /edx/app/xqueue
 docker-compose $DOCKER_COMPOSE_FILES exec xqueue bash -c 'source /edx/app/xqueue/venvs/xqueue/bin/activate && cd /edx/app/xqueue/xqueue && SERVICE_VARIANT=xqueue python manage.py update_users --settings=xqueue.devstack'
 
 # Create a user that can be used by xqueue to create / manage queues
-docker-compose $DOCKER_COMPOSE_FILES exec rabbitmq bash -c 'rabbitmqctl delete_user guest'
 docker-compose $DOCKER_COMPOSE_FILES exec rabbitmq bash -c 'rabbitmqctl add_user edx edx'
 docker-compose $DOCKER_COMPOSE_FILES exec rabbitmq bash -c 'rabbitmqctl set_permissions edx ".*" ".*" ".*"'
 docker-compose $DOCKER_COMPOSE_FILES exec rabbitmq bash -c 'rabbitmqctl set_user_tags edx administrator'


### PR DESCRIPTION
Having a devstack.sh means local runs of make test are simpler since
make xqueue-shell drops you in the right place with the correct
virtualenv.
https://github.com/edx/configuration/pull/4349

Leave the guest user for rabbit since it makes tests easier, and this
code is being deleted soon anyway.