### PR TITLE
Support for offline-installable snapshots

### DIFF
--- a/scripts/extract_snapshot_linux.sh
+++ b/scripts/extract_snapshot_linux.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# Installs Open edX devstack on Linux from a local snapshot of repository,
+# image, and volume tarballs.
+
+set -e
+
+# Extract all of the Open edX source code repositories needed to run devstack
+for tarball in repositories/*.tar.gz
+do
+    echo "Extracting $tarball"
+    tar xzf $tarball
+done
+
+# Load Docker containers and their associated volumes
+# Calls to "docker" usually require sudo privileges on Linux
+sudo python devstack/scripts/restore.py
+
+# For the rest, we need to be in the directory with the devstack Makefile
+cd devstack
+
+# Shut down all the running containers, the volumes were incomplete at startup
+sudo make down
+
+# Start all the containers again with correctly populated volumes.
+sudo make dev.up

--- a/scripts/extract_snapshot_mac.sh
+++ b/scripts/extract_snapshot_mac.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# Installs Open edX devstack on macOS from a local snapshot of repository,
+# image, and volume tarballs.
+
+set -e
+
+# Extract all of the Open edX source code repositories needed to run devstack
+for tarball in repositories/*.tar.gz
+do
+    echo "Extracting $tarball"
+    tar xzf $tarball
+done
+
+# Load Docker containers and populate their associated volumes
+python devstack/scripts/restore.py
+
+# For the rest, we need to be in the directory with the devstack Makefile
+cd devstack
+
+# Shut down all the running containers, the volumes were incomplete at startup
+make down
+
+# Start all the containers again with correctly populated volumes.
+make dev.up

--- a/scripts/restore.py
+++ b/scripts/restore.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+"""
+Restore Docker images and volumes from the tarballs found in "images" and
+"volumes" subdirectories of the current directory.
+"""
+from __future__ import absolute_import, print_function, unicode_literals
+
+import json
+import os
+from subprocess import check_call
+
+SOURCE_DIR = os.getcwd()
+IMAGES_DIR = os.path.join(SOURCE_DIR, 'images')
+VOLUMES_DIR = os.path.join(SOURCE_DIR, 'volumes')
+VOLUMES_JSON = os.path.join(VOLUMES_DIR, 'volumes.json')
+DEVSTACK_REPO_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Use this minimal container image to restore volume content
+BACKUP_IMAGE = 'alpine:3.7'
+
+
+def load_images():
+    """
+    Load all of the Docker images from the associated tarballs.
+    """
+    for filename in os.listdir(IMAGES_DIR):
+        if not filename.endswith('.tar.gz'):
+            continue
+        tarball = os.path.join(IMAGES_DIR, filename)
+        print('Loading Docker image from {}'.format(filename))
+        check_call(['docker', 'load', '--input', tarball])
+
+
+def start_devstack():
+    """
+    Start the devstack containers so their volumes can be populated.
+    """
+    cwd = os.getcwd()
+    os.chdir(DEVSTACK_REPO_DIR)
+    check_call(['make', 'dev.up'])
+    os.chdir(cwd)
+
+
+def load_volumes():
+    """
+    Restore the image volume content from the associated tarballs.
+    """
+    with open(VOLUMES_JSON, 'r') as f:
+        volumes = json.loads(f.read())
+    for volume in volumes:
+        container_name = volume['container']
+        path = volume['path']
+        if path.endswith('/'):
+            path = path[:-1]
+        tarball = volume['tarball']
+        components = str(path.count('/'))
+        print('Loading volume from {}'.format(tarball))
+        check_call(['docker', 'run', '--rm', '--volumes-from', container_name,
+                    '-v', '{}:/backup'.format(VOLUMES_DIR), BACKUP_IMAGE,
+                    'tar', 'xzf', '/backup/{}'.format(tarball), '-C', path,
+                    '--strip-components', components])
+
+
+if __name__ == "__main__":
+    load_images()
+    start_devstack()
+    load_volumes()

--- a/scripts/snapshot.py
+++ b/scripts/snapshot.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+"""
+Script to capture a snapshot of the current devstack images, repositories,
+and volume content to tarballs for no-network installation.  To be run while
+devstack is running (otherwise volume content can't be accessed).
+"""
+from __future__ import absolute_import, print_function, unicode_literals
+
+import argparse
+import json
+import os
+import re
+from shutil import copyfile
+from subprocess import check_call
+
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEVSTACK_WORKSPACE = os.path.dirname(REPO_ROOT)
+REPO_SCRIPT = os.path.join(REPO_ROOT, 'repo.sh')
+
+# Use this minimal container image to fetch volume content
+BACKUP_IMAGE = 'alpine:3.7'
+
+
+def make_directories(output_dir):
+    """
+    Create any of the output directories that don't already exist.
+    """
+    if not os.path.exists(output_dir):
+        os.mkdir(output_dir)
+    for dir_name in ('images', 'repositories', 'volumes'):
+        path = os.path.join(output_dir, dir_name)
+        if not os.path.exists(path):
+            os.mkdir(path)
+
+
+def archive_repos(output_dir):
+    """
+    Create tarballs for each of the relevant repositories in DEVSTACK_WORKSPACE
+    """
+    with open('repo.sh', 'r') as f:
+        script = f.read()
+    prefix = r'https://github\.com/edx/'
+    suffix = r'\.git'
+    repos = re.findall(r'{}[^\.]+{}'.format(prefix, suffix), script)
+    dirs = [repo[len(prefix) - 1:1 - len(suffix)] for repo in repos if 'edx-themes' not in repo]
+    dirs.append('devstack')
+    repositories_dir = os.path.join(output_dir, 'repositories')
+    cwd = os.getcwd()
+    os.chdir(DEVSTACK_WORKSPACE)
+    for directory in dirs:
+        print('Archiving {}'.format(directory))
+        output = os.path.join(repositories_dir, '{}.tar.gz'.format(directory))
+        check_call(['tar', 'czf', output, directory])
+    os.chdir(cwd)
+
+
+def process_compose_file(filename, output_dir):
+    """
+    Go through the given docker-compose YAML file and save any of the
+    referenced Docker images and data volumes to tarballs.
+    """
+    images_dir = os.path.join(output_dir, 'images')
+    volumes_dir = os.path.join(output_dir, 'volumes')
+    compose_path = os.path.join(REPO_ROOT, filename)
+    with open(compose_path, 'r') as f:
+        devstack = yaml.safe_load(f.read())
+
+    volume_list = []
+    services = devstack['services']
+    saved_images = set()
+    for service_name in services:
+        service = services[service_name]
+        image = service['image']
+        container_name = service['container_name']
+        # Don't save the same image twice, like edxapp for lms and studio
+        if image not in saved_images:
+            output = os.path.join(images_dir, '{}.tar'.format(service_name))
+            print('Saving image {}'.format(service_name))
+            check_call(['docker', 'save', '--output', output, image])
+            check_call(['gzip', output])
+            saved_images.add(image)
+
+        if 'volumes' in service:
+            volumes = service['volumes']
+            for volume in volumes:
+                if volume[0] == '.':
+                    # Mount of a host directory, skip it
+                    continue
+                parts = volume.split(':')
+                volume_name = parts[0]
+                volume_path = parts[1]
+                tarball = '{}.tar.gz'.format(volume_name)
+                volume_list.append({'container': container_name,
+                                    'path': volume_path, 'tarball': tarball})
+                print('Saving volume {}'.format(volume_name))
+                check_call(['docker', 'run', '--rm', '--volumes-from', container_name, '-v',
+                            '{}:/backup'.format(volumes_dir), BACKUP_IMAGE, 'tar', 'czf',
+                            '/backup/{}'.format(tarball), volume_path])
+    print('Saving image alpine')
+    output = os.path.join(images_dir, 'alpine.tar')
+    check_call(['docker', 'save', '--output', output, BACKUP_IMAGE])
+    check_call(['gzip', output])
+    print('Saving volume metadata')
+    with open(os.path.join(volumes_dir, 'volumes.json'), 'w') as f:
+        f.write(json.dumps(volume_list))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('output_dir', help='The directory in which to create the devstack snapshot')
+    args = parser.parse_args()
+    output_dir = args.output_dir
+    make_directories(output_dir)
+    archive_repos(output_dir)
+    process_compose_file('docker-compose.yml', output_dir)
+    copyfile(os.path.join(REPO_ROOT, 'scripts', 'extract_snapshot_linux.sh'),
+             os.path.join(output_dir, 'linux.sh'))
+    copyfile(os.path.join(REPO_ROOT, 'scripts', 'extract_snapshot_mac.sh'),
+             os.path.join(output_dir, 'mac.sh'))


### PR DESCRIPTION
Scripts for creating and restoring reasonably comprehensive snapshots of devstack which can be installed and used without a network connection.  Created to avoid a bandwidth crisis during the Open edX Conference workshops by distributing devstack on USB flash drives.

This doesn't yet include any of the optional containers like analytics, etc.  The resulting output is currently about 7 GB, and requires an additional 25 GB of space on the target system once installed.

This also lays the groundwork for other options like downloading pre-provisioned data volumes along with the latest Docker images.  All of the compressed volumes combined are about 194 MB, significantly smaller than any of the current Open edX service images.