### PR TITLE
Add devpi dependency to lms and studio

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -130,6 +130,7 @@ services:
     command: bash -c 'source /edx/app/edxapp/edxapp_env && while true; do python /edx/app/edxapp/edx-platform/manage.py lms runserver 0.0.0.0:18000 --settings devstack_docker; sleep 2; done'
     container_name: edx.devstack.lms
     depends_on:
+      - devpi
       - mysql
       - memcached
       - mongo
@@ -155,6 +156,7 @@ services:
     command: bash -c 'source /edx/app/edxapp/edxapp_env && while true; do python /edx/app/edxapp/edx-platform/manage.py cms runserver 0.0.0.0:18010 --settings devstack_docker; sleep 2; done'
     container_name: edx.devstack.studio
     depends_on:
+      - devpi
       - mysql
       - memcached
       - mongo


### PR DESCRIPTION
Both lms and studio now count on devpi being up when updating dependencies, but we hadn't captured this in the explicit container dependencies (which a problem during provisioning, when only a subset of the containers are launched).  It's not strictly needed (pip will eventually fall back to PyPI), but installing dependencies without it is slower and generates lots of warnings like this:

```
Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPConnection object at 0x7fd046336290>: Failed to establish a new connection: [Errno -2] Name or service not known',)': /root/pypi/+simple/edx-i18n-tools/
```