### PR TITLE
Add program-manager to devstack

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -313,7 +313,21 @@ meant to be user-facing, the "homepage" may be the API root.
 +---------------------+-------------------------------------+
 | Studio/CMS          | http://localhost:18010/             |
 +---------------------+-------------------------------------+
-| Registrar           | http://localhost:18734/             |
+| Registrar           | http://localhost:18734/api-docs/    |
++---------------------+-------------------------------------+
+
+Microfrontend URLs
+------------
+
+Each microfrontend is accessible at ``localhost`` on a specific port. The table below
+provides links to each microfrontend.
+
++---------------------+-------------------------------------+
+| Service             | URL                                 |
++=====================+=====================================+
+| Gradebook           | http://localhost:1994/              |
++---------------------+-------------------------------------+
+| Program Manager     | http://localhost:1976/              |
 +---------------------+-------------------------------------+
 
 Useful Commands
@@ -345,6 +359,8 @@ In all the above commands, ``<service>`` should be replaced with one of the foll
 -  edx_notes_api
 -  studio
 -  registrar
+-  gradebook
+-  program-manager
 
 If you'd like to add some convenience make targets, you can add them to a ``local.mk`` file, ignored by git.
 

--- a/docker-compose-host.yml
+++ b/docker-compose-host.yml
@@ -33,16 +33,20 @@ services:
   forum:
     volumes:
       - ${DEVSTACK_WORKSPACE}/cs_comments_service:/edx/app/forum/cs_comments_service:cached
-  gradebook:
-    volumes:
-      - ${DEVSTACK_WORKSPACE}/gradebook:/edx/app/gradebook:cached
-      - gradebook_node_modules:/edx/app/gradebook/node_modules
   registrar:
     volumes:
       - ${DEVSTACK_WORKSPACE}/registrar:/edx/app/registrar/registrar
   registrar-worker:
     volumes:
       - ${DEVSTACK_WORKSPACE}/registrar:/edx/app/registrar/registrar
+  gradebook:
+    volumes:
+      - ${DEVSTACK_WORKSPACE}/gradebook:/edx/app/gradebook:cached
+      - gradebook_node_modules:/edx/app/gradebook/node_modules
+  program-manager:
+    volumes:
+      - ${DEVSTACK_WORKSPACE}/frontend-app-program-manager:/edx/app/program-manager:cached
+      - program_manager_node_modules:/edx/app/program-manager/node_modules
 
 volumes:
   credentials_node_modules:
@@ -50,3 +54,4 @@ volumes:
   ecommerce_node_modules:
   edxapp_node_modules:
   gradebook_node_modules:
+  program_manager_node_modules:

--- a/docker-compose-sync.yml
+++ b/docker-compose-sync.yml
@@ -22,6 +22,12 @@ services:
   registrar:
     volumes:
       - registrar-sync:/edx/app/registrar/registrar:nocopy
+  gradebook:
+    volumes:
+      - gradebook-sync:/edx/app/gradebook/gradebook:nocopy
+  program-manager:
+    volumes:
+      - program-manager-sync:/edx/app/program-manager:nocopy
 
 volumes:
   credentials-sync:
@@ -35,4 +41,8 @@ volumes:
   forum-sync:
     external: true
   registrar-sync:
+    external: true
+  gradebook-sync:
+    external: true
+  program-manager-sync:
     external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -300,15 +300,28 @@ services:
       - devpi_data:/data
 
   gradebook:
-    command: bash -c 'npm install && npm run start'
+    extends:
+      file: microfrontend.yml
+      service: microfrontend
     working_dir: '/edx/app/gradebook'
     container_name: edx.devstack.gradebook
-    image: node:10
     ports:
       - "1994:1994"
-    environment:
-      - NODE_ENV=development
-      
+    depends_on:
+      - lms
+
+  program-manager:
+    extends:
+      file: microfrontend.yml
+      service: microfrontend
+    working_dir: '/edx/app/program-manager'
+    container_name: edx.devstack.program-manager
+    ports:
+      - "1976:1976"
+    depends_on:
+      - lms
+      - registrar
+
 volumes:
   discovery_assets:
   edxapp_lms_assets:

--- a/docker-sync.yml
+++ b/docker-sync.yml
@@ -34,3 +34,13 @@ syncs:
     host_disk_mount_mode: 'cached'
     src: '../registrar/'
     sync_excludes: [ '.git', '.idea' ]
+
+  gradebook-sync:
+    host_disk_mount_mode: 'cached'
+    src: '../gradebook/'
+    sync_excludes: [ '.git', '.idea' ]
+
+  program-manager-sync:
+    host_disk_mount_mode: 'cached'
+    src: '../frontend-app-program-manager/'
+    sync_excludes: [ '.git', '.idea' ]

--- a/microfrontend.yml
+++ b/microfrontend.yml
@@ -1,0 +1,10 @@
+# This file contains configuration common too all microfrontends
+
+version: "2.1"
+
+services:
+  microfrontend:
+    command: bash -c 'npm install && npm run start'
+    image: node:10
+    environment:
+      - NODE_ENV=development

--- a/repo.sh
+++ b/repo.sh
@@ -33,8 +33,9 @@ repos=(
     "https://github.com/edx/edx-platform.git"
     "https://github.com/edx/xqueue.git"
     "https://github.com/edx/edx-analytics-pipeline.git"
-    "https://github.com/edx/gradebook.git"
     "https://github.com/edx/registrar.git"
+    "https://github.com/edx/gradebook.git"
+    "https://github.com/edx/frontend-app-program-manager.git"
 )
 
 private_repos=(


### PR DESCRIPTION
@edx/masters-neem 
[EDUCATOR-4331](https://openedx.atlassian.net/browse/EDUCATOR-4331)

This PR:
- Adds `frontend-app-program-manager` to devstack in its own container
- Does a bit of clean-up for the `gradebook` devstack installation

Both frontends' containers are build from the same image (`node:10`)

We discussed adding all microfrontends to their own docker-compose file, so that they are not started by `make dev.up`. I opted against this due to the cumbersomeness of adding `-f docker-compose-frontends.yml` to like 10 different Makefile rules. My thinking is that (1) it does not take long to start the MFE containers, and (2) one can avoid starting the MFE containers by instead running `make dev.up.<service-name>`.

If you folks disagree, however, I can definitely switch back to the separate-docker-compose-file approach.