### PR TITLE
Create a fresh/clean devstack with one script

### DIFF
--- a/new-devstack.sh
+++ b/new-devstack.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+read -p "This will delete ALL docker and local Git data. Would you like to proceed? [y/n] " -r
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+    # 1. Ensure all docker containers, images, and volumes are cleaned up
+    # Stop all containers
+    docker stop $(docker ps -a -q)
+    # Delete all containers
+    docker rm $(docker ps -a -q)
+    # Delete all images
+    docker rmi $(docker images -q)
+    # Delete all volumes
+    docker volume rm -f $(docker volume ls -q)
+
+    # 2. Remove and remake workspace directory
+    rm -rf ~/workspace
+    mkdir ~/workspace/
+    cd ~/workspace
+
+    # 3. Rebuild the system
+    git clone https://github.com/edx/devstack.git # git@github.com:edx/devstack.git
+    cd devstack
+    make requirements
+    make dev.clone
+    make dev.provision
+    make dev.up
+
+    # 4. Possible way to handle optional/additional repo-cloning? i.e. our team always needs studio-frontend
+fi


### PR DESCRIPTION
The idea for this stems because @efischer19 created some scripts that we can use on our team to blow away and recreate our devstacks with one command. This process takes about 30-35 minutes, which is awesome. Eric also runs this weekly (dare I say daily) to ensure his local setup does encounter errors due to staleness.

I took this idea and tried to leverage it with a new hire recently who needed devstack set up, but does not necessarily need to know how it works / the details of what commands to run and when. I also wanted see if we can use this sort of script creation for our internship program. I see this as a way of helping folks get onboard faster with a running local setup, then be able to leverage the extensive Makefile/devstack README to learn the details as needed.

This PR is mostly to get the conversation started (thanks @doctoryes) and I realize it will need some changes, especially since we can't clean/remove the Git workspace repo if the script that's running is living within that repo. Ultimately I think this sort of functionality could be useful for devs in general, but I know getting folks on board with that is a bigger hurdle. If we can come up with a solution that will at least help our internship group here in a couple of weeks and then iterate on it from there, that'd be swell.