### PR TITLE
Using NFS mounted volumes for MacOSX

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ you should configure Docker with a sufficient
 amount of resources. We find that `configuring Docker for Mac`_ with
 a minimum of 2 CPUs and 8GB of memory does work.
 
-1. Install the requirements inside of a `Python virtualenv`_.
+1. (Optional) Install the requirements inside of a `Python virtualenv`_.
 
    .. code:: sh
 
@@ -108,6 +108,12 @@ a minimum of 2 CPUs and 8GB of memory does work.
 
        make dev.pull
 
+3. (Optional) You have an option to use nfs on MacOS which will improve the performance significantly, to set it up ONLY ON MAC, do
+    .. code:: sh
+
+        make dev.nfs.setup
+
+
 4. Run the provision command, if you haven't already, to configure the various
    services with superusers (for development without the auth service) and
    tenants (for multi-tenancy).
@@ -131,6 +137,12 @@ a minimum of 2 CPUs and 8GB of memory does work.
 
        make dev.sync.provision
 
+    Provision using `nfs`_:
+
+   .. code:: sh
+
+       make dev.nfs.provision
+
    This is expected to take a while, produce a lot of output from a bunch of steps, and finally end with ``Provisioning complete!``
 
 5. Start the services. This command will mount the repositories under the
@@ -149,6 +161,12 @@ a minimum of 2 CPUs and 8GB of memory does work.
    .. code:: sh
 
        make dev.sync.up
+
+   Start using `nfs`_:
+
+   .. code:: sh
+
+       make dev.nfs.up
 
 
 After the services have started, if you need shell access to one of the

--- a/docker-compose-host-nfs.yml
+++ b/docker-compose-host-nfs.yml
@@ -1,0 +1,70 @@
+version: "2.1"
+
+services:
+  credentials:
+    volumes:
+      - ${DEVSTACK_WORKSPACE}/credentials:/edx/app/credentials/credentials:cached
+      - credentials_node_modules:/edx/app/credentials/credentials/node_modules
+      - src-nfs:/edx/src:cached
+  discovery:
+      volumes:
+      - ${DEVSTACK_WORKSPACE}/course-discovery:/edx/app/discovery/discovery:cached
+      - discovery_node_modules:/edx/app/discovery/discovery/node_modules
+      - src-nfs:/edx/src:cached
+  ecommerce:
+    volumes:
+      - ${DEVSTACK_WORKSPACE}/ecommerce:/edx/app/ecommerce/ecommerce:cached
+      - ecommerce_node_modules:/edx/app/ecommerce/ecommerce/node_modules
+      - src-nfs:/edx/src:cached
+  lms:
+    volumes:
+      - edx-nfs:/edx/app/edxapp/edx-platform
+      - edxapp_media:/edx/var/edxapp/media
+      - edxapp_node_modules:/edx/app/edxapp/edx-platform/node_modules
+      - edxapp_uploads:/edx/var/edxapp/uploads
+      - src-nfs:/edx/src:cached
+  edx_notes_api:
+    volumes:
+      - ${DEVSTACK_WORKSPACE}/edx-notes-api:/edx/app/edx_notes_api/edx_notes_api:cached
+      - src-nfs:/edx/src:cached
+  studio:
+    volumes:
+      - edx-nfs:/edx/app/edxapp/edx-platform
+      - edxapp_media:/edx/var/edxapp/media
+      - edxapp_node_modules:/edx/app/edxapp/edx-platform/node_modules
+      - edxapp_uploads:/edx/var/edxapp/uploads
+      - src-nfs:/edx/src:cached
+  forum:
+    volumes:
+      - ${DEVSTACK_WORKSPACE}/cs_comments_service:/edx/app/forum/cs_comments_service:cached
+  registrar:
+    volumes:
+      - ${DEVSTACK_WORKSPACE}/registrar:/edx/app/registrar/registrar
+  registrar-worker:
+    volumes:
+      - ${DEVSTACK_WORKSPACE}/registrar:/edx/app/registrar/registrar
+  gradebook:
+    volumes:
+      - ${DEVSTACK_WORKSPACE}/frontend-app-gradebook:/edx/app/gradebook:cached
+      - gradebook_node_modules:/edx/app/gradebook/node_modules
+  program-manager:
+    volumes:
+      - ${DEVSTACK_WORKSPACE}/frontend-app-program-manager:/edx/app/program-manager:cached
+      - program_manager_node_modules:/edx/app/program-manager/node_modules
+
+volumes:
+  credentials_node_modules:
+  discovery_node_modules:
+  ecommerce_node_modules:
+  edx-nfs:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
+      device: :${DEVSTACK_WORKSPACE}/edx-platform
+  src-nfs:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
+      device: :${DEVSTACK_WORKSPACE}/src

--- a/docker-compose-watchers-nfs.yml
+++ b/docker-compose-watchers-nfs.yml
@@ -1,0 +1,34 @@
+version: "2.1"
+
+services:
+  lms_watcher:
+    command: bash -c 'cd /edx/app/edxapp/edx-platform && source ../edxapp_env && while true; do paver watch_assets --w=$$ASSET_WATCHER_TIMEOUT; sleep 2; done'
+    container_name: edx.devstack.lms_watcher
+    environment:
+      BOK_CHOY_HOSTNAME: edx.devstack.lms_watcher
+      ASSET_WATCHER_TIMEOUT: 12
+    image: edxops/edxapp:${OPENEDX_RELEASE:-latest}
+    volumes:
+      - edx-nfs:/edx/app/edxapp/edx-platform
+      - edxapp_lms_assets:/edx/var/edxapp/staticfiles/
+      - edxapp_node_modules:/edx/app/edxapp/edx-platform/node_modules
+      - src-nfs:/edx/src
+      - ${DEVSTACK_WORKSPACE}/edx-themes:/edx/app/edx-themes:cached
+
+  studio_watcher:
+    command: bash -c 'cd /edx/app/edxapp/edx-platform && source ../edxapp_env && while true; do paver watch_assets --w=$$ASSET_WATCHER_TIMEOUT; sleep 2; done'
+    container_name: edx.devstack.studio_watcher
+    environment:
+      BOK_CHOY_HOSTNAME: edx.devstack.studio_watcher
+      ASSET_WATCHER_TIMEOUT: 12
+    image: edxops/edxapp:${OPENEDX_RELEASE:-latest}
+    volumes:
+      - edxapp_studio_assets:/edx/var/edxapp/staticfiles/
+      - edx-nfs:/edx/app/edxapp/edx-platform
+      - edxapp_node_modules:/edx/app/edxapp/edx-platform/node_modules
+      - src-nfs:/edx/src:cached
+      - ${DEVSTACK_WORKSPACE}/edx-themes:/edx/app/edx-themes:cached
+volumes:
+  edxapp_lms_assets:
+  edxapp_studio_assets:
+  edxapp_node_modules:

--- a/setup_native_nfs_docker_osx.sh
+++ b/setup_native_nfs_docker_osx.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Coppied from https://github.com/ajeetraina/docker101/tree/master/os/macOS/nfs
+#
+
+OS=`uname -s`
+
+if [ $OS != "Darwin" ]; then
+  echo "This script is OSX-only. Please do not run it on any other Unix."
+  exit 1
+fi
+
+if [[ $EUID -eq 0 ]]; then
+  echo "This script must NOT be run with sudo/root. Please re-run without sudo." 1>&2
+  exit 1
+fi
+
+echo ""
+echo " +-----------------------------+"
+echo " | Setup native NFS for Docker |"
+echo " +-----------------------------+"
+echo ""
+
+echo "WARNING: This script will shut down running containers, delete volumes, delete current native NFS configs on this Mac"
+echo ""
+echo -n "Do you wish to proceed? [y]: "
+read decision
+
+if [ "$decision" != "y" ]; then
+  echo "Exiting. No changes made."
+  exit 1
+fi
+
+echo ""
+
+if ! docker ps > /dev/null 2>&1 ; then
+  echo "== Waiting for docker to start..."
+fi
+
+open -a Docker
+
+while ! docker ps > /dev/null 2>&1 ; do sleep 2; done
+
+echo "== Stopping running docker containers..."
+docker-compose down > /dev/null 2>&1
+
+osascript -e 'quit app "Docker"'
+
+echo "== Resetting folder permissions..."
+U=`id -u`
+G=`id -g`
+sudo chown -R "$U":"$G" .
+
+echo "== Setting up nfs..."
+LINE="/Users -alldirs -mapall=$U:$G localhost"
+FILE=/etc/exports
+grep -xqF -- "$LINE" "$FILE" || sudo echo "$LINE" | sudo tee -a $FILE > /dev/null
+
+NFS_LINE="nfs.server.mount.require_resv_port = 0"
+NFS_FILE=/etc/nfs.conf
+grep -qF -- "$NFS_LINE" "$NFS_FILE" || sudo echo "$NFS_LINE" | sudo tee -a $NFS_FILE > /dev/null
+
+echo "== Restarting nfsd..."
+sudo nfsd restart
+
+echo "== Restarting docker..."
+open -a Docker
+
+while ! docker ps > /dev/null 2>&1 ; do sleep 2; done
+
+echo ""
+echo "SUCCESS! Now go run your containers 🐳"


### PR DESCRIPTION
To improve the performance issues found with both dev.sync.up and dev.up.

NFS is the best method we've found so far for the heavy Open edX devstack on MacOSX.


To use it, follow new README instructions on MacOS 
