### PR TITLE
Add Jenkinsfile to build snapshot installers

### DIFF
--- a/programs/provision.sh
+++ b/programs/provision.sh
@@ -42,7 +42,7 @@ docker_exec() {
     /edx/app/$app/$repo/manage.py $cmd
     "
 
-    docker-compose exec "$service" bash -c "$CMDS"
+    docker-compose exec -T "$service" bash -c "$CMDS"
 }
 
 provision_ida() {

--- a/provision-analytics-pipeline.sh
+++ b/provision-analytics-pipeline.sh
@@ -42,11 +42,11 @@ else
   docker exec -i edx.devstack.mysql mysql -uroot mysql < provision.sql
   ./load-db.sh edxapp
   docker-compose $DOCKER_COMPOSE_FILES up -d lms studio
-  docker-compose exec lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform && NO_PYTHON_UNINSTALL=1 paver install_prereqs'
+  docker-compose exec -T lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform && NO_PYTHON_UNINSTALL=1 paver install_prereqs'
   #Installing prereqs crashes the process
   docker-compose restart lms
   # Run edxapp migrations first since they are needed for the service users and OAuth clients
-  docker-compose exec lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform && paver update_db --settings devstack_docker'
+  docker-compose exec -T lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform && paver update_db --settings devstack_docker'
 fi
 
 echo -e "${GREEN}LMS database provisioned successfully...${NC}"

--- a/provision-discovery.sh
+++ b/provision-discovery.sh
@@ -1,10 +1,10 @@
 # Provisioning script for the discovery service
 ./provision-ida.sh discovery discovery 18381
 
-docker-compose exec discovery bash -c 'rm -rf /edx/var/discovery/*'
-docker-compose exec discovery bash -c 'source /edx/app/discovery/discovery_env && python /edx/app/discovery/discovery/manage.py create_or_update_partner --site-id 1 --site-domain localhost:18381 --code edx --name edX --courses-api-url "http://edx.devstack.lms:18000/api/courses/v1/" --ecommerce-api-url "http://edx.devstack.ecommerce:18130/api/v2/" --organizations-api-url "http://edx.devstack.lms:18000/api/organizations/v0/" --oidc-url-root "http://edx.devstack.lms:18000/oauth2" --oidc-key discovery-key --oidc-secret discovery-secret'
-docker-compose exec discovery bash -c 'source /edx/app/discovery/discovery_env && python /edx/app/discovery/discovery/manage.py refresh_course_metadata'
-docker-compose exec discovery bash -c 'source /edx/app/discovery/discovery_env && python /edx/app/discovery/discovery/manage.py update_index --disable-change-limit'
+docker-compose exec -T discovery bash -c 'rm -rf /edx/var/discovery/*'
+docker-compose exec -T discovery bash -c 'source /edx/app/discovery/discovery_env && python /edx/app/discovery/discovery/manage.py create_or_update_partner --site-id 1 --site-domain localhost:18381 --code edx --name edX --courses-api-url "http://edx.devstack.lms:18000/api/courses/v1/" --ecommerce-api-url "http://edx.devstack.ecommerce:18130/api/v2/" --organizations-api-url "http://edx.devstack.lms:18000/api/organizations/v0/" --oidc-url-root "http://edx.devstack.lms:18000/oauth2" --oidc-key discovery-key --oidc-secret discovery-secret'
+docker-compose exec -T discovery bash -c 'source /edx/app/discovery/discovery_env && python /edx/app/discovery/discovery/manage.py refresh_course_metadata'
+docker-compose exec -T discovery bash -c 'source /edx/app/discovery/discovery_env && python /edx/app/discovery/discovery/manage.py update_index --disable-change-limit'
 
 # Add demo program
 ./programs/provision.sh discovery

--- a/provision-e2e.sh
+++ b/provision-e2e.sh
@@ -13,11 +13,11 @@ fi
 docker cp ${DEVSTACK_WORKSPACE}/edx-e2e-tests/upload_files/course.tar.gz edx.devstack.studio:/tmp/
 
 # Extract the test course tarball
-docker-compose exec studio bash -c 'cd /tmp && tar xzf course.tar.gz'
+docker-compose exec -T studio bash -c 'cd /tmp && tar xzf course.tar.gz'
 
 # Import the course content
-docker-compose exec studio bash -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py cms --settings=devstack_docker import /tmp course'
+docker-compose exec -T studio bash -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py cms --settings=devstack_docker import /tmp course'
 
 # Clean up the temp files
-docker-compose exec studio bash -c 'rm /tmp/course.tar.gz'
-docker-compose exec studio bash -c 'rm -r /tmp/course'
+docker-compose exec -T studio bash -c 'rm /tmp/course.tar.gz'
+docker-compose exec -T studio bash -c 'rm -r /tmp/course'

--- a/provision-forum.sh
+++ b/provision-forum.sh
@@ -3,4 +3,4 @@ set -o pipefail
 set -x
 
 docker-compose $DOCKER_COMPOSE_FILES up -d forum
-docker-compose exec forum bash -c 'source /edx/app/forum/ruby_env && cd /edx/app/forum/cs_comments_service && bundle install --deployment --path /edx/app/forum/.gem/'
+docker-compose exec -T forum bash -c 'source /edx/app/forum/ruby_env && cd /edx/app/forum/cs_comments_service && bundle install --deployment --path /edx/app/forum/.gem/'

--- a/provision-lms.sh
+++ b/provision-lms.sh
@@ -13,33 +13,33 @@ for app in "${apps[@]}"; do
     docker-compose $DOCKER_COMPOSE_FILES up -d $app
 done
 
-docker-compose exec lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform && NO_PYTHON_UNINSTALL=1 paver install_prereqs'
+docker-compose exec -T lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform && NO_PYTHON_UNINSTALL=1 paver install_prereqs'
 
 #Installing prereqs crashes the process
 docker-compose restart lms
 
 # Run edxapp migrations first since they are needed for the service users and OAuth clients
-docker-compose exec lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform && paver update_db --settings devstack_docker'
+docker-compose exec -T lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform && paver update_db --settings devstack_docker'
 
 # Create a superuser for edxapp
-docker-compose exec lms bash -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker manage_user edx edx@example.com --superuser --staff'
-docker-compose exec lms bash -c 'source /edx/app/edxapp/edxapp_env && echo "from django.contrib.auth import get_user_model; User = get_user_model(); user = User.objects.get(username=\"edx\"); user.set_password(\"edx\"); user.save()" | python /edx/app/edxapp/edx-platform/manage.py lms shell  --settings=devstack_docker'
+docker-compose exec -T lms bash -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker manage_user edx edx@example.com --superuser --staff'
+docker-compose exec -T lms bash -c 'source /edx/app/edxapp/edxapp_env && echo "from django.contrib.auth import get_user_model; User = get_user_model(); user = User.objects.get(username=\"edx\"); user.set_password(\"edx\"); user.save()" | python /edx/app/edxapp/edx-platform/manage.py lms shell  --settings=devstack_docker'
 
 # Create an enterprise service user for edxapp
-docker-compose exec lms bash -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker manage_user enterprise_worker enterprise_worker@example.com'
+docker-compose exec -T lms bash -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker manage_user enterprise_worker enterprise_worker@example.com'
 
 # Enable the LMS-E-Commerce integration
-docker-compose exec lms bash -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker configure_commerce'
+docker-compose exec -T lms bash -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker configure_commerce'
 
 # Create demo course and users
-docker-compose exec lms bash -c '/edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook /edx/app/edx_ansible/edx_ansible/playbooks/demo.yml -v -c local -i "127.0.0.1," --extra-vars="COMMON_EDXAPP_SETTINGS=devstack_docker"'
+docker-compose exec -T lms bash -c '/edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook /edx/app/edx_ansible/edx_ansible/playbooks/demo.yml -v -c local -i "127.0.0.1," --extra-vars="COMMON_EDXAPP_SETTINGS=devstack_docker"'
 
 # Fix missing vendor file by clearing the cache
-docker-compose exec lms bash -c 'rm /edx/app/edxapp/edx-platform/.prereqs_cache/Node_prereqs.sha1'
+docker-compose exec -T lms bash -c 'rm /edx/app/edxapp/edx-platform/.prereqs_cache/Node_prereqs.sha1'
 
 # Create static assets for both LMS and Studio
 for app in "${apps[@]}"; do
-    docker-compose exec $app bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform && paver update_assets --settings devstack_docker'
+    docker-compose exec -T $app bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform && paver update_assets --settings devstack_docker'
 done
 
 # Provision a retirement service account user

--- a/scripts/Jenkinsfiles/snapshot
+++ b/scripts/Jenkinsfiles/snapshot
@@ -1,0 +1,33 @@
+pipeline {
+    agent { label "codejail-worker" }
+    environment {
+        COMPOSE_HTTP_TIMEOUT = '120'
+        DOCKER_CLIENT_TIMEOUT = '120'
+        USE_TTY = 'false'
+    }
+    options {
+        timestamps()
+        timeout(120)
+    }
+    stages {
+        stage("Build installer") {
+            steps {
+                withPythonEnv('System-CPython-2.7') {
+                    dir('devstack') {
+                        sh 'make requirements'
+                        sh 'make dev.clone'
+                        sh 'make pull'
+                        sh 'make dev.provision'
+                        sh 'python scripts/snapshot.py ../devstack_snapshot'
+                    }
+                }
+                archiveArtifacts 'devstack_snapshot/**/*'
+            }
+        }
+    }
+    post {
+        always {
+            cleanWs()
+        }
+    }
+}


### PR DESCRIPTION
Add a Jenkins pipeline for building offline installers for devstack snapshots, to use at conferences and meetup events.  The generated directory hierarchy of tarballs and scripts can be downloaded in one click from the job artifacts.