### PR TITLE
Match repo URLs with greedier regex

### DIFF
--- a/repo.sh
+++ b/repo.sh
@@ -41,7 +41,7 @@ private_repos=(
     "https://github.com/edx/edx-themes.git"
 )
 
-name_pattern=".*edx/(.*).git"
+name_pattern=".*/(.*).git"
 
 _checkout ()
 {


### PR DESCRIPTION
so that we can support non-edx repositories.
To build our development environment at Stanford, we use forked
repositories running custom branches.

The regular expression here is used to match the repository-name part of
a Github URL. However, it is written with the assumption that the owner
of the repository be `edx` (or any name that ends with that substring).
By making the regex greedier, we can just ignore everything through the
final slash, ignoring the owner entirely.

This allows other teams to run custom code by just forking the `repos`
list in `repo.sh`, eg:

```sh
repos=(
    "https://github.com/edx/credentials.git"
    "https://github.com/stvstnfrd/cs_comments_service.git"
    "https://github.com/Stanford-Online/edx-platform.git"
)
```