### PR TITLE
Upgrade Python package dependencies

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ backports.ssl-match-hostname==3.7.0.1  # via docker, docker-compose
 bcrypt==3.1.6             # via paramiko
 cached-property==1.5.1    # via docker-compose
 certifi==2019.3.9         # via requests
-cffi==1.12.2              # via bcrypt, cryptography, pynacl
+cffi==1.12.3              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via requests
 cryptography==2.6.1       # via paramiko
 docker-compose==1.24.0
@@ -30,5 +30,5 @@ pyyaml==3.13
 requests==2.20.1          # via docker, docker-compose
 six==1.12.0               # via bcrypt, cryptography, docker, docker-compose, docker-pycreds, dockerpty, pynacl, websocket-client
 texttable==0.9.1          # via docker-compose
-urllib3==1.24.1           # via requests
+urllib3==1.24.2           # via requests
 websocket-client==0.56.0  # via docker, docker-compose

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,5 +5,5 @@
 #    make upgrade
 #
 click==7.0                # via pip-tools
-pip-tools==3.6.0
+pip-tools==3.6.1
 six==1.12.0               # via pip-tools


### PR DESCRIPTION
The automated job couldn't handle this one because `pip` 19.1 recently broke the `pip-compile` version that was in use; had to bump its version manually in `pip-tools.txt` before `make upgrade` would work again.  We'll probably see this in more `make upgrade` runs soon; the relevant error message is `AttributeError: 'PackageFinder' object has no attribute '_candidate_sort_key'`.  [Fixed](https://github.com/jazzband/pip-tools/blob/master/CHANGELOG.md#361-2019-04-24) in `pip-tools` 3.6.1.