### PR TITLE
Put uploads in a volume so it stays after restart

### DIFF
--- a/docker-compose-host.yml
+++ b/docker-compose-host.yml
@@ -19,7 +19,9 @@ services:
   lms:
     volumes:
       - ${DEVSTACK_WORKSPACE}/edx-platform:/edx/app/edxapp/edx-platform:cached
+      - edxapp_media:/edx/var/edxapp/media
       - edxapp_node_modules:/edx/app/edxapp/edx-platform/node_modules
+      - edxapp_uploads:/edx/var/edxapp/uploads
       - ${DEVSTACK_WORKSPACE}/src:/edx/src:cached
   edx_notes_api:
     volumes:
@@ -28,7 +30,9 @@ services:
   studio:
     volumes:
       - ${DEVSTACK_WORKSPACE}/edx-platform:/edx/app/edxapp/edx-platform:cached
+      - edxapp_media:/edx/var/edxapp/media
       - edxapp_node_modules:/edx/app/edxapp/edx-platform/node_modules
+      - edxapp_uploads:/edx/var/edxapp/uploads
       - ${DEVSTACK_WORKSPACE}/src:/edx/src:cached
   forum:
     volumes:
@@ -52,6 +56,8 @@ volumes:
   credentials_node_modules:
   discovery_node_modules:
   ecommerce_node_modules:
+  edxapp_media:
   edxapp_node_modules:
+  edxapp_uploads:
   gradebook_node_modules:
   program_manager_node_modules:


### PR DESCRIPTION
This issue has come up often for our designer in which the upload on the LMS are lost after a container  restart.

### Steps to Reproduce

 - Go to your profile
 - Upload a profile image
 - Make sure it shows up in `$ docker exec -it edx.devstack.lms ls -v /edx/var/edxapp/{media,uploads}`
 - Take the devstack down: `$ make down`
 - Run the devstack again: `$ make dev.up`
 - Again, run `$ docker exec -it edx.devstack.lms ls -v /edx/var/edxapp/{media,uploads}`
 - Go to your profile again

### Expected
 - The image profile to stay

### Actual
 - The file gets lost after a docker restart