### PR TITLE
remove unnecessary step while provisioning edx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ dev.clone: ## Clone service repos to the parent directory
 dev.provision.run: ## Provision all services with local mounted directories
 	DOCKER_COMPOSE_FILES="-f docker-compose.yml -f docker-compose-host.yml -f docker-compose-themes.yml" $(WINPTY) bash ./provision.sh
 
-dev.provision: | check-memory dev.clone dev.provision.run stop ## Provision dev environment with all services stopped
+dev.provision: | check-memory dev.provision.run stop ## Provision dev environment with all services stopped
 
 dev.provision.xqueue: | check-memory dev.provision.xqueue.run stop stop.xqueue  # Provision XQueue; run after other services are provisioned
 


### PR DESCRIPTION
[The docs](https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/installation/install_devstack.html) describe the needed steps to provision edx however step number **7** - at the moment of sending this PR - is about executing `make dev.clone` then on step number **9** is about executing `make dev.provision` which contains also `dev.clone`. It seems to be a duplicated step so I have removed it as we already explaining it in previous steps