### PR TITLE
Use node 12 for the program-manager devstack container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -325,6 +325,7 @@ services:
       file: microfrontend.yml
       service: microfrontend
     working_dir: '/edx/app/program-manager'
+    image: node:12
     container_name: edx.devstack.program-manager
     ports:
       - "1976:1976"


### PR DESCRIPTION
JIRA:EDUCATOR-4755

Will also require a change of travis configuration in the repo itself, i.e. https://github.com/edx/frontend-app-program-manager/pull/14

Tested over several weeks of using the service in devstack without realizing it 😛 