### PR TITLE
Parameterize provisioning script by service

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -270,6 +270,15 @@ whether or not you need them.
 To instead only pull images required by your service and its dependencies,
 run ``make dev.pull.<service>``.
 
+Finally, ``make dev.provision.<service>`` can be used in place of
+``make dev.provision`` in order to run an expedited version of
+provisioning for that singular service. For example, if you mess up just your
+Course Discovery database, running ``make dev.provision.discovery``
+will take much less time than the full provisioning process.
+However, note that some services' provisioning processes depend on other services
+already being correcty provisioned.
+So, when in doubt, it may still be best to run the full ``make dev.provision``.
+
 Sometimes you may need to restart a particular application server. To do so,
 simply use the ``docker-compose restart`` command:
 

--- a/README.rst
+++ b/README.rst
@@ -212,84 +212,6 @@ is ``edx``.
 | verified   | verified@example.com   |
 +------------+------------------------+
 
-Getting Started on Analytics
-----------------------------
-
-Analyticstack can be run by following the steps below.
-
-**NOTE:** Since a Docker-based devstack runs many containers, you should configure
-Docker with a sufficient amount of resources. We find that
-`configuring Docker for Mac`_ with a minimum of 2 CPUs and 6GB of memory works
-well for **analyticstack**. If you intend on running other docker services besides
-analyticstack ( e.g. lms, studio etc ) consider setting higher memory.
-
-1. Follow steps `1` and `2` from `Getting Started`_ section.
-
-2. Before running the provision command, make sure to pull the relevant
-   docker images from dockerhub by running the following commands:
-
-   .. code:: sh
-
-       make dev.pull
-       make pull.analytics_pipeline
-
-3. Run the provision command to configure the analyticstack.
-
-   .. code:: sh
-
-       make dev.provision.analytics_pipeline
-
-4. Start the analytics service. This command will mount the repositories under the
-   DEVSTACK\_WORKSPACE directory.
-
-   **NOTE:** it may take up to 60 seconds for Hadoop services to start.
-
-   .. code:: sh
-
-       make dev.up.analytics_pipeline
-
-5. To access the analytics pipeline shell, run the following command. All analytics
-   pipeline job/workflows should be executed after accessing the shell.
-
-   .. code:: sh
-
-     make analytics-pipeline-shell
-
-   - To see logs from containers running in detached mode, you can either use
-     "Kitematic" (available from the "Docker for Mac" menu), or by running the
-     following command:
-
-      .. code:: sh
-
-        make logs
-
-   - To view the logs of a specific service container run ``make <service>-logs``.
-     For example, to access the logs for Hadoop's namenode, you can run:
-
-      .. code:: sh
-
-        make namenode-logs
-
-   - To reset your environment and start provisioning from scratch, you can run:
-
-      .. code:: sh
-
-        make destroy
-
-     **NOTE:** Be warned! This will remove all the containers and volumes
-     initiated by this repository and all the data ( in these docker containers )
-     will be lost.
-
-   - For information on all the available ``make`` commands, you can run:
-
-      .. code:: sh
-
-        make help
-
-6. For running acceptance tests on docker analyticstack, follow the instructions in the
-   `Running analytics acceptance tests in docker`_ guide.
-7. For troubleshooting docker analyticstack, follow the instructions in the
-   `Troubleshooting docker analyticstack`_ guide.
 
 Service URLs
 ------------
@@ -1103,3 +1025,83 @@ GitHub issue which explains the `current status of implementing delegated consis
 .. _Python virtualenv: http://docs.python-guide.org/en/latest/dev/virtualenvs/#lower-level-virtualenv
 .. _Running analytics acceptance tests in docker: http://edx-analytics-pipeline-reference.readthedocs.io/en/latest/running_acceptance_tests_in_docker.html
 .. _Troubleshooting docker analyticstack: http://edx-analytics-pipeline-reference.readthedocs.io/en/latest/troubleshooting_docker_analyticstack.html
+
+
+Getting Started on Analytics
+----------------------------
+
+Analyticstack can be run by following the steps below.
+
+**NOTE:** Since a Docker-based devstack runs many containers, you should configure
+Docker with a sufficient amount of resources. We find that
+`configuring Docker for Mac`_ with a minimum of 2 CPUs and 6GB of memory works
+well for **analyticstack**. If you intend on running other docker services besides
+analyticstack ( e.g. lms, studio etc ) consider setting higher memory.
+
+1. Follow steps `1` and `2` from `Getting Started`_ section.
+
+2. Before running the provision command, make sure to pull the relevant
+   docker images from dockerhub by running the following commands:
+
+   .. code:: sh
+
+       make dev.pull
+       make pull.analytics_pipeline
+
+3. Run the provision command to configure the analyticstack.
+
+   .. code:: sh
+
+       make dev.provision.analytics_pipeline
+
+4. Start the analytics service. This command will mount the repositories under the
+   DEVSTACK\_WORKSPACE directory.
+
+   **NOTE:** it may take up to 60 seconds for Hadoop services to start.
+
+   .. code:: sh
+
+       make dev.up.analytics_pipeline
+
+5. To access the analytics pipeline shell, run the following command. All analytics
+   pipeline job/workflows should be executed after accessing the shell.
+
+   .. code:: sh
+
+     make analytics-pipeline-shell
+
+   - To see logs from containers running in detached mode, you can either use
+     "Kitematic" (available from the "Docker for Mac" menu), or by running the
+     following command:
+
+      .. code:: sh
+
+        make logs
+
+   - To view the logs of a specific service container run ``make <service>-logs``.
+     For example, to access the logs for Hadoop's namenode, you can run:
+
+      .. code:: sh
+
+        make namenode-logs
+
+   - To reset your environment and start provisioning from scratch, you can run:
+
+      .. code:: sh
+
+        make destroy
+
+     **NOTE:** Be warned! This will remove all the containers and volumes
+     initiated by this repository and all the data ( in these docker containers )
+     will be lost.
+
+   - For information on all the available ``make`` commands, you can run:
+
+      .. code:: sh
+
+        make help
+
+6. For running acceptance tests on docker analyticstack, follow the instructions in the
+   `Running analytics acceptance tests in docker`_ guide.
+7. For troubleshooting docker analyticstack, follow the instructions in the
+   `Troubleshooting docker analyticstack`_ guide.

--- a/provision.sh
+++ b/provision.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 
-# This script will provision all of the services. Each service will be setup in the following manner:
-#
+# This script will provision the service specified in the first argument,
+# or all services if 'all' is passed as the argument.
+# 
+# Service(s) will generally be setup in the following manner
+# (but refer to  individual ./provision-{service} scripts to be sure):
 # 1. Migrations run,
 # 2. Tenants—as in multi-tenancy—setup,
 # 3. Service users and OAuth clients setup in LMS,
 # 4. Static assets compiled/collected.
-
 
 set -e
 set -o pipefail
@@ -16,6 +18,30 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[0;33m'
 NC='\033[0m' # No Color
+
+if [[ $# -ne 1 ]]; then
+	echo -e "${RED}Exactly one argument required: Name of service or 'all'.\n\
+	Example 1: ./provision.sh discovery\n\
+	Example 2: ./provision.sh all${NC}"
+	exit 1
+fi
+
+service=$1
+case $service in
+	all)
+		echo -e "${GREEN}Will provision all services.${NC}"
+		;;
+	lms|ecommerce|discovery|credentials|e2e|forum|notes|registrar)
+		echo -e "${GREEN}Will provision one service: ${service}.${NC}"
+		;;
+	studio)
+		echo -e "${YELLOW}Studio is provisioned along with LMS; try running './provision.sh lms'${NC}"
+		exit 0
+		;;
+	*)
+		echo -e "${YELLOW}Service '${service}' either doesn't exist or isn't provisionable. Exiting.${NC}"
+		exit 1
+esac		
 
 # Bring the databases online.
 docker-compose up -d mysql mongo
@@ -29,36 +55,38 @@ do
 done
 
 # In the event of a fresh MySQL container, wait a few seconds for the server to restart
-# This can be removed once https://github.com/docker-library/mysql/issues/245 is resolved.
+# See https://github.com/docker-library/mysql/issues/245 for why this is necessary.
 sleep 20
-
 echo -e "MySQL ready"
 
-# Ensure the MongoDB server is online and usable
-echo "Waiting for MongoDB"
-until docker exec -i edx.devstack.mongo mongo --eval "printjson(db.serverStatus())" &> /dev/null
-do
-  printf "."
-  sleep 1
-done
-
-echo -e "MongoDB ready"
-
-echo -e "${GREEN}Creating databases and users...${NC}"
+# Ensure that the MySQL databases and users are created for all IDAs.
+# (A no-op for databases and users that already exist).
+echo -e "${GREEN}Ensuring MySQL databases and users exist...${NC}"
 docker exec -i edx.devstack.mysql mysql -uroot mysql < provision.sql
-docker exec -i edx.devstack.mongo mongo < mongo-provision.js
 
-./provision-lms.sh
+# If necessary, ensure the MongoDB server is online and usable
+# and create its users.
+case $service in
+	"lms"|"studio"|"forum"|"")
+		echo "Waiting for MongoDB"
+		until docker exec -i edx.devstack.mongo mongo --eval "printjson(db.serverStatus())" &> /dev/null
+		do
+		  printf "."
+		  sleep 1
+		done
+		echo -e "MongoDB ready"
+		echo -e "${GREEN}Creating MongoDB users...${NC}"
+		docker exec -i edx.devstack.mongo mongo < mongo-provision.js
+		;;
+	*)
+		echo -e "${GREEN}MongoDB preparation not required; skipping.${NC}"
+esac
 
-# Nothing special needed for studio
-docker-compose $DOCKER_COMPOSE_FILES up -d studio
-./provision-ecommerce.sh
-./provision-discovery.sh
-./provision-credentials.sh
-./provision-e2e.sh
-./provision-forum.sh
-./provision-notes.sh
-./provision-registrar.sh
+# Run the service-specific provisioning script(s)
+for serv in ${service:-lms ecommerce discovery credentials e2e forum notes registrar}; do
+	echo -e "${GREEN} Provisioning ${serv}...${NC}"
+	./provision-${serv}.sh
+done
 
 docker image prune -f
 


### PR DESCRIPTION
The provision script now takes a parameter: `./provision.sh lms`

This allows the creation of a new Make target: `make dev.provision.<single_service>`

Hopefully this should save time when just one of your services gets messed up, but the rest are fine :)

todo:
* local testing
* fix analytics makefile targets