### PR TITLE
Add demo program when provisioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,8 @@ dev.repo.reset: ## Attempts to reset the local repo checkouts to the master work
 
 dev.up: | check-memory ## Bring up all services with host volumes
 	docker-compose -f docker-compose.yml -f docker-compose-host.yml up -d
+	@# Comment out this next line if you want to save some time and don't care about catalog programs
+	./programs/provision.sh cache >/dev/null
 
 dev.up.watchers: | check-memory ## Bring up asset watcher containers
 	docker-compose -f docker-compose-watchers.yml up -d

--- a/programs/README.md
+++ b/programs/README.md
@@ -1,0 +1,21 @@
+# Support for Provisioning Programs
+
+This directory holds a few scripts that set up a demo program.
+
+Currently, the demo program is very simple, just one demo course and no purchase-bundling support enabled.
+
+Normally you don't need to manually run these scripts to provision the demo course, as it is automatically added when provisioning fresh devstacks.
+
+## Reprovisioning
+
+If you have an existing older devstack installation and want to add the demo program to it, simply run:
+
+``./programs/provision.sh``
+
+And it will set it up for you. This can be run mutiple times safely.
+
+## Recaching
+
+If you have an existing devstack with the demo program, but want to recache the programs inside LMS (something you need to do every time you bring the LMS container back up), simply run:
+
+``./programs/provision.sh cache``

--- a/programs/discovery.py
+++ b/programs/discovery.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# Run like so:
+# ./manage.py shell -c "`cat discovery.py`"
+
+import urllib.request as request
+from course_discovery.apps.core.models import Partner
+from course_discovery.apps.course_metadata.models import (
+    Course, CourseRun, Organization, Program, ProgramType, SeatType
+)
+
+DEMO_IMAGE_URL = 'http://edx.devstack.lms:18000/asset-v1:edX+DemoX+Demo_Course+type@asset+block@images_course_image.jpg'
+
+
+# Make sure micromasters type exists
+micromasters, _ = ProgramType.objects.get_or_create(slug='micromasters', defaults={'name': 'MicroMasters'})
+micromasters.applicable_seat_types.add(
+    SeatType.objects.get_or_create(slug='verified', defaults={'name': 'Verified'})[0],
+    SeatType.objects.get_or_create(slug='professional', defaults={'name': 'Professional'})[0],
+    SeatType.objects.get_or_create(slug='credit', defaults={'name': 'Credit'})[0],
+)
+
+# Add a demo program
+edx_partner = Partner.objects.get(short_code='edx')  # created during normal provision
+program, _ = Program.objects.update_or_create(
+    marketing_slug='demo-program',
+    defaults={
+        'title': 'edX Demonstration Program',
+        'type': micromasters,
+        'status': 'active',
+        'partner': edx_partner,
+        'overview': 'A demo program for testing.',
+        'total_hours_of_effort': 4,
+        'min_hours_effort_per_week': 1,
+        'max_hours_effort_per_week': 4,
+        'one_click_purchase_enabled': True,
+        'card_image_url': DEMO_IMAGE_URL,
+    },
+)
+
+# Now, after an ID has been created, connect the program to other models
+
+course = Course.objects.get(key='edX+DemoX')
+program.courses = [course]
+
+try:
+    # This run causes run-time exceptions, because it uses old style key.
+    deprecated_run = CourseRun.objects.get(key='edX/DemoX/Demo_Course')
+    program.excluded_course_runs = [deprecated_run]
+except CourseRun.DoesNotExist:
+    # This key only seems to be in some existing devstacks, don't worry if it doesn't exist
+    pass
+
+edx_org = Organization.objects.get(key='edX')
+program.authoring_organizations = [edx_org]
+program.credit_backing_organizations = [edx_org]
+
+# And set up the banner image
+if not program.banner_image.name:
+    program.banner_image.save('banner.jpg', request.urlopen(DEMO_IMAGE_URL))
+
+program.save()

--- a/programs/lms.py
+++ b/programs/lms.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# Run like so:
+# ./manage.py lms shell -c "`cat lms.py`"
+
+from django.contrib.sites.models import Site
+from openedx.core.djangoapps.catalog.models import CatalogIntegration
+from openedx.core.djangoapps.programs.models import ProgramsApiConfig
+from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
+
+DISCOVERY_API_URL = 'http://edx.devstack.discovery:18381/api/v1/'
+
+
+def set_current_config(cls, args):
+    if not cls.equal_to_current(args):
+        config = cls(**args)
+        config.save()
+
+
+# Enable the program dashboard
+set_current_config(ProgramsApiConfig, {'enabled': True})
+
+# Enable the discovery worker
+set_current_config(CatalogIntegration, {
+    'enabled': True,
+    'internal_api_url': 'https://example.com/api',  # required but unused
+    'service_username': 'discovery_worker',
+})
+
+# Tell LMS about discovery
+SiteConfiguration.objects.update_or_create(
+    site=Site.objects.get(domain='example.com'),
+    defaults={
+        'enabled': True,
+        'values': {'COURSE_CATALOG_API_URL': DISCOVERY_API_URL},
+    },
+)

--- a/programs/provision.sh
+++ b/programs/provision.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+#
+# To add programs support, we need to tweak/add certain rows in the database.
+# We want to go through Django for this (rather than direct db modification), since we have a lot of Python
+# side-effect code and validation in our models.
+#
+# We *could* create several tiny management commands. But this use case is very special cased. Instead, we just
+# have the scripts here and pass them into Django's management shell.
+#
+# But to get the commands through Docker and Django intact, we have to do some creative quoting.
+
+# Run this command with no arguments to completely provision an existing devstack.
+# This can be run multiple times in a row with no ill effect (it's idempotent).
+
+BASEDIR=$(dirname "$0")
+
+# Main items are green, rest is dull grey since they are noisy, but we still might want to see their output,
+# for error cases and the like.
+notice() {
+    SWITCH="\033["
+    GREY="${SWITCH}0;37m"
+    GREEN="${SWITCH}0;32m"
+    echo "${GREEN}${@}${GREY}"
+}
+
+# We reset color once we're done with the script.
+# If we wanted to be really fancy, we'd trap signals and reset there too.
+reset_color() {
+    SWITCH="\033["
+    NORMAL="${SWITCH}0m"
+    echo "${NORMAL}"
+}
+
+docker_exec() {
+    service=${1}
+    cmd=${2}
+    app=${3:-$service}
+    repo=${4:-$app}
+
+    CMDS="
+    source /edx/app/$app/${app}_env &&
+    /edx/app/$app/$repo/manage.py $cmd
+    "
+
+    docker-compose exec "$service" bash -c "$CMDS"
+}
+
+provision_ida() {
+    service=${1}
+    cmd=${2:-"shell"}
+
+    # Escape double quotes and backticks from the Python
+    PROGRAM_SCRIPT="$(sed 's/\("\|`\)/\\\1/g' < "$BASEDIR/$service.py")"
+
+    cmd="$cmd -c \"$PROGRAM_SCRIPT\""
+
+    docker_exec "$service" "$cmd" "$3" "$4"
+}
+
+if [ "$1" = "lms" -o -z "$1" ]; then
+    notice Adding program support to LMS...
+    provision_ida lms "lms shell" edxapp edx-platform
+fi
+
+if [ "$1" = "discovery" -o -z "$1" ]; then
+    notice Adding demo program to Discovery...
+    provision_ida discovery
+fi
+
+if [ "$1" = "cache" -o -z "$1" ]; then
+    notice Caching programs inside the LMS...
+    docker_exec lms "lms cache_programs" edxapp edx-platform
+fi
+
+reset_color

--- a/provision-discovery.sh
+++ b/provision-discovery.sh
@@ -5,3 +5,6 @@ docker-compose exec discovery bash -c 'rm -rf /edx/var/discovery/*'
 docker-compose exec discovery bash -c 'source /edx/app/discovery/discovery_env && python /edx/app/discovery/discovery/manage.py create_or_update_partner --site-id 1 --site-domain localhost:18381 --code edx --name edX --courses-api-url "http://edx.devstack.lms:18000/api/courses/v1/" --ecommerce-api-url "http://edx.devstack.ecommerce:18130/api/v2/" --organizations-api-url "http://edx.devstack.lms:18000/api/organizations/v0/" --oidc-url-root "http://edx.devstack.lms:18000/oauth2" --oidc-key discovery-key --oidc-secret discovery-secret'
 docker-compose exec discovery bash -c 'source /edx/app/discovery/discovery_env && python /edx/app/discovery/discovery/manage.py refresh_course_metadata'
 docker-compose exec discovery bash -c 'source /edx/app/discovery/discovery_env && python /edx/app/discovery/discovery/manage.py update_index --disable-change-limit'
+
+# Add demo program
+./programs/provision.sh discovery

--- a/provision-lms.sh
+++ b/provision-lms.sh
@@ -41,3 +41,6 @@ done
 
 # Provision a retirement service account user
 ./provision-retirement-user.sh retirement retirement_service_worker
+
+# Add demo program
+./programs/provision.sh lms


### PR DESCRIPTION
Add some scripts to provision a demo program.

It will automatically do so when doing a normal provision. Or you can manually do it for your current devstack by running ./programs/provision.sh.

Errors are not fatal, to match the rest of the provisioning scripts, and because configuring one IDA can still be done if an earlier one fails. We print errors, so they can still be investigated.

I chose to do this work as tiny Python scripts rather than tiny management commands, because it seemed so use-case-specific. It does mean that refactoring in the IDAs might break these scripts... But I think that's an acceptable risk.

I've also **added a cache-programs step during dev.up**. If we don't do this, everytime you start a container, you'd have to manually cache the programs to have it work at all in the LMS. It adds ~7s to every dev.up time... But guh I hate caching manually. Looking for opinions on the tradeoff.

I chose to ignore bundling, since that wasn't our immediate concern. Which meant I could ignore ecommerce. I also ignored marketing, since we don't care about interactions there right now.

But this is a good base for future-us to work on to add such support.

Once this lands, we should ping devs about it, as an FYI.

https://openedx.atlassian.net/browse/LEARNER-5141