### PR TITLE
git checkout fix when OPENEDX_RELEASE is non-zero

### DIFF
--- a/repo.sh
+++ b/repo.sh
@@ -90,7 +90,9 @@ _clone ()
                 git clone -c core.symlinks=true $repo
             fi
             if [ -n "${OPENEDX_RELEASE}" ]; then
+                cd $name
                 git checkout open-release/${OPENEDX_RELEASE}
+                cd ..
             fi
         fi
     done


### PR DESCRIPTION
Setting up devstack by defining `OPENEDX_RELEASE` as the first step:
```
$ export OPENEDX_RELEASE=hawthorn.master
```
At the cloning step `make dev.clone`, I encountered this error:
```
./repo.sh clone
Cloning into 'course-discovery'...
remote: Enumerating objects: 180, done.
remote: Counting objects: 100% (180/180), done.
remote: Compressing objects: 100% (107/107), done.
remote: Total 39875 (delta 63), reused 108 (delta 45), pack-reused 39695
Receiving objects: 100% (39875/39875), 17.31 MiB | 140.00 KiB/s, done.
Resolving deltas: 100% (28040/28040), done.
fatal: Not a git repository (or any of the parent directories): .git
Makefile:56: recipe for target 'dev.clone' failed
make: *** [dev.clone] Error **128**
```
The script `repo.sh` seems to be checking if `OPENEDX_RELEASE` is already defined and if it is (as in my case) it runs a `git checkout` command that navigates to the branch set in `OPENEDX_RELEASE`. However, the `git checkout` command fails with the message:
```
fatal: Not a git repository (or any of the parent directories): .git
```
This happens because the script doesn't go into the repo directory to run the checkout command.