### PR TITLE
Update Makefile when performing a dev.reset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ dev.provision.xqueue: | check-memory dev.provision.xqueue.run stop stop.xqueue
 dev.provision.xqueue.run:
 	DOCKER_COMPOSE_FILES="-f docker-compose.yml -f docker-compose-xqueue.yml" ./provision-xqueue.sh
 
-dev.reset: | down dev.repo.reset pull dev.up static update-db ## Attempts to reset the local devstack to a the master working state
+dev.reset: | down dev.repo.reset pull dev.provision dev.up static update-db ## Attempts to reset the local devstack to a the master working state
 
 dev.status: ## Prints the status of all git repositories
 	./repo.sh status


### PR DESCRIPTION
The current dev.reset is currently failing since the dev.up only runs `./programs/provision.sh cache`.
Since the new images have been pulled, the provisioning process should be run from scratch.
The proposal is to add a `dev.provision` between the `pull` and the `dev.up`