### PR TITLE
TE-2791 XQueue and snapshot fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ dev.provision.run: ## Provision all services with local mounted directories
 
 dev.provision: | check-memory dev.clone dev.provision.run stop ## Provision dev environment with all services stopped
 
-dev.provision.xqueue: | check-memory dev.provision.xqueue.run stop stop.xqueue
+dev.provision.xqueue: | check-memory dev.provision.xqueue.run stop stop.xqueue  # Provision XQueue; run after other services are provisioned
 
 dev.provision.xqueue.run:
 	DOCKER_COMPOSE_FILES="-f docker-compose.yml -f docker-compose-xqueue.yml" $(WINPTY) bash ./provision-xqueue.sh
@@ -109,7 +109,7 @@ stop.watchers: ## Stop asset watchers
 
 stop.all: | stop.analytics_pipeline stop stop.watchers ## Stop all containers, including asset watchers
 
-stop.xqueue:
+stop.xqueue: ## Stop the XQueue service container
 	docker-compose -f docker-compose-xqueue.yml stop
 
 down: ## Remove all service containers and networks
@@ -155,7 +155,7 @@ restore:  ## Restore all data volumes from the host. WARNING: THIS WILL OVERWRIT
 %-shell: ## Run a shell on the specified service container
 	docker exec -it edx.devstack.$* /bin/bash
 
-credentials-shell:
+credentials-shell: ## Run a shell on the credentials container
 	docker exec -it edx.devstack.credentials env TERM=$(TERM) bash -c 'source /edx/app/credentials/credentials_env && cd /edx/app/credentials/credentials && /bin/bash'
 
 discovery-shell: ## Run a shell on the discovery container

--- a/provision-xqueue.sh
+++ b/provision-xqueue.sh
@@ -18,6 +18,8 @@ do
 done
 
 docker exec -i edx.devstack.mysql mysql -uroot mysql < provision-xqueue.sql
+# Update dependencies
+docker-compose $DOCKER_COMPOSE_FILES exec xqueue bash -c 'source /edx/app/xqueue/xqueue_env && cd /edx/app/xqueue/xqueue && make requirements'
 # Run migrations
 docker-compose $DOCKER_COMPOSE_FILES exec xqueue bash -c 'source /edx/app/xqueue/xqueue_env && cd /edx/app/xqueue/xqueue && python manage.py migrate'
 # Add users that graders use to fetch data, there's one default user in Ansible which is part of our settings

--- a/scripts/snapshot.py
+++ b/scripts/snapshot.py
@@ -73,6 +73,7 @@ def process_compose_file(filename, output_dir):
     for service_name in services:
         service = services[service_name]
         image = service['image']
+        image = re.sub(r'\$.*', 'latest', image)
         container_name = service['container_name']
         # Don't save the same image twice, like edxapp for lms and studio
         if image not in saved_images:


### PR DESCRIPTION
* Make XQueue install development dependencies during provisioning (mainly to get `pyinotify` for more efficient file change polling)
* Added help strings to a few `make` targets so they'll actually appear in `make help`
* Fix creation of offline devstack installers to work again after a change in how the images are specified in `docker-compose.yml`