### PR TITLE
Make repo.sh error if it finds a non-empty but non-git directory when…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,7 @@ a minimum of 2 CPUs and 6GB of memory works well.
 
    You may customize where the local repositories are found by setting the
    DEVSTACK\_WORKSPACE environment variable.
-   
+
    Be sure to share the cloned directories in the Docker -> Preferences... ->
    File Sharing box.
 
@@ -131,6 +131,7 @@ a minimum of 2 CPUs and 6GB of memory works well.
 
        make dev.sync.provision
 
+   This is expected to take a while, produce a lot of output from a bunch of steps, and finally end with ``Provisioning complete!``
 
 5. Start the services. This command will mount the repositories under the
    DEVSTACK\_WORKSPACE directory.
@@ -253,11 +254,11 @@ analyticstack ( e.g. lms, studio etc ) consider setting higher memory.
    .. code:: sh
 
      make analytics-pipeline-shell
-    
+
    - To see logs from containers running in detached mode, you can either use
      "Kitematic" (available from the "Docker for Mac" menu), or by running the
      following command:
-    
+
       .. code:: sh
 
         make logs
@@ -268,9 +269,9 @@ analyticstack ( e.g. lms, studio etc ) consider setting higher memory.
       .. code:: sh
 
         make namenode-logs
-    
+
    - To reset your environment and start provisioning from scratch, you can run:
-    
+
       .. code:: sh
 
         make destroy
@@ -278,9 +279,9 @@ analyticstack ( e.g. lms, studio etc ) consider setting higher memory.
      **NOTE:** Be warned! This will remove all the containers and volumes
      initiated by this repository and all the data ( in these docker containers )
      will be lost.
-    
+
    - For information on all the available ``make`` commands, you can run:
-    
+
       .. code:: sh
 
         make help
@@ -475,7 +476,7 @@ To access a MySQL or Mongo shell, run the following commands, respectively:
    mysql
 
 .. code:: sh
-    
+
    make mongo-shell
    mongo
 

--- a/repo.sh
+++ b/repo.sh
@@ -83,6 +83,10 @@ _clone ()
         # If a directory exists and it is nonempty, assume the repo has been checked out
         # and only make sure it's on the required branch
         if [ -d "$name" -a -n "$(ls -A "$name" 2>/dev/null)" ]; then
+            if [ ! -d "$name/.git" ]; then
+              printf "ERROR: [%s] exists but is not a git repo.\n" $name
+              exit 1
+            fi
             printf "The [%s] repo is already checked out. Checking for updates.\n" $name
             cd ${DEVSTACK_WORKSPACE}/${name}
             _checkout_and_update_branch
@@ -108,7 +112,7 @@ _checkout_and_update_branch ()
         git fetch origin ${OPENEDX_GIT_BRANCH}:${OPENEDX_GIT_BRANCH}
         git checkout ${OPENEDX_GIT_BRANCH}
     fi
-    find . -name '*.pyc' -not -path './.git/*' -delete 
+    find . -name '*.pyc' -not -path './.git/*' -delete
 }
 
 clone ()


### PR DESCRIPTION
… cloning

I was getting a less-obvious error when running `make dev.provision` so I didn't realize that it never got to any of the provisioning.  If there's some behavior other than throwing an error that would be preferable here, let me know.