### PR TITLE
Install npm packages before building static files in studio and lms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,10 +215,10 @@ xqueue_consumer-restart: ## Kill the XQueue development server. The watcher proc
 	docker exec -t edx.devstack.$* bash -c 'source /edx/app/$*/$*_env && cd /edx/app/$*/$*/ && make static'
 
 lms-static: ## Rebuild static assets for the LMS container
-	docker exec -t edx.devstack.lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && paver update_assets'
+	docker exec -t edx.devstack.lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && npm install && paver update_assets'
 
 studio-static: ## Rebuild static assets for the Studio container
-	docker exec -t edx.devstack.studio bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && paver update_assets'
+	docker exec -t edx.devstack.studio bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && npm install && paver update_assets'
 
 static: | credentials-static discovery-static ecommerce-static lms-static studio-static ## Rebuild static assets for all service containers
 


### PR DESCRIPTION
WebPack wasn't succeeding. Now it is.



### How to Reproduce?
So sorry for providing no more details, but it's really hard to reproduce errors in `devstack`. So probably the error won't be reproducible on your machine.

```
$ cd devstack
$ git checkout master
$ git pull
$ make destroy
$ make dev.reset
```

Somewhere in the lines you'll get the error below while the LMS complains about an IOError because of a missing WebPack file:

```
Copying '/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/debug_toolbar/static/debug_toolbar/js/jquery_post.js'
Copying '/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/debug_toolbar/static/debug_toolbar/js/toolbar.profiling.js'
Copying '/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/debug_toolbar/static/debug_toolbar/js/toolbar.template.js'

2801 static files copied to '/edx/var/ecommerce/staticfiles', 424 unmodified.
python manage.py compress --force
Found 'compress' tags in:
	/edx/app/ecommerce/ecommerce/ecommerce/templates/coupons/offer.html
	/edx/app/ecommerce/ecommerce/ecommerce/templates/edx/checkout/receipt_not_found.html
	/edx/app/ecommerce/ecommerce/ecommerce/templates/404.html
	/edx/app/ecommerce/ecommerce/ecommerce/templates/edx/email_confirmation_required.html
	/edx/app/ecommerce/ecommerce/ecommerce/templates/coupons/coupon_app.html
	/edx/app/ecommerce/ecommerce/ecommerce/templates/oscar/checkout/payment_error.html
	/edx/app/ecommerce/ecommerce/ecommerce/programs/templates/programs/programoffer_list.html
	/edx/app/ecommerce/ecommerce/ecommerce/templates/coupons/_offer_error.html
	/edx/app/ecommerce/ecommerce/ecommerce/templates/courses/course_app.html
	/edx/app/ecommerce/ecommerce/ecommerce/templates/500.html
	/edx/app/ecommerce/ecommerce/ecommerce/templates/edx/credit/checkout.html
	/edx/app/ecommerce/ecommerce/ecommerce/templates/oscar/dashboard/refunds/refund_detail.html
	/edx/app/ecommerce/ecommerce/ecommerce/templates/bootstrap-demo.html
	/edx/app/ecommerce/ecommerce/ecommerce/templates/edx/error.html
	/edx/app/ecommerce/ecommerce/ecommerce/enterprise/templates/enterprise/enterpriseoffer_form.html
	/edx/app/ecommerce/ecommerce/ecommerce/templates/edx/base.html
	/edx/app/ecommerce/ecommerce/ecommerce/enterprise/templates/enterprise/enterpriseoffer_list.html
	/edx/app/ecommerce/ecommerce/ecommerce/templates/oscar/dashboard/orders/order_list.html
	/edx/app/ecommerce/ecommerce/ecommerce/templates/oscar/dashboard/orders/order_detail.html
	/edx/app/ecommerce/ecommerce/ecommerce/journals/templates/journals/journalbundleoffer_form.html
	/edx/app/ecommerce/ecommerce/ecommerce/templates/oscar/checkout/cancel_checkout.html
	/edx/app/ecommerce/ecommerce/ecommerce/templates/edx/checkout/receipt.html
	/edx/app/ecommerce/ecommerce/ecommerce/templates/oscar/checkout/sdn_failure.html
	/edx/app/ecommerce/ecommerce/ecommerce/programs/templates/programs/programoffer_form.html
	/edx/app/ecommerce/ecommerce/ecommerce/journals/templates/journals/journalbundleoffer_list.html
	/edx/app/ecommerce/ecommerce/ecommerce/templates/oscar/basket/basket.html
	/edx/app/ecommerce/ecommerce/ecommerce/templates/oscar/dashboard/refunds/refund_list.html
	/edx/app/ecommerce/ecommerce/ecommerce/templates/oscar/checkout/error.html
Compressing... done
Compressed 17 block(s) from 28 template(s) for 1 context(s).
docker exec -t edx.devstack.lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && paver update_assets'
---> pavelib.assets.update_assets
---> pavelib.prereqs.install_node_prereqs
Node prereqs unchanged, skipping...
---> pavelib.assets.process_xmodule_assets
---> pavelib.prereqs.install_python_prereqs
---> pavelib.prereqs.uninstall_python_packages
NO_PYTHON_UNINSTALL is set. No attempts will be made to uninstall old Python libs.
pip install -q --disable-pip-version-check --exists-action w -r requirements/edx/development.txt
xmodule_assets common/static/xmodule
		Finished processing xmodule assets.
mkdir_p path('common/static/common/js/vendor')
mkdir_p path('common/static/common/css')
mkdir_p path('common/static/common/css/vendor')
mkdir_p path('common/static/common/media')
mkdir_p path('common/static/common/media/vendor')
Copying vendor files into static directory


Captured Task Output:
---------------------

---> pavelib.assets.update_assets
---> pavelib.prereqs.install_node_prereqs
---> pavelib.assets.process_xmodule_assets
---> pavelib.prereqs.install_python_prereqs
---> pavelib.prereqs.uninstall_python_packages
pip install -q --disable-pip-version-check --exists-action w -r requirements/edx/development.txt
xmodule_assets common/static/xmodule
mkdir_p path('common/static/common/js/vendor')
mkdir_p path('common/static/common/css')
mkdir_p path('common/static/common/css/vendor')
mkdir_p path('common/static/common/media')
mkdir_p path('common/static/common/media/vendor')
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/paver/tasks.py", line 201, in _run_task
    return do_task()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/paver/tasks.py", line 198, in do_task
    return func(**kw)
  File "pavelib/utils/timer.py", line 39, in timed
    return wrapped(*args, **kwargs)
  File "pavelib/assets.py", line 948, in update_assets
    process_npm_assets()
  File "pavelib/assets.py", line 650, in process_npm_assets
    copy_vendor_library(library)
  File "pavelib/assets.py", line 619, in copy_vendor_library
    raise Exception('Missing vendor file {library_path}'.format(library_path=library_path))
Exception: Missing vendor file node_modules/backbone.paginator/lib/backbone.paginator.js

Makefile:218: recipe for target 'lms-static' failed
make: *** [lms-static] Error 1
```