### PR TITLE
Set COMPOSE_PROJECT_NAME var in provision scripts

### DIFF
--- a/provision-credentials.sh
+++ b/provision-credentials.sh
@@ -3,6 +3,8 @@
 # NOTE (CCB): We do NOT call provision-ida because it expects a virtualenv.
 # The new images for Credentials do not use virtualenv.
 
+export COMPOSE_PROJECT_NAME='devstack'
+
 name=credentials
 port=18150
 

--- a/provision-discovery.sh
+++ b/provision-discovery.sh
@@ -1,4 +1,6 @@
 # Provisioning script for the discovery service
+export COMPOSE_PROJECT_NAME='devstack'
+
 ./provision-ida.sh discovery 18381
 
 docker-compose exec discovery bash -c 'rm -rf /edx/var/discovery/*'

--- a/provision-e2e.sh
+++ b/provision-e2e.sh
@@ -2,6 +2,8 @@ set -e
 set -o pipefail
 set -x
 
+export COMPOSE_PROJECT_NAME='devstack'
+
 if [ -z "$DEVSTACK_WORKSPACE" ]; then
     DEVSTACK_WORKSPACE=..
 elif [ ! -d "$DEVSTACK_WORKSPACE" ]; then

--- a/provision-ecommerce.sh
+++ b/provision-ecommerce.sh
@@ -1,3 +1,5 @@
+export COMPOSE_PROJECT_NAME='devstack'
+
 # Load database dumps for the largest databases to save time
 ./load-db.sh ecommerce
 

--- a/provision-forum.sh
+++ b/provision-forum.sh
@@ -2,5 +2,7 @@ set -e
 set -o pipefail
 set -x
 
+export COMPOSE_PROJECT_NAME='devstack'
+
 docker-compose $DOCKER_COMPOSE_FILES up -d forum
 docker-compose exec forum bash -c 'source /edx/app/forum/ruby_env && cd /edx/app/forum/cs_comments_service && bundle install --deployment --path /edx/app/forum/.gem/'

--- a/provision-ida-user.sh
+++ b/provision-ida-user.sh
@@ -1,4 +1,5 @@
 #This script depends on the LMS being up!
+export COMPOSE_PROJECT_NAME='devstack'
 
 name=$1
 port=$2

--- a/provision-ida.sh
+++ b/provision-ida.sh
@@ -1,3 +1,4 @@
+export COMPOSE_PROJECT_NAME='devstack'
 name=$1
 port=$2
 

--- a/provision-lms.sh
+++ b/provision-lms.sh
@@ -2,6 +2,7 @@ set -e
 set -o pipefail
 set -x
 
+export COMPOSE_PROJECT_NAME='devstack'
 apps=( lms studio )
 
 # Load database dumps for the largest databases to save time

--- a/provision-xqueue.sh
+++ b/provision-xqueue.sh
@@ -2,6 +2,8 @@ set -e
 set -o pipefail
 set -x
 
+export COMPOSE_PROJECT_NAME='devstack'
+
 # Bring up RabbitMQ and XQueue
 docker-compose $DOCKER_COMPOSE_FILES up -d rabbitmq
 docker-compose $DOCKER_COMPOSE_FILES up -d xqueue

--- a/provision.sh
+++ b/provision.sh
@@ -17,6 +17,8 @@ GREEN='\033[0;32m'
 YELLOW='\033[0;33m'
 NC='\033[0m' # No Color
 
+export COMPOSE_PROJECT_NAME='devstack'
+
 # Bring the databases online.
 docker-compose up -d mysql mongo
 


### PR DESCRIPTION
This sets the project name to a consistent value `"devstack"` regardless of the folder name during provisioning. This is a follow up to https://github.com/edx/devstack/pull/280 which set the variable within the Makefile.

I tested this by renaming my `devstack` folder to `devstack-test`, ran `sh provision-discovery.sh`, and then `docker volume list | grep devstacktest` which returned no results.