### PR TITLE
Use Registrar image from edxops + additional fixes

### DIFF
--- a/docker-compose-registrar.yml
+++ b/docker-compose-registrar.yml
@@ -13,12 +13,13 @@ services:
     tty: true
     environment:
       DB_HOST: edx.devstack.mysql
-      DB_NAME: edxmktg
+      DB_NAME: registrar
+      DB_PORT: 3306
+      DB_USER: registrar001
       DB_PASSWORD: password
-      DB_USER: edxmktg001
       LMS_HOST: http://localhost:18000
       MEMCACHE_HOST: edx.devstack.memcached
-    image: kdmccormick96/registrar:latest
+    image: edxops/registrar:${OPENEDX_RELEASE:-latest}
     ports:
       - "18734:18734"
     volumes:

--- a/registrar.mk
+++ b/registrar.mk
@@ -29,10 +29,15 @@ up-registrar-sync:  ## Bring up all services (including the registrar site) with
 clean-registrar-sync:   ## Remove the docker-sync containers for all services (including the registrar site)
 	docker-sync-stack clean -c docker-sync-registrar.yml
 
-registrar-setup: registrar-requirements registrar-update-db registrar-create-superuser registrar-provision-ida-user registrar-static  ## Set up Registrar development environment
+registrar-setup: registrar-requirements registrar-create-db registrar-update-db registrar-create-superuser registrar-provision-ida-user registrar-static  ## Set up Registrar development environment
 
 registrar-requirements:  ## Install requirements for registrar service
 	docker exec -it edx.devstack.registrar env TERM=$(TERM) bash -c 'cd /edx/app/registrar/registrar && make requirements && make production-requirements'
+
+registrar-create-db:  ## Ensure that the Registrar database is created
+	docker exec -i edx.devstack.mysql mysql -uroot mysql < provision.sql
+	@# We just re-run provision.sql. This only has an effect on devstacks
+	@# that were provisioned before Registrar was introduced
 
 registrar-update-db: ## Run migrations for Registrar database
 	docker exec -t edx.devstack.registrar bash -c 'source /edx/app/registrar/registrar_env && cd /edx/app/registrar/registrar && make migrate'


### PR DESCRIPTION
In #387 I added the Registrar service to Devstack. I had it point at a Docker image in my personal registry, `kdmccormick96/registrar`. This PR updates the image to be `edxops/registrar:${OPENEDX_RELEASE:-latest}`, in correspondence with all the other Devstack services.

Additionally, I fix a couple mistakes from the original Registrar PR.

~This PR is blocked by https://github.com/edx/edx-internal/pull/738.~ Meged