### PR TITLE
REVMI-272 Comment out mysql port

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -598,8 +598,15 @@ How do I connect to the databases from an outside editor?
 ---------------------------------------------------------
 
 To connect to the databases from an outside editor (such as MySQLWorkbench),
-use the values below. Note that the username and password will vary depending
-on the database. For all of the options, see ``provision.sql``.
+first uncomment these lines from ``docker-compose.yml``'s ``mysql`` section:
+
+.. code-block::
+
+  ports:
+    - "3506:3306"
+
+Then connect using the values below. Note that the username and password will
+vary depending on the database. For all of the options, see ``provision.sql``.
 
 - Host: ``localhost``
 - Port: ``3506``

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,8 +74,8 @@ services:
       MYSQL_ROOT_PASSWORD: ""
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
     image: mysql:5.6
-    ports:
-      - "3506:3306"
+    # ports:
+    #   - "3506:3306"
     volumes:
       - mysql_data:/var/lib/mysql
 


### PR DESCRIPTION
Tweak to https://github.com/edx/devstack/pull/422

After merging the above PR, I happened to restart my laptop and then started seeing some odd mysql exceptions in my logs. Commenting out the port by default seems safer.