### PR TITLE
Change notes container name to edxnotesapi.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -176,7 +176,7 @@ services:
 
   edx_notes_api:
     command: bash -c 'source /edx/app/edx_notes_api/edx_notes_api_env && while true; do python /edx/app/edx_notes_api/edx_notes_api/manage.py runserver 0.0.0.0:18120 --settings notesserver.settings.devstack; sleep 2; done'
-    container_name: edx.devstack.edx_notes_api
+    container_name: edx.devstack.edxnotesapi
     hostname: edx_notes_api.devstack.edx
     depends_on:
       - devpi

--- a/provision-ida.sh
+++ b/provision-ida.sh
@@ -1,21 +1,23 @@
+#!/bin/sh -x
 app_name=$1  # The name of the IDA application, i.e. /edx/app/<app_name>
 client_name=$2  # The name of the Oauth client stored in the edxapp DB.
 client_port=$3  # The port corresponding to this IDA service in devstack.
+container_name=${4:-$1} # (Optional) The name of the container.  If missing, will use app_name.
 
 docker-compose $DOCKER_COMPOSE_FILES up -d $app_name
 
 echo -e "${GREEN}Installing requirements for ${app_name}...${NC}"
-docker exec -t edx.devstack.${app_name}  bash -c 'source /edx/app/$1/$1_env && cd /edx/app/$1/$1/ && make requirements' -- "$app_name"
+docker exec -t edx.devstack.${container_name}  bash -c 'source /edx/app/$1/$1_env && cd /edx/app/$1/$1/ && make requirements' -- "$app_name"
 
 echo -e "${GREEN}Running migrations for ${app_name}...${NC}"
-docker exec -t edx.devstack.${app_name}  bash -c 'source /edx/app/$1/$1_env && cd /edx/app/$1/$1/ && make migrate' -- "$app_name"
+docker exec -t edx.devstack.${container_name}  bash -c 'source /edx/app/$1/$1_env && cd /edx/app/$1/$1/ && make migrate' -- "$app_name"
 
 echo -e "${GREEN}Creating super-user for ${app_name}...${NC}"
-docker exec -t edx.devstack.${app_name}  bash -c 'source /edx/app/$1/$1_env && echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser(\"edx\", \"edx@example.com\", \"edx\") if not User.objects.filter(username=\"edx\").exists() else None" | python /edx/app/$1/$1/manage.py shell' -- "$app_name"
+docker exec -t edx.devstack.${container_name}  bash -c 'source /edx/app/$1/$1_env && echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser(\"edx\", \"edx@example.com\", \"edx\") if not User.objects.filter(username=\"edx\").exists() else None" | python /edx/app/$1/$1/manage.py shell' -- "$app_name"
 
 ./provision-ida-user.sh $app_name $client_name $client_port
 
 # Compile static assets last since they are absolutely necessary for all services. This will allow developers to get
 # started if they do not care about static assets
 echo -e "${GREEN}Compiling static assets for ${app_name}...${NC}"
-docker exec -t edx.devstack.${app_name}  bash -c 'source /edx/app/$1/$1_env && cd /edx/app/$1/$1/ && make static' -- "$app_name"
+docker exec -t edx.devstack.${container_name}  bash -c 'source /edx/app/$1/$1_env && cd /edx/app/$1/$1/ && make static' -- "$app_name"

--- a/provision-notes.sh
+++ b/provision-notes.sh
@@ -1,8 +1,8 @@
 # Provisioning script for the notes service
 
 # Common provisioning tasks for IDAs, including requirements, migrations, oauth client creation, etc.
-./provision-ida.sh edx_notes_api edx-notes 18120
+./provision-ida.sh edx_notes_api edx-notes 18120 edxnotesapi
 
 # This will build the elasticsearch index for notes.
 echo -e "${GREEN}Creating indexes for edx_notes_api...${NC}"
-docker exec -t edx.devstack.edx_notes_api bash -c 'source /edx/app/$1/$1_env && cd /edx/app/$1/$1/ && python manage.py rebuild_index --noinput' -- edx_notes_api
+docker exec -t edx.devstack.edxnotesapi bash -c 'source /edx/app/$1/$1_env && cd /edx/app/$1/$1/ && python manage.py rebuild_index --noinput' -- edx_notes_api


### PR DESCRIPTION
API calls from LMS to notes were failing due to the fact that the container name is used to identify the target of the call.  The underscores in edx_notes_api caused an illegal hostname exception on the notes side, which caused the api calls to return errors.

This PR removes the underscores from the container name.  It also enhances the provision_ida.sh script to allow an optional container name parameter to be passed in, allowing the container name to be different from the app name.