### PR TITLE
Fix bug caused by provision-ida-user.sh refactor

### DIFF
--- a/provision-credentials.sh
+++ b/provision-credentials.sh
@@ -20,7 +20,7 @@ docker exec -t edx.devstack.${name}  bash -c 'echo "from django.contrib.auth imp
 echo -e "${GREEN}Configuring site for ${name}...${NC}"
 docker exec -t edx.devstack.${name} bash -c './manage.py create_or_update_site --site-id=1 --site-domain=localhost:18150 --site-name="Open edX" --platform-name="Open edX" --company-name="Open edX" --lms-url-root=http://localhost:18000 --catalog-api-url=http://edx.devstack.discovery:18381/api/v1/ --tos-url=http://localhost:18000/tos --privacy-policy-url=http://localhost:18000/privacy --homepage-url=http://localhost:18000 --certificate-help-url=http://localhost:18000/faq --theme-name=openedx'
 
-./provision-ida-user.sh ${name} ${port}
+./provision-ida-user.sh ${name} ${name} ${port}
 
 # Compile static assets last since they are absolutely necessary for all services. This will allow developers to get
 # started if they do not care about static assets


### PR DESCRIPTION
The provision-credentials.sh script was missed as part of a recent
change to provision-ida-user.sh arguments.  Tests passed even with this
error, perhaps due to return codes not bubbling up through
docker-compose, or a missing set -e somewhere but I haven't debugged.

---

This was the error:
```
CommandError: URLs provided are invalid. Please provide valid application and redirect URLs.
```

Now, the credentials client is successfully created:

```
{
    "name": "credentials", 
    "url": "http://localhost:18150", 
    "logout_uri": "http://localhost:18150/logout/", 
    "redirect_uri": "http://localhost:18150/complete/edx-oidc/", 
    "client_id": "credentials-key", 
    "user": {
        "username": "credentials_worker", 
        "first_name": "", 
        "last_name": "", 
        "is_active": true, 
        "email": "credentials_worker@example.com", 
        "is_superuser": true, 
        "is_staff": true, 
        "last_login": null, 
        "password": "pbkdf2_sha256$20000$7LkYbekAHaMd$2InidT7nklBXmbU7LBjV/KrV+xZhLENf6CqU6u/FwM4=", 
        "id": 3, 
        "date_joined": "2016-12-17T01:53:56.965Z"
    }, 
    "client_type": 0, 
    "client_secret": "credentials-secret"
}
```