### PR TITLE
FEDX-507 Fix issue with watcher assets for LMS and Studio services.

### DIFF
--- a/docker-compose-watchers.yml
+++ b/docker-compose-watchers.yml
@@ -11,6 +11,7 @@ services:
     volumes:
       - ${DEVSTACK_WORKSPACE}/edx-platform:/edx/app/edxapp/edx-platform:cached
       - edxapp_lms_assets:/edx/var/edxapp/staticfiles/
+      - edxapp_node_modules:/edx/app/edxapp/edx-platform/node_modules
       - ${DEVSTACK_WORKSPACE}/src:/edx/src:cached
 
   studio_watcher:
@@ -23,8 +24,10 @@ services:
     volumes:
       - edxapp_studio_assets:/edx/var/edxapp/staticfiles/
       - ${DEVSTACK_WORKSPACE}/edx-platform:/edx/app/edxapp/edx-platform:cached
+      - edxapp_node_modules:/edx/app/edxapp/edx-platform/node_modules
       - ${DEVSTACK_WORKSPACE}/src:/edx/src:cached
 
 volumes:
   edxapp_lms_assets:
   edxapp_studio_assets:
+  edxapp_node_modules:


### PR DESCRIPTION
Would like to make sure that the watchers for LMS and Studio services for docker_devstack are working properly. Error was occurring since `/edx/app/edxapp/edx-platform/node_modules` volume mapping was missing.
https://openedx.atlassian.net/browse/FEDX-507?focusedCommentId=353646&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-353646