### PR TITLE
Fix gradebook repo location.

### DIFF
--- a/docker-compose-host.yml
+++ b/docker-compose-host.yml
@@ -45,7 +45,7 @@ services:
       - ${DEVSTACK_WORKSPACE}/registrar:/edx/app/registrar/registrar
   gradebook:
     volumes:
-      - ${DEVSTACK_WORKSPACE}/gradebook:/edx/app/gradebook:cached
+      - ${DEVSTACK_WORKSPACE}/frontend-app-gradebook:/edx/app/gradebook:cached
       - gradebook_node_modules:/edx/app/gradebook/node_modules
   program-manager:
     volumes:

--- a/repo.sh
+++ b/repo.sh
@@ -34,7 +34,7 @@ repos=(
     "https://github.com/edx/xqueue.git"
     "https://github.com/edx/edx-analytics-pipeline.git"
     "https://github.com/edx/registrar.git"
-    "https://github.com/edx/gradebook.git"
+    "https://github.com/edx/frontend-app-gradebook.git"
     "https://github.com/edx/frontend-app-program-manager.git"
 )
 


### PR DESCRIPTION
We broke gradebook in devstack when it the repo was renamed from `gradebook` to `frontend-app-gradebook`.  This PR fixes it.