### PR TITLE
Only output stderr of credentials make static on failure

### DIFF
--- a/provision-credentials.sh
+++ b/provision-credentials.sh
@@ -25,4 +25,4 @@ docker exec -t edx.devstack.${name} bash -c './manage.py create_or_update_site -
 # Compile static assets last since they are absolutely necessary for all services. This will allow developers to get
 # started if they do not care about static assets
 echo -e "${GREEN}Compiling static assets for ${name}...${NC}"
-docker exec -t edx.devstack.${name}  bash -c ' make static' -- "$name"
+docker exec -t edx.devstack.${name}  bash -c ' if ! make static 2>creds_make_static.err; then echo "------- Last 100 lines of stderr"; tail creds_make_static.err -n 100; echo "-------"; fi;' -- "$name"


### PR DESCRIPTION
Currently make static outputs so many warnings it kills our Travis
builds. This should work around that by redirecting stderr and tailing
the last 100 lines only if make static returns an error code.