### PR TITLE
Add Registrar as an optional service

### DIFF
--- a/docker-compose-registrar-host.yml
+++ b/docker-compose-registrar-host.yml
@@ -1,0 +1,6 @@
+version: "2.1"
+
+services:
+  registrar:
+    volumes:
+      - ../registrar:/edx/app/registrar/registrar

--- a/docker-compose-registrar-sync.yml
+++ b/docker-compose-registrar-sync.yml
@@ -1,0 +1,10 @@
+version: "2.1"
+
+services:
+  marketing:
+    volumes:
+      - registrar-sync
+
+volumes:
+  registrar-sync:
+    external: true

--- a/docker-compose-registrar.yml
+++ b/docker-compose-registrar.yml
@@ -1,0 +1,25 @@
+version: "2.1"
+
+services:
+  registrar:
+    command: bash -c 'source /edx/app/registrar/registrar_env && while true; do python /edx/app/registrar/registrar/manage.py runserver 0.0.0.0:18734; sleep 2; done'
+    container_name: edx.devstack.registrar
+    hostname: registrar.devstack.edx
+    depends_on:
+      - mysql
+      - memcached
+    # Allows attachment to the registrar service using 'docker attach <containerID>'.
+    stdin_open: true
+    tty: true
+    environment:
+      DB_HOST: edx.devstack.mysql
+      DB_NAME: edxmktg
+      DB_PASSWORD: password
+      DB_USER: edxmktg001
+      LMS_HOST: http://localhost:18000
+      MEMCACHE_HOST: edx.devstack.memcached
+    image: kdmccormick96/registrar:latest
+    ports:
+      - "18734:18734"
+    volumes:
+      - /edx/var/registrar/

--- a/docker-sync-registrar.yml
+++ b/docker-sync-registrar.yml
@@ -1,0 +1,35 @@
+version: "2"
+
+options:
+  compose-file-path:
+    - 'docker-compose.yml'
+    - 'docker-compose-registrar.yml'
+  compose-dev-file-path:
+    - 'docker-compose-sync.yml'
+    - 'docker-compose-registrar-sync.yml'
+
+syncs:
+  credentials-sync:
+    host_disk_mount_mode: 'cached'
+    src: '../credentials/'
+    sync_excludes: [ '.git', '.idea', 'node_modules', 'credentials/assets', 'credentials/static/bundles', 'webpack-stats.json' ]
+
+  discovery-sync:
+    host_disk_mount_mode: 'cached'
+    src: '../course-discovery/'
+    sync_excludes: [ '.git', '.idea', 'node_modules', 'course_discovery/assets', 'course_discovery/static/bower_components', 'course_discovery/static/build' ]
+
+  ecommerce-sync:
+    host_disk_mount_mode: 'cached'
+    src: '../ecommerce/'
+    sync_excludes: [ '.git', '.idea', 'node_modules', 'assets', 'ecommerce/static/bower_components', 'ecommerce/static/build' ]
+
+  edxapp-sync:
+    host_disk_mount_mode: 'cached'
+    src: '../edx-platform/'
+    sync_excludes: [ '.git', '.idea', 'node_modules', '.prereqs_cache' ]
+
+  regsistrar-sync:
+    host_disk_mount_mode: 'cached'
+    src: '../registrar/'
+    sync_excludes: [ '.git', '.idea' Z]

--- a/provision.sql
+++ b/provision.sql
@@ -13,6 +13,9 @@ GRANT ALL ON edxmktg.* TO 'edxmktg001'@'%' IDENTIFIED BY 'password';
 CREATE DATABASE IF NOT EXISTS notes;
 GRANT ALL ON notes.* TO 'notes001'@'%' IDENTIFIED BY 'password';
 
+CREATE DATABASE IF NOT EXISTS registrar;
+GRANT ALL ON registrar.* TO 'registrar001'@'%' IDENTIFIED BY 'password';
+
 CREATE DATABASE IF NOT EXISTS edxapp;
 CREATE DATABASE IF NOT EXISTS edxapp_csmh;
 GRANT ALL ON edxapp.* TO 'edxapp001'@'%' IDENTIFIED BY 'password';

--- a/registrar.mk
+++ b/registrar.mk
@@ -1,0 +1,50 @@
+help-registrar: ## Display this help message
+	@echo "Please use \`make <target>' where <target> is one of"
+	@perl -nle'print $& if m{^[\.a-zA-Z_-]+:.*?## .*$$}' $(MAKEFILE_LIST) | grep registrar | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m  %-25s\033[0m %s\n", $$1, $$2}'
+
+registrar-clone:  ## Clone registrar repository
+	git clone https://github.com/edx/registrar
+
+registrar-pull:  ## Pulls latest version of all Docker images including Registrar
+	docker-compose -f docker-compose.yml -f docker-compose-registrar.yml pull
+
+registrar-shell: ## Run a shell on the registrar site container
+	docker exec -it edx.devstack.registrar env TERM=$(TERM) bash -c 'source /edx/app/registrar/registrar_env && cd /edx/app/registrar/registrar; /bin/bash'
+
+stop-registrar:   ## Stop all services (including the registrar site) with host volumes
+	docker-compose -f docker-compose.yml -f docker-compose-host.yml -f docker-compose-registrar.yml -f docker-compose-registrar-host.yml stop
+
+down-registrar:   ## Bring down all services (including the registrar site) with host volumes
+	docker-compose -f docker-compose.yml -f docker-compose-host.yml -f docker-compose-registrar.yml -f docker-compose-registrar-host.yml down
+
+up-registrar:   ## Bring up all services (including the registrar site) with host volumes
+	docker-compose -f docker-compose.yml -f docker-compose-host.yml -f docker-compose-registrar.yml -f docker-compose-registrar-host.yml up
+
+up-registrar-detached:   ## Bring up all services (including the registrar site) with host volumes (in detached mode)
+	docker-compose -f docker-compose.yml -f docker-compose-host.yml -f docker-compose-registrar.yml -f docker-compose-registrar-host.yml up -d
+
+up-registrar-sync:  ## Bring up all services (including the registrar site) with docker-sync
+	docker-sync-stack start -c docker-sync-registrar.yml
+
+clean-registrar-sync:   ## Remove the docker-sync containers for all services (including the registrar site)
+	docker-sync-stack clean -c docker-sync-registrar.yml
+
+registrar-setup: registrar-requirements registrar-update-db registrar-create-superuser registrar-provision-ida-user registrar-static  ## Set up Registrar development environment
+
+registrar-requirements:  ## Install requirements for registrar service
+	docker exec -it edx.devstack.registrar env TERM=$(TERM) bash -c 'cd /edx/app/registrar/registrar && make requirements && make production-requirements'
+
+registrar-update-db: ## Run migrations for Registrar database
+	docker exec -t edx.devstack.registrar bash -c 'source /edx/app/registrar/registrar_env && cd /edx/app/registrar/registrar && make migrate'
+
+registrar-provision-ida-user:  ## Provisions a service user for Registrar
+	./provision-ida-user.sh registrar registrar 18734
+
+registrar-create-superuser:  ## Create admin user with username/password of edx/edx
+	docker exec -t edx.devstack.registrar bash -c 'source /edx/app/registrar/registrar_env && cd /edx/app/registrar/registrar && make createsuperuser'
+
+registrar-static:  # Compile static assets for Registrar
+	docker exec -t edx.devstack.registrar bash -c 'source /edx/app/registrar/registrar_env && cd /edx/app/registrar/registrar && make static'
+
+registrar-logs:  ## View logs for registrar
+	docker-compose -f docker-compose.yml -f docker-compose-host.yml -f docker-compose-registrar.yml -f docker-compose-registrar-host.yml logs -f --tail=500 registrar


### PR DESCRIPTION
**Ticket:** https://openedx.atlassian.net/browse/EDUCATOR-4017
**Team:** @edx/educator-neem 

This PR adds the new [Registrar service](https://github.com/edx/registrar) to devstack. Like the Marketing Site, it has its own docker-compose files and a separate Makefile, allowing it be safely ignored by any developers to whom the service is not relevant.

~This PR depends on [this Registrar PR](https://github.com/edx/registrar/pull/9) being merged first.~ Merged.

TODO: Update [this](https://github.com/edx/devstack/pull/387/files#diff-57389a269eb6129538590d572eca5b4cR21) line when we publish `registrar` to edX's Docker registry.