### PR TITLE
LEARNER-5358 Adds records-help-url config parameter

### DIFF
--- a/provision-credentials.sh
+++ b/provision-credentials.sh
@@ -18,7 +18,7 @@ echo -e "${GREEN}Creating super-user for ${name}...${NC}"
 docker exec -t edx.devstack.${name}  bash -c 'echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser(\"edx\", \"edx@example.com\", \"edx\") if not User.objects.filter(username=\"edx\").exists() else None" | python /edx/app/$1/$1/manage.py shell' -- "$name"
 
 echo -e "${GREEN}Configuring site for ${name}...${NC}"
-docker exec -t edx.devstack.${name} bash -c './manage.py create_or_update_site --site-id=1 --site-domain=localhost:18150 --site-name="Open edX" --platform-name="Open edX" --company-name="Open edX" --lms-url-root=http://localhost:18000 --catalog-api-url=http://edx.devstack.discovery:18381/api/v1/ --tos-url=http://localhost:18000/tos --privacy-policy-url=http://localhost:18000/privacy --homepage-url=http://localhost:18000 --certificate-help-url=http://localhost:18000/faq --theme-name=openedx'
+docker exec -t edx.devstack.${name} bash -c './manage.py create_or_update_site --site-id=1 --site-domain=localhost:18150 --site-name="Open edX" --platform-name="Open edX" --company-name="Open edX" --lms-url-root=http://localhost:18000 --catalog-api-url=http://edx.devstack.discovery:18381/api/v1/ --tos-url=http://localhost:18000/tos --privacy-policy-url=http://localhost:18000/privacy --homepage-url=http://localhost:18000 --certificate-help-url=http://localhost:18000/faq --records-help-url=http://localhost:18000/faq --theme-name=openedx'
 
 ./provision-ida-user.sh ${name} ${name} ${port}
 


### PR DESCRIPTION
https://github.com/edx/credentials/pull/400 from [LEARNER-5358](https://openedx.atlassian.net/browse/LEARNER-5358) adds in an optional configuration parameter for the records-help-url.  Since it is left empty by default, I think it makes sense to add a value to the provision script.

This can't be merged until https://github.com/edx/credentials/pull/400 has been merged since create_or_update_site will not accept unknown args