### PR TITLE
TE-2639 Support for named release images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,9 @@ upgrade: ## Upgrade requirements with pip-tools
 		requirements/pip-tools.txt \
 		requirements/base.txt \
 
+dev.checkout: ## Check out "openedx-release/$OPENEDX_RELEASE" in each repo if set, "master" otherwise
+	./repo.sh checkout
+
 dev.clone: ## Clone service repos to the parent directory
 	./repo.sh clone
 

--- a/README.rst
+++ b/README.rst
@@ -351,14 +351,17 @@ How do I build images?
 
 There are `Docker CI Jenkins jobs`_ on tools-edx-jenkins that build and push new
 Docker images to DockerHub on code changes to either the configuration repository or the IDA's codebase. These images
-are tagged ``latest``. Images that require tags other than ``latest`` are built and pushed by hand (see NOTES below).
+are tagged according to the branch from which they were built (see NOTES below).
 If you want to build the images on your own, the Dockerfiles are available in the ``edx/configuration`` repo.
 
 NOTES:
 
-1. edxapp and IDAs use the ``latest`` tag since their configuration changes have been merged to master branch of
-   ``edx/configuration``.
-2. The elasticsearch used in devstack is built using elasticsearch-devstack/Dockerfile and the ``devstack`` tag.
+1. edxapp and IDAs use the ``latest`` tag for configuration changes which have been merged to master branch of
+   their repository and ``edx/configuration``.
+2. Images for a named Open edX release are built from the corresponding branch
+   of each repository and tagged appropriately, for example ``hawthorn.master``
+   or ``hawthorn.rc1``.
+3. The elasticsearch used in devstack is built using elasticsearch-devstack/Dockerfile and the ``devstack`` tag.
 
 BUILD COMMANDS:
 
@@ -384,6 +387,22 @@ and not ``EDXAPP_VERSION``.
 For example, if you wanted to build tag ``release-2017-03-03`` for the
 E-Commerce Service, you would modify ``ECOMMERCE_VERSION`` in
 ``docker/build/ecommerce/ansible_overrides.yml``.
+
+How do I run the images for a named Open edX release?
+-----------------------------------------------------
+
+1. Set the ``OPENEDX_RELEASE`` environment variable to the appropriate image
+   tag; "hawthorn.master", "zebrawood.rc1", etc.  Note that unlike a server
+   install, ``OPENEDX_RELEASE`` should not have the "open-release/" prefix.
+2. Use ``make dev.checkout`` to check out the correct branch in the local
+   checkout of each service repository once you've set the ``OPENEDX_RELEASE``
+   environment variable above.
+3. ``make pull`` to get the correct images.
+
+All ``make`` target and ``docker-compose`` calls should now use the correct
+images until you change or unset ``OPENEDX_RELEASE`` again.  To work on the
+master branches and ``latest`` images, unset ``OPENEDX_RELEASE`` or set it to
+an empty string.
 
 How do I create database dumps?
 -------------------------------

--- a/docker-compose-analytics-pipeline.yml
+++ b/docker-compose-analytics-pipeline.yml
@@ -2,7 +2,7 @@ version: "2.1"
 
 services:
   namenode:
-    image: edxops/analytics_pipeline_hadoop_namenode:latest
+    image: edxops/analytics_pipeline_hadoop_namenode:${OPENEDX_RELEASE:-latest}
     container_name: edx.devstack.analytics_pipeline.namenode
     hostname: namenode
     environment:
@@ -14,7 +14,7 @@ services:
       - namenode_data:/hadoop/dfs/name
 
   datanode:
-    image: edxops/analytics_pipeline_hadoop_datanode:latest
+    image: edxops/analytics_pipeline_hadoop_datanode:${OPENEDX_RELEASE:-latest}
     container_name: edx.devstack.analytics_pipeline.datanode
     hostname: datanode
     environment:
@@ -28,7 +28,7 @@ services:
       - datanode_data:/hadoop/dfs/data
 
   resourcemanager:
-    image: edxops/analytics_pipeline_hadoop_resourcemanager:latest
+    image: edxops/analytics_pipeline_hadoop_resourcemanager:${OPENEDX_RELEASE:-latest}
     container_name: edx.devstack.analytics_pipeline.resourcemanager
     hostname: resourcemanager
     environment:
@@ -45,7 +45,7 @@ services:
     command: ["/run.sh"]
 
   nodemanager:
-    image: edxops/analytics_pipeline_hadoop_nodemanager:latest
+    image: edxops/analytics_pipeline_hadoop_nodemanager:${OPENEDX_RELEASE:-latest}
     container_name: edx.devstack.analytics_pipeline.nodemanager
     hostname: nodemanager
     environment:
@@ -66,7 +66,7 @@ services:
     command: ["/run.sh"]
 
   sparkmaster:
-    image: edxops/analytics_pipeline_spark_master:latest
+    image: edxops/analytics_pipeline_spark_master:${OPENEDX_RELEASE:-latest}
     container_name: edx.devstack.analytics_pipeline.sparkmaster
     hostname: sparkmaster
     ports:
@@ -76,7 +76,7 @@ services:
       - 127.0.0.1:18080:18080     # spark history server
 
   sparkworker:
-    image: edxops/analytics_pipeline_spark_worker:latest
+    image: edxops/analytics_pipeline_spark_worker:${OPENEDX_RELEASE:-latest}
     container_name: edx.devstack.analytics_pipeline.sparkworker
     hostname: sparkworker
     depends_on:
@@ -93,7 +93,7 @@ services:
       - vertica_data:/home/dbadmin/docker
 
   analyticspipeline:
-    image: edxops/analytics_pipeline:latest
+    image: edxops/analytics_pipeline:${OPENEDX_RELEASE:-latest}
     container_name: edx.devstack.analytics_pipeline
     hostname: analyticspipeline
     volumes:

--- a/docker-compose-marketing-site.yml
+++ b/docker-compose-marketing-site.yml
@@ -25,6 +25,6 @@ services:
       - DRUPAL_EXTRA_SETTINGS=${DRUPAL_EXTRA_SETTINGS:-/var/www/html/sites/default/docker.settings.php}
       # IP address of your machine to enable debugging (IP_ADDRESS set in .env file)
       - XDEBUG_CONFIG=remote_host=${XDEBUG_IP_ADDRESS:-127.0.0.1}
-    image: edxops/edx-mktg:latest
+    image: edxops/edx-mktg:${OPENEDX_RELEASE:-latest}
     ports:
       - "8080:80"

--- a/docker-compose-watchers.yml
+++ b/docker-compose-watchers.yml
@@ -7,7 +7,7 @@ services:
     environment:
       BOK_CHOY_HOSTNAME: edx.devstack.lms_watcher
       ASSET_WATCHER_TIMEOUT: 12
-    image: edxops/edxapp:latest
+    image: edxops/edxapp:${OPENEDX_RELEASE:-latest}
     volumes:
       - ${DEVSTACK_WORKSPACE}/edx-platform:/edx/app/edxapp/edx-platform:cached
       - edxapp_lms_assets:/edx/var/edxapp/staticfiles/
@@ -19,7 +19,7 @@ services:
     environment:
       BOK_CHOY_HOSTNAME: edx.devstack.studio_watcher
       ASSET_WATCHER_TIMEOUT: 12
-    image: edxops/edxapp:latest
+    image: edxops/edxapp:${OPENEDX_RELEASE:-latest}
     volumes:
       - edxapp_studio_assets:/edx/var/edxapp/staticfiles/
       - ${DEVSTACK_WORKSPACE}/edx-platform:/edx/app/edxapp/edx-platform:cached

--- a/docker-compose-xqueue.yml
+++ b/docker-compose-xqueue.yml
@@ -3,7 +3,7 @@ version: "2.1"
 services:
   xqueue:
     container_name: edx.devstack.xqueue
-    image: edxops/xqueue:latest
+    image: edxops/xqueue:${OPENEDX_RELEASE:-latest}
     command: bash -c 'source /edx/app/xqueue/xqueue_env && while true; do python /edx/app/xqueue/xqueue/manage.py runserver 0.0.0.0:18040 ; sleep 2; done'
     volumes:
       - ${DEVSTACK_WORKSPACE}/xqueue:/edx/app/xqueue/xqueue:cached
@@ -13,7 +13,7 @@ services:
 
   xqueue_consumer:
     container_name: edx.devstack.xqueue_consumer
-    image: edxops/xqueue:latest
+    image: edxops/xqueue:${OPENEDX_RELEASE:-latest}
     command: bash -c 'source /edx/app/xqueue/xqueue_env && while true; do python /edx/app/xqueue/xqueue/manage.py run_consumer ; sleep 2; done'
     volumes:
       - ${DEVSTACK_WORKSPACE}/xqueue:/edx/app/xqueue/xqueue:cached

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
   # Third-party services
   chrome:
     container_name: edx.devstack.chrome
-    image: edxops/chrome:latest
+    image: edxops/chrome:${OPENEDX_RELEASE:-latest}
     shm_size: 2g
     ports:
       - "15900:5900"
@@ -35,7 +35,7 @@ services:
 
   firefox:
     container_name: edx.devstack.firefox
-    image: edxops/firefox:latest
+    image: edxops/firefox:${OPENEDX_RELEASE:-latest}
     shm_size: 2g
     ports:
       - "25900:5900"
@@ -88,7 +88,7 @@ services:
       DB_HOST: edx.devstack.mysql
       SOCIAL_AUTH_EDX_OIDC_URL_ROOT: http://edx.devstack.lms:18000/oauth2
       ENABLE_DJANGO_TOOLBAR: 1
-    image: edxops/credentials:latest
+    image: edxops/credentials:${OPENEDX_RELEASE:-latest}
     ports:
       - "18150:18150"
 
@@ -105,7 +105,7 @@ services:
     environment:
       TEST_ELASTICSEARCH_URL: "http://edx.devstack.elasticsearch:9200"
       ENABLE_DJANGO_TOOLBAR: 1
-    image: edxops/discovery:latest
+    image: edxops/discovery:${OPENEDX_RELEASE:-latest}
     ports:
       - "18381:18381"
     volumes:
@@ -122,7 +122,7 @@ services:
     tty: true
     environment:
       ENABLE_DJANGO_TOOLBAR: 0
-    image: edxops/ecommerce:latest
+    image: edxops/ecommerce:${OPENEDX_RELEASE:-latest}
     ports:
       - "18130:18130"
 
@@ -143,7 +143,7 @@ services:
       BOK_CHOY_CMS_PORT: 18031
       EDXAPP_TEST_MONGO_HOST: edx.devstack.mongo
       NO_PYTHON_UNINSTALL: 1
-    image: edxops/edxapp:latest
+    image: edxops/edxapp:${OPENEDX_RELEASE:-latest}
     ports:
       - "18000:18000"
       - "19876:19876" # JS test debugging
@@ -159,7 +159,7 @@ services:
       - devpi
       - elasticsearch
       - mysql
-    image: edxops/notes:latest
+    image: edxops/notes:${OPENEDX_RELEASE:-latest}
     ports:
       - "18120:18120"
     environment:
@@ -189,7 +189,7 @@ services:
       BOK_CHOY_CMS_PORT: 18131
       EDXAPP_TEST_MONGO_HOST: edx.devstack.mongo
       NO_PYTHON_UNINSTALL: 1
-    image: edxops/edxapp:latest
+    image: edxops/edxapp:${OPENEDX_RELEASE:-latest}
     ports:
       - "18010:18010"
       - "19877:19877" # JS test debugging
@@ -205,13 +205,13 @@ services:
       - mongo
       - memcached
       - elasticsearch
-    image: edxops/forum:latest
+    image: edxops/forum:${OPENEDX_RELEASE:-latest}
     ports:
       - "44567:4567"
 
   devpi:
     container_name: edx.devstack.devpi
-    image: edxops/devpi:latest
+    image: edxops/devpi:${OPENEDX_RELEASE:-latest}
     ports:
       - "3141:3141"
     volumes:


### PR DESCRIPTION
Use [docker-compose variable substitution](https://docs.docker.com/compose/compose-file/#variable-substitution) to more easily support using devstack Docker images for named Open edX releases.

We'll want to hold off on merging this until ``edx-e2e-tests`` has been tagged for release and we have a full set of ``hawthorn.master`` images so we can test it properly.