### PR TITLE
Disable ecommerce django toolbar

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,7 +121,7 @@ services:
     stdin_open: true
     tty: true
     environment:
-      ENABLE_DJANGO_TOOLBAR: 1
+      ENABLE_DJANGO_TOOLBAR: 0
     image: edxops/ecommerce:latest
     ports:
       - "18130:18130"


### PR DESCRIPTION
There is currently an issue only on devstack where some
of the pages on ecommerce is taking very long to load
(on the order of minutes) when the django debug toolbar
is enabled.