### PR TITLE
Add instructions on how to fix broken docker volume setup in Pycharm

### DIFF
--- a/docs/pycharm_integration.rst
+++ b/docs/pycharm_integration.rst
@@ -272,6 +272,33 @@ While working in PyCharm, you could see the following error:
 
 This issue has been fixed in PyCharm 2017.1.2.
 
+
+Cannot open the manage.py file
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The error happens when you try to run a stack (lms or studio for example)::
+
+    Attaching to edx.devstack.lms
+    edx.devstack.lms | /edx/app/edxapp/venvs/edxapp/bin/python: can't open file '/edx/app/edxapp/edx-platform/manage.py': [Errno 2] No such file or directory
+    edx.devstack.lms exited with code 2
+    Aborting on container exit...
+
+Best is to recheck all your settings in particular the Remote Interpreter's settings and make sure that you have included the docker-compose-host.yml file. Make also sure
+that you have defined the DEVSTACK_WORKSPACE environment variable correctly (i.e. to the root of your workspace where all repositories are checked out).
+
+You can check which volumes are mounted on each docker container by using the Docker Tool Window. Please note that there is an unnecessary volume creation in the process that
+maps /opt/project to the local source file folder. You can safely ignore this unless you forgot to add the  docker-compose-host.yml to the Configuration files in the setup above.
+
+For info, the Docker Tool Window (https://www.jetbrains.com/help/pycharm/using-docker-compose-as-a-remote-interpreter.html) can help to see what's happening:
+
+1. Click on the Docker/devstack instances and find your instance (for example Docker/devstack/lms/edx.devstack.lms)
+
+2. Select the Volume Bindings tab
+
+3. Make sure that the Container path and Host path are right. Normally you should have a line mapping /edx/app/edxapp/edx-platform to the related local source folder (i.e. often DEVSTACK_WORKSPACE/edx-platform).
+
+
+
 Project Interpreter has no packages
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
I followed the instruction to setup Pycharm with Docker but had a persistent issue with an error message related to not finding the manage.py.
It ended up being an issue with the way the volume was mounted by Pycharm override onto the docker image.
Not sure it is a very common issue but I wanted to share some doc on how to fix the issue.