### PR TITLE
[WIP] Adding a volume in which to clone the theming repos

### DIFF
--- a/docker-compose-host.yml
+++ b/docker-compose-host.yml
@@ -16,6 +16,7 @@ services:
   lms:
     volumes:
       - ${DEVSTACK_WORKSPACE}/edx-platform:/edx/app/edxapp/edx-platform:cached
+      - ${DEVSTACK_WORKSPACE}/openedx-themes:/edx/app/openedx-themes:cached
       - edxapp_node_modules:/edx/app/edxapp/edx-platform/node_modules
       - ${DEVSTACK_WORKSPACE}/src:/edx/src:cached
   studio:


### PR DESCRIPTION
## Description

This PR adds a volume where comprehensive theme repositories are supposed to be cloned.

Then it would be quite easy to update `devstack.py` to include some configurations like:
```
DEFAULT_SITE_THEME = "my_theme_name"
ENABLE_COMPREHENSIVE_THEMING = True
COMPREHENSIVE_THEME_DIRS = [
    "/edx/app/openedx-themes/my_theme_repo",
] 
```
And that would be all what is needed to start developing a comprehensive theme, outside of the main `edx-platform` repo.

## Motivation

I tried to find a good location for this, and the only reference I found to themes was the `Makefile.edx.dev.clone_whitelabel` target. That however relies on the developer having access to a private repo.

This PR wants to spark the discussion about some best practices around how developers in the community are supposed to work with this docker based devstack.

## Reviewers

- [ ] I have no idea who would be a good fit to review this.
