### PR TITLE
Go to a useful directory when entering marketing shell.

### DIFF
--- a/marketing.mk
+++ b/marketing.mk
@@ -3,7 +3,7 @@ help-marketing: ## Display this help message
 	@perl -nle'print $& if m{^[\.a-zA-Z_-]+:.*?## .*$$}' $(MAKEFILE_LIST) | grep marketing | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m  %-25s\033[0m %s\n", $$1, $$2}'
 
 marketing-shell: ## Run a shell on the marketing site container
-	docker exec -it edx.devstack.marketing env TERM=$(TERM) bash
+	docker exec -it edx.devstack.marketing env TERM=$(TERM) bash -c 'cd /edx/app/edx-mktg/edx-mktg; exec /bin/bash -sh'
 
 stop-marketing:   ## Stop all services (including the marketing site) with host volumes
 	docker-compose -f docker-compose.yml -f docker-compose-host.yml -f docker-compose-marketing-site.yml -f docker-compose-marketing-site-host.yml stop


### PR DESCRIPTION
Previously, `make marketing-shell` would send you to some useless directory inside the marketing container.  Now it goes to the repo root.