### PR TITLE
run jenkinsfile on devstack worker

### DIFF
--- a/scripts/Jenkinsfiles/snapshot
+++ b/scripts/Jenkinsfiles/snapshot
@@ -1,5 +1,5 @@
 pipeline {
-    agent { label "codejail-worker" }
+    agent { label "devstack-worker" }
     environment {
         COMPOSE_HTTP_TIMEOUT = '120'
         DOCKER_CLIENT_TIMEOUT = '120'


### PR DESCRIPTION
Once reseeded, Jenkins will have a new `devstack-worker` defined here: https://github.com/edx-ops/testeng-secure/pull/235