### PR TITLE
Upgrade vertica container to use vertica 9.1 CE

### DIFF
--- a/docker-compose-analytics-pipeline.yml
+++ b/docker-compose-analytics-pipeline.yml
@@ -87,7 +87,8 @@ services:
       - 127.0.0.1:8081:8081       # spark worker UI
 
   vertica:
-    image: sumitchawla/vertica:latest
+    image: iamamr/vertica:9.1.0-0
+    hostname: vertica
     container_name: edx.devstack.analytics_pipeline.vertica
     volumes:
       - vertica_data:/home/dbadmin/docker


### PR DESCRIPTION
This PR upgrades vertica container ( used by analytics pipeline ) to use vertica 9.1 community edition.