### PR TITLE
Fix Registrar requirements recipe

### DIFF
--- a/registrar.mk
+++ b/registrar.mk
@@ -3,13 +3,13 @@ help-registrar: ## Display this help message
 	@perl -nle'print $& if m{^[\.a-zA-Z_-]+:.*?## .*$$}' $(MAKEFILE_LIST) | grep registrar | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m  %-25s\033[0m %s\n", $$1, $$2}'
 
 registrar-clone:  ## Clone registrar repository
-	git clone https://github.com/edx/registrar
+	git clone https://github.com/edx/registrar ../registrar
 
 registrar-pull:  ## Pulls latest version of all Docker images including Registrar
 	docker-compose -f docker-compose.yml -f docker-compose-registrar.yml pull
 
 registrar-shell: ## Run a shell on the registrar site container
-	docker exec -it edx.devstack.registrar env TERM=$(TERM) bash -c 'source /edx/app/registrar/registrar_env && cd /edx/app/registrar/registrar; /bin/bash'
+	docker exec -it edx.devstack.registrar env TERM=$(TERM) bash -c 'source /edx/app/registrar/registrar_env && cd /edx/app/registrar/registrar && /bin/bash'
 
 stop-registrar:   ## Stop all services (including the registrar site) with host volumes
 	docker-compose -f docker-compose.yml -f docker-compose-host.yml -f docker-compose-registrar.yml -f docker-compose-registrar-host.yml stop
@@ -32,24 +32,18 @@ clean-registrar-sync:   ## Remove the docker-sync containers for all services (i
 registrar-setup: registrar-requirements registrar-create-db registrar-update-db registrar-create-superuser registrar-provision-ida-user registrar-static  ## Set up Registrar development environment
 
 registrar-requirements:  ## Install requirements for registrar service
-	docker exec -it edx.devstack.registrar env TERM=$(TERM) bash -c 'cd /edx/app/registrar/registrar && make requirements && make production-requirements'
+	docker exec -it edx.devstack.registrar env TERM=$(TERM) bash -c 'source /edx/app/registrar/registrar_env && cd /edx/app/registrar/registrar && make requirements'
 
 registrar-create-db:  ## Ensure that the Registrar database is created
 	docker exec -i edx.devstack.mysql mysql -uroot mysql < provision.sql
 	@# We just re-run provision.sql. This only has an effect on devstacks
 	@# that were provisioned before Registrar was introduced
 
-registrar-update-db: ## Run migrations for Registrar database
-	docker exec -t edx.devstack.registrar bash -c 'source /edx/app/registrar/registrar_env && cd /edx/app/registrar/registrar && make migrate'
-
 registrar-provision-ida-user:  ## Provisions a service user for Registrar
 	./provision-ida-user.sh registrar registrar 18734
 
 registrar-create-superuser:  ## Create admin user with username/password of edx/edx
 	docker exec -t edx.devstack.registrar bash -c 'source /edx/app/registrar/registrar_env && cd /edx/app/registrar/registrar && make createsuperuser'
-
-registrar-static:  # Compile static assets for Registrar
-	docker exec -t edx.devstack.registrar bash -c 'source /edx/app/registrar/registrar_env && cd /edx/app/registrar/registrar && make static'
 
 registrar-logs:  ## View logs for registrar
 	docker-compose -f docker-compose.yml -f docker-compose-host.yml -f docker-compose-registrar.yml -f docker-compose-registrar-host.yml logs -f --tail=500 registrar


### PR DESCRIPTION
This PR fixes two issues with `make registrar-requirements`:
* The recipe was not activating registrar_env
* The recipe was also installing `production-requirements` for devstack development. With plain old `pip` this wouldn't be a problem, but `pip-sync` makes the installation profile exactly match the requirements file. So, when `production-requirements` is made, all non-production packages (e.g., `pytest`) are uninstalled.

I also piggy-backed two unrelated Registrar tweaks:
* `make registrar-clone` now clones Registrar into a sibling of the `devstack` directory instead of into a child of it.
* Removed `registrar-static` and `registrar-update-db`, which are redundant with the generic recipes in `Makefile`

@edx/masters-neem 