### PR TITLE
Always delete all the .pyc files when changing the code

### DIFF
--- a/repo.sh
+++ b/repo.sh
@@ -107,6 +107,7 @@ _checkout_and_update_branch ()
         git fetch origin ${OPENEDX_GIT_BRANCH}:${OPENEDX_GIT_BRANCH}
         git checkout ${OPENEDX_GIT_BRANCH}
     fi
+    find . -name '*.pyc' -not -path './.git/*' -delete 
 }
 
 clone ()


### PR DESCRIPTION
In the last week, I have stumbled over this twice (moving between master and Hawthorn).  Clean up the .pyc files automatically so you will really be running the code you just pulled.

Are there other places we should do this?