### PR TITLE
Define project name independent of folder name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,10 @@ DEVSTACK_WORKSPACE ?= $(shell pwd)/..
 
 OS := $(shell uname)
 
+COMPOSE_PROJECT_NAME=devstack
+
 export DEVSTACK_WORKSPACE
+export COMPOSE_PROJECT_NAME
 
 include *.mk
 


### PR DESCRIPTION
By default, [docker compose will create a default network](https://docs.docker.com/compose/networking/) for all of the containers called `myapp_default` where `myapp` is the name of the folder containing the compose file.

[studio-frontend](https://github.com/edx/studio-frontend/blob/master/docker-compose.yml#L18) started connecting to the devstack's `devstack_default` network, but it relies on the developer having checked out this repo to a folder named "devstack", and not something else like "docker-devstack".

This change defines the [`COMPOSE_PROJECT_NAME`](https://docs.docker.com/compose/reference/envvars/#compose_project_name) which overrides the default of just using the folder name. That way, the network name will always be `devstack_default` no matter what the folder name is.

Sidenote: I would have defined the env var in the `.env` file [like this issue suggests](https://github.com/docker/compose/issues/2982), but it looks like it is already being used for something else and is gitignored. It may be possible for things to go haywire if someone a) doesn't have a folder named "devstack" and b) uses straight `docker-compose` commands instead of `make` commands (since [Makefile's `export` directive only exposes the variable to commands inside the Makefile](https://www.gnu.org/software/make/manual/html_node/Variables_002fRecursion.html)).