### PR TITLE
Fix Bug in Site Config Provisioning

### DIFF
--- a/ecommerce.sql
+++ b/ecommerce.sql
@@ -992,7 +992,7 @@ CREATE TABLE `core_siteconfiguration` (
   `discovery_api_url` varchar(200) NOT NULL,
   `enable_apple_pay` tinyint(1) NOT NULL,
   `enable_partial_program` tinyint(1) NOT NULL,
-  `journals_api_url` varchar(200) DEFAULT NULL,
+  `journals_api_url` varchar(200),
   PRIMARY KEY (`id`),
   UNIQUE KEY `core_siteconfiguration_site_id_3124a87d_uniq` (`site_id`),
   UNIQUE KEY `core_siteconfiguration_partner_id_75739217_uniq` (`partner_id`),


### PR DESCRIPTION
- The way that journals_api_url was set in the ecommerce sql provision
  script caused an error if you had to run migrations in ecommerce
  after running the provision script.  Now it's fixed!