### PR TITLE
setup analytics pipeline travis build tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ python:
   - "3.5"
 
 env:
-  - DEVSTACK_WORKSPACE=/tmp DOCKER_COMPOSE_VERSION=1.13.0 SHALLOW_CLONE=1
+  - DEVSTACK_WORKSPACE=/tmp DOCKER_COMPOSE_VERSION=1.13.0 SHALLOW_CLONE=1 DEVSTACK='lms'
+  - DEVSTACK_WORKSPACE=/tmp DOCKER_COMPOSE_VERSION=1.13.0 SHALLOW_CLONE=1 DEVSTACK='analytics_pipeline'
 
 services:
   - docker
@@ -28,17 +29,8 @@ before_install:
 
   - make requirements
   - make dev.clone
-  - make pull
+  - if [[ $DEVSTACK == 'lms' ]]; then make pull; fi
+  - if [[ $DEVSTACK == 'analytics_pipeline' ]]; then make dev.up.analytics_pipeline; fi
 
 script:
-  - make dev.provision
-  - make dev.up
-  - sleep 60 # LMS needs like 60 seconds to come up
-  - make healthchecks
-  - make validate-lms-volume
-  # Disable e2e-tests until either:
-  # * tests are less flaky
-  # * We have a way to test the infrastructure for testing but ignore the test results.
-  # See PLAT-1712
-  # - make e2e-tests
-  - make up-marketing-detached
+  - "./.travis/run.sh"

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [[ $DEVSTACK == 'lms' ]]; then
+    make dev.provision
+    make dev.up
+    sleep 60  # LMS needs like 60 seconds to come up
+    make healthchecks
+    make validate-lms-volume
+    # Disable e2e-tests until either:
+    # * tests are less flaky
+    # * We have a way to test the infrastructure for testing but ignore the test results.
+    # See PLAT-1712
+    # - make e2e-tests
+    make up-marketing-detached
+fi
+
+if [[ $DEVSTACK == 'analytics_pipeline' ]]; then
+    make dev.provision.analytics_pipeline
+    make dev.up.analytics_pipeline
+    sleep 30 # hadoop services need some time to be fully functional and out of safemode
+    make analytics-pipeline-devstack-test
+fi

--- a/Makefile
+++ b/Makefile
@@ -251,11 +251,17 @@ dev.up.analytics_pipeline: | check-memory ## Bring up analytics_pipeline
 	docker-compose -f docker-compose.yml -f docker-compose-analytics-pipeline.yml -f docker-compose-host.yml up -d analyticspipeline
 
 pull.analytics_pipeline: ## Update Analytics pipeline Docker images
-	docker-compose -f docker-compose-analytics-pipeline.yml pull --parallel
+	docker-compose -f docker-compose.yml -f docker-compose-analytics-pipeline.yml pull --parallel
+
+analytics-pipeline-devstack-test:
+	docker exec -u hadoop -i edx.devstack.analytics_pipeline bash -c 'sudo chown -R hadoop:hadoop /edx/app/analytics_pipeline && source /edx/app/hadoop/.bashrc && make develop-local && make docker-test-acceptance-local ONLY_TESTS=edx.analytics.tasks.tests.acceptance.test_internal_reporting_database && make docker-test-acceptance-local ONLY_TESTS=edx.analytics.tasks.tests.acceptance.test_user_activity'
 
 stop.analytics_pipeline:
 	docker-compose -f docker-compose.yml -f docker-compose-analytics-pipeline.yml stop
 	docker-compose up -d mysql      ## restart mysql as other containers need it
+
+hadoop-application-logs-%: ## Hadoop logs by application Id
+	docker exec -it edx.devstack.analytics_pipeline.nodemanager yarn logs -applicationId $*
 
 # Provisions studio, ecommerce, and marketing with course(s) in test-course.json
 # Modify test-course.json before running this make target to generate a custom course

--- a/docker-compose-analytics-pipeline.yml
+++ b/docker-compose-analytics-pipeline.yml
@@ -98,7 +98,7 @@ services:
     container_name: edx.devstack.analytics_pipeline
     hostname: analyticspipeline
     volumes:
-      - ../edx-analytics-pipeline:/edx/app/analytics_pipeline/analytics_pipeline
+      - ${DEVSTACK_WORKSPACE}/edx-analytics-pipeline:/edx/app/analytics_pipeline/analytics_pipeline
     command: ["/etc/bootstrap.sh", "-d"]
     depends_on:
       - mysql


### PR DESCRIPTION
This PR adds support for 
- Running analytics pipeline acceptance tests using their docker images/containers , as part of travis build. 
- Optimizes analytics docker devstack provisioning.

##### Analytics pipeline tests finish within 30mins which is still lower than lms provisioning & test which is around 34mins.