### PR TITLE
Make sure xqueue(_consumer) has logs/shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,12 @@ logs: ## View logs from containers running in detached mode
 %-logs: ## View the logs of the specified service container
 	docker-compose logs -f --tail=500 $*
 
+xqueue-logs: ## View logs from containers running in detached mode
+	docker-compose -f docker-compose-xqueue.yml logs -f xqueue
+
+xqueue_consumer-logs: ## View logs from containers running in detached mode
+	docker-compose -f docker-compose-xqueue.yml logs -f xqueue_consumer
+
 pull: ## Update Docker images
 	docker-compose pull --parallel
 
@@ -171,8 +177,14 @@ studio-restart: ## Kill the LMS Django development server. The watcher process w
 xqueue-shell: ## Run a shell on the XQueue container
 	docker exec -it edx.devstack.xqueue env TERM=$(TERM) /edx/app/xqueue/devstack.sh open
 
+xqueue-restart: ## Kill the XQueue development server. The watcher process will restart it.
+	docker exec -t edx.devstack.xqueue bash -c 'kill $$(ps aux | grep "manage.py runserver" | egrep -v "while|grep" | awk "{print \$$2}")'
+
 xqueue_consumer-shell: ## Run a shell on the XQueue consumer container
 	docker exec -it edx.devstack.xqueue_consumer env TERM=$(TERM) /edx/app/xqueue/devstack.sh open
+
+xqueue_consumer-restart: ## Kill the XQueue development server. The watcher process will restart it.
+	docker exec -t edx.devstack.xqueue_consumer bash -c 'kill $$(ps aux | grep "manage.py run_consumer" | egrep -v "while|grep" | awk "{print \$$2}")'
 
 rabbit-shell: ## Run a shell on the RabbitMQ container
 	docker exec -it edx.devstack.rabbit env TERM=$(TERM) /bin/bash

--- a/docker-compose-xqueue.yml
+++ b/docker-compose-xqueue.yml
@@ -1,18 +1,13 @@
 version: "2.1"
 
 services:
-  rabbitmq:
-    image: rabbitmq:3.6.9
-    container_name: edx.devstack.rabbit
-
   xqueue:
     container_name: edx.devstack.xqueue
     image: edxops/xqueue:latest
     command: bash -c 'source /edx/app/xqueue/venvs/xqueue/bin/activate && while true; do SERVICE_VARIANT=xqueue python /edx/app/xqueue/xqueue/manage.py runserver 0.0.0.0:18040 --settings xqueue.devstack; sleep 2; done'
     volumes:
       - ${DEVSTACK_WORKSPACE}/xqueue:/edx/app/xqueue/xqueue:cached
-    depends_on: # even though we need mysql, we can't refer to it because it's started in the other compose file
-      - rabbitmq
+    # depends_on: even though we need mysql, we can't refer to it because it's started in the other compose file
     ports:
       - 18040:18040
 
@@ -22,5 +17,4 @@ services:
     command: bash -c 'source /edx/app/xqueue/venvs/xqueue/bin/activate && while true; do SERVICE_VARIANT=xqueue python /edx/app/xqueue/xqueue/manage.py run_consumer --settings xqueue.devstack ; sleep 2; done'
     volumes:
       - ${DEVSTACK_WORKSPACE}/xqueue:/edx/app/xqueue/xqueue:cached
-    depends_on: # even though we need mysql, we can't refer to it because it's started in the other compose file
-      - rabbitmq
+    # depends_on: even though we need mysql, we can't refer to it because it's started in the other compose file

--- a/provision-xqueue.sh
+++ b/provision-xqueue.sh
@@ -2,8 +2,7 @@ set -e
 set -o pipefail
 set -x
 
-# Bring up RabbitMQ and XQueue
-docker-compose $DOCKER_COMPOSE_FILES up -d rabbitmq
+# Bring up XQueue, we don't need the consumer for provisioning
 docker-compose $DOCKER_COMPOSE_FILES up -d xqueue
 
 # This works in case you provision xqueue without having other services up
@@ -23,8 +22,3 @@ docker exec -i edx.devstack.mysql mysql -uroot mysql < provision-xqueue.sql
 docker-compose $DOCKER_COMPOSE_FILES exec xqueue bash -c 'source /edx/app/xqueue/venvs/xqueue/bin/activate && cd /edx/app/xqueue/xqueue && SERVICE_VARIANT=xqueue python manage.py migrate --settings=xqueue.devstack'
 # Add users that graders use to fetch data, there's one default user in Ansible which is part of our settings
 docker-compose $DOCKER_COMPOSE_FILES exec xqueue bash -c 'source /edx/app/xqueue/venvs/xqueue/bin/activate && cd /edx/app/xqueue/xqueue && SERVICE_VARIANT=xqueue python manage.py update_users --settings=xqueue.devstack'
-
-# Create a user that can be used by xqueue to create / manage queues
-docker-compose $DOCKER_COMPOSE_FILES exec rabbitmq bash -c 'rabbitmqctl add_user edx edx'
-docker-compose $DOCKER_COMPOSE_FILES exec rabbitmq bash -c 'rabbitmqctl set_permissions edx ".*" ".*" ".*"'
-docker-compose $DOCKER_COMPOSE_FILES exec rabbitmq bash -c 'rabbitmqctl set_user_tags edx administrator'


### PR DESCRIPTION
Remove rabbit now that we no longer need it.
This includes the provisioning