### PR TITLE
Deprecate 'make pull', add 'make dev.pull.<service>'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
 
   - make requirements
   - make dev.clone
-  - if [[ $DEVSTACK == 'lms' ]]; then make pull; fi
+  - if [[ $DEVSTACK == 'lms' ]]; then make dev.pull; fi
   - if [[ $DEVSTACK == 'analytics_pipeline' ]]; then make dev.up.analytics_pipeline; fi
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -140,12 +140,21 @@ xqueue-logs: ## View logs from containers running in detached mode
 xqueue_consumer-logs: ## View logs from containers running in detached mode
 	docker-compose -f docker-compose-xqueue.yml logs -f xqueue_consumer
 
-pull:
-	@echo "This command is deprecated."
+RED="\033[0;31m"
+YELLOW="\033[0;33m"
+GREY="\033[1;90m"
+NO_COLOR="\033[0m"
+
+pull: dev.pull
+	@echo -n $(RED)
+	@echo "******************* PLEASE NOTE ********************************"
+	@echo -n $(YELLOW)
+	@echo "The 'make pull' command is deprecated."
 	@echo "Please use 'make dev.pull.<service>'."
 	@echo "It will pull all the images that the given serivce depends upon."
 	@echo "Example: "
 	@echo "----------------------------------"
+	@echo -n $(GREY)
 	@echo "~/devstack$$ make dev.pull.lms"
 	@echo "   Pulling chrome        ... done"
 	@echo "   Pulling firefox       ... done"
@@ -158,9 +167,13 @@ pull:
 	@echo "   Pulling devpi         ... done"
 	@echo "   Pulling lms           ... done"
 	@echo "~/devstack$$"
+	@echo -n $(YELLOW)
 	@echo "----------------------------------"
-	@echo "If you must pull all images (for example, for initial provisioning),"
-	@echo "run 'make dev.pull'."
+	@echo "If you must pull all images, such as for initial"
+	@echo "provisioning, run 'make dev.pull'."
+	@echo -n $(RED)
+	@echo "****************************************************************"
+	@echo -n $(NO_COLOR)
 
 pull.xqueue: ## Update XQueue Docker images
 	docker-compose -f docker-compose-xqueue.yml pull

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,12 @@ dev.status: ## Prints the status of all git repositories
 dev.repo.reset: ## Attempts to reset the local repo checkouts to the master working state
 	$(WINPTY) bash ./repo.sh reset
 
+dev.pull: ## Pull *all* required Docker images. Consider `make dev.pull.<service>` instead.
+	docker-compose pull
+
+dev.pull.%: ## Pull latest Docker images for a given service and all its dependencies
+	docker-compose pull --include-deps $*
+
 dev.up: | check-memory ## Bring up all services with host volumes
 	bash -c 'docker-compose -f docker-compose.yml -f docker-compose-host.yml -f docker-compose-themes.yml up -d'
 	@# Comment out this next line if you want to save some time and don't care about catalog programs
@@ -134,8 +140,27 @@ xqueue-logs: ## View logs from containers running in detached mode
 xqueue_consumer-logs: ## View logs from containers running in detached mode
 	docker-compose -f docker-compose-xqueue.yml logs -f xqueue_consumer
 
-pull: ## Update Docker images
-	docker-compose pull
+pull:
+	@echo "This command is deprecated."
+	@echo "Please use 'make dev.pull.<service>'."
+	@echo "It will pull all the images that the given serivce depends upon."
+	@echo "Example: "
+	@echo "----------------------------------"
+	@echo "~/devstack$$ make dev.pull.lms"
+	@echo "   Pulling chrome        ... done"
+	@echo "   Pulling firefox       ... done"
+	@echo "   Pulling memcached     ... done"
+	@echo "   Pulling mongo         ... done"
+	@echo "   Pulling mysql         ... done"
+	@echo "   Pulling elasticsearch ... done"
+	@echo "   Pulling discovery     ... done"
+	@echo "   Pulling forum         ... done"
+	@echo "   Pulling devpi         ... done"
+	@echo "   Pulling lms           ... done"
+	@echo "~/devstack$$"
+	@echo "----------------------------------"
+	@echo "If you must pull all images (for example, for initial provisioning),"
+	@echo "run 'make dev.pull'."
 
 pull.xqueue: ## Update XQueue Docker images
 	docker-compose -f docker-compose-xqueue.yml pull

--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ below, run the following sequence of commands if you want to use the most up-to-
 .. code:: sh
 
     make down
-    make pull
+    make dev.pull
     make dev.up
 
 This will stop any running devstack containers, pull the latest images, and then start all of the devstack containers.
@@ -106,7 +106,7 @@ a minimum of 2 CPUs and 8GB of memory does work.
 
    .. code:: sh
 
-       make pull
+       make dev.pull
 
 4. Run the provision command, if you haven't already, to configure the various
    services with superusers (for development without the auth service) and
@@ -230,7 +230,7 @@ analyticstack ( e.g. lms, studio etc ) consider setting higher memory.
 
    .. code:: sh
 
-       make pull
+       make dev.pull
        make pull.analytics_pipeline
 
 3. Run the provision command to configure the analyticstack.
@@ -343,6 +343,11 @@ Credentials, etc:
 
     make dev.up.lms
 
+Similarly, ``make dev.pull`` can take a long time, as it pulls all services' images,
+whether or not you need them.
+To instead only pull images required by your service and its dependencies,
+run ``make dev.pull.<service>``.
+
 Sometimes you may need to restart a particular application server. To do so,
 simply use the ``docker-compose restart`` command:
 
@@ -447,7 +452,7 @@ How do I run the images for a named Open edX release?
 2. Use ``make dev.checkout`` to check out the correct branch in the local
    checkout of each service repository once you've set the ``OPENEDX_RELEASE``
    environment variable above.
-3. ``make pull`` to get the correct images.
+3. ``make dev.pull`` to get the correct images.
 
 All ``make`` target and ``docker-compose`` calls should now use the correct
 images until you change or unset ``OPENEDX_RELEASE`` again.  To work on the
@@ -552,7 +557,7 @@ starts, you have a few options:
 
 * Merge your updated requirements files and wait for a new `edxops Docker image`_
   for that service to be built and uploaded to `Docker Hub`_.  You can
-  then download and use the updated image (for example, via ``make pull``).
+  then download and use the updated image (for example, via ``make dev.pull.<service>``).
   The discovery and edxapp images are built automatically via a Jenkins job. All other
   images are currently built as needed by edX employees, but will soon be built
   automatically on a regular basis. See `How do I build images?`_
@@ -629,7 +634,7 @@ database migrations and package updates.
 When switching to a branch which differs greatly from the one you've been
 working on (especially if the new branch is more recent), you may wish to
 halt the existing containers via ``make down``, pull the latest Docker
-images via ``make pull``, and then re-run ``make dev.provision`` or
+images via ``make dev.pull.<service>``, and then re-run ``make dev.provision`` or
 ``make dev.sync.provision`` in order to recreate up-to-date databases,
 static assets, etc.
 
@@ -817,7 +822,7 @@ directory:
 
 .. code:: sh
 
-   make pull
+   make dev.pull
 
 Pull the latest Docker Compose configuration and provisioning scripts by running
 the following command from the devstack directory:
@@ -926,7 +931,7 @@ No space left on device
 If you see the error ``no space left on device`` on a Mac, Docker has run
 out of space in its Docker.qcow2 file.
 
-Here is an example error while running ``make pull``:
+Here is an example error while running ``make dev.pull``:
 
 .. code:: sh
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ build_script:
 - md X:\devstack
 - "\"%ProgramFiles%/Git/bin/bash.exe\" -c \"make dev.clone\""
 # Stop here until we get provisioning to finish reliably
-#- "\"%ProgramFiles%/Git/bin/bash.exe\" -c \"make pull\""
+#- "\"%ProgramFiles%/Git/bin/bash.exe\" -c \"make dev.pull\""
 
 test_script:
 - "\"%ProgramFiles%/Git/bin/bash.exe\" -c \"make help\""

--- a/scripts/Jenkinsfiles/snapshot
+++ b/scripts/Jenkinsfiles/snapshot
@@ -16,7 +16,7 @@ pipeline {
                     dir('devstack') {
                         sh 'make requirements'
                         sh 'make dev.clone'
-                        sh 'make pull'
+                        sh 'make dev.pull'
                         sh 'make dev.provision'
                         sh 'python scripts/snapshot.py ../devstack_snapshot'
                     }


### PR DESCRIPTION
@nasthagiri 

Running `make pull` is rarely required, as it pulls __all__ images. Few devs need every single devstack Docker image, so this is a big waste of time and disk space.

This PR discourages its use by soft-deprecating it, directing devs to use `make dev.pull.<serivce>` instead, which pulls only a service and its dependencies' images. For example, `make dev.pull.lms` will pull only the images of LMS and its dependencies (`edxops/edxapp`, `mysql`, `chrome`, etc.)

It also adds `make dev.pull`, which does what `make pull` used to do.