### PR TITLE
fix repo.sh checkout

### DIFF
--- a/repo.sh
+++ b/repo.sh
@@ -90,7 +90,9 @@ _clone ()
                 git clone $repo
             fi
             if [ -n "${OPENEDX_RELEASE}" ]; then
-                git checkout open-release/${OPENEDX_RELEASE}
+                cd $name
+                    git checkout open-release/${OPENEDX_RELEASE}
+                cd -
             fi
         fi
     done


### PR DESCRIPTION
My effort to run branch **open-release/hawthorn.master** which requires to switch to the outer folder to get  the **make dev.clone** and **make dev.checkout** a success.