### PR TITLE
remove sudo from linux commands in linux setup script.

### DIFF
--- a/scripts/extract_snapshot_linux.sh
+++ b/scripts/extract_snapshot_linux.sh
@@ -14,13 +14,16 @@ done
 
 # Load Docker containers and their associated volumes
 # Calls to "docker" usually require sudo privileges on Linux
-sudo python devstack/scripts/restore.py
+# add sudo here (and line 25 & 28) if needed...
+# However, best practice is to create docker group:
+# q.v. https://docs.docker.com/install/linux/linux-postinstall/
+python devstack/scripts/restore.py
 
 # For the rest, we need to be in the directory with the devstack Makefile
 cd devstack
 
 # Shut down all the running containers, the volumes were incomplete at startup
-sudo make down
+make down
 
 # Start all the containers again with correctly populated volumes.
-sudo make dev.up
+make dev.up


### PR DESCRIPTION
We have sudo prefixing commands in the linux setup script.

This commit removes the sudo, and provides link to docker post install instructions here:
https://docs.docker.com/install/linux/linux-postinstall/

I have installed docker and used the above instructions to set up a docker group, and these changes worked for me.


I wasn't sure how to open an issue, so please let me know if this should be be offered in a different format.