### PR TITLE
clone repos before provisioning, not after

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ dev.clone: ## Clone service repos to the parent directory
 dev.provision.run: ## Provision all services with local mounted directories
 	DOCKER_COMPOSE_FILES="-f docker-compose.yml -f docker-compose-host.yml" ./provision.sh
 
-dev.provision: | check-memory dev.provision.run stop dev.clone ## Provision dev environment with all services stopped
+dev.provision: | check-memory dev.clone dev.provision.run stop ## Provision dev environment with all services stopped
 
 dev.provision.xqueue: | check-memory dev.provision.xqueue.run stop stop.xqueue
 


### PR DESCRIPTION
This time it actually clones before provisioning:

```
$ make dev.provision
./repo.sh clone
The [course-discovery] repo is already checked out. Continuing.
The [credentials] repo is already checked out. Continuing.
The [cs_comments_service] repo is already checked out. Continuing.
The [ecommerce] repo is already checked out. Continuing.
The [edx-e2e-tests] repo is already checked out. Continuing.
The [edx-notes-api] repo is already checked out. Continuing.
The [edx-platform] repo is already checked out. Continuing.
The [xqueue] repo is already checked out. Continuing.
The [edx-analytics-pipeline] repo is already checked out. Continuing.
DOCKER_COMPOSE_FILES="-f docker-compose.yml -f docker-compose-host.yml" ./provision.sh
+ RED='\033[0;31m'
+ GREEN='\033[0;32m'
+ YELLOW='\033[0;33m'
+ NC='\033[0m'
+ docker-compose up -d mysql mongo
Creating network "devstack_default" with the default driver
Creating edx.devstack.mysql ...
Creating edx.devstack.mongo ...
...
```