### PR TITLE
Use docker --format to get memory allocation (not Python)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -279,7 +279,7 @@ build-courses: ## NOTE: marketing course creation is not available for those out
 	rm course-generator/tmp-config.json
 
 check-memory: ## Check if enough memory has been allocated to Docker
-	@if [ `docker info --format '{{json .}}' | python -c "from __future__ import print_function; import sys, json; print(json.load(sys.stdin)['MemTotal'])"` -lt 2095771648 ]; then echo "\033[0;31mWarning, System Memory is set too low!!! Increase Docker memory to be at least 2 Gigs\033[0m"; fi || exit 0
+	@if [ `docker info --format '{{.MemTotal}}'` -lt 2095771648 ]; then echo "\033[0;31mWarning, System Memory is set too low!!! Increase Docker memory to be at least 2 Gigs\033[0m"; fi || exit 0
 
 stats: ## Get per-container CPU and memory utilization data
 	docker stats --format "table {{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}"


### PR DESCRIPTION
@jdmulloy Just to kill the python dependency