### PR TITLE
Use a a different folder for Acquia marketing ssh key

### DIFF
--- a/docker-compose-marketing-site-host.yml
+++ b/docker-compose-marketing-site-host.yml
@@ -4,6 +4,6 @@ services:
   marketing:
     volumes:
       # NOTE: A private key is needed to sync the files and database from production.
-      - ~/.ssh/id_rsa:/root/.ssh/id_rsa
+      - ~/.ssh/id_rsa_acquia:/root/.ssh/id_rsa_acquia
       - ../edx-mktg:/edx/app/edx-mktg/edx-mktg
       - ../edx-mktg/docroot:/var/www/html


### PR DESCRIPTION
To be paired with https://github.com/edx/edx-mktg/pull/2138

Turns out the marketing container shares the same key using in your local machine. This can get very ugly if you decide to create new ssh keys in your marketing container since it could overwrite your local machines keys.