### PR TITLE
Make provision.sh handle arbitrary # of arguments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,12 +30,12 @@ before_install:
 
   - make requirements
   - make dev.clone
-  - if [[ $DEVSTACK == 'lms' ]]; then make dev.pull.lms; fi
-  - if [[ $DEVSTACK == 'registrar' ]]; then make dev.pull.registrar; fi
-  - if [[ $DEVSTACK == 'ecommerce' ]]; then make dev.pull.ecommerce; fi
-  - if [[ $DEVSTACK == 'edx_notes_api' ]]; then make dev.pull.edx_notes_api; fi
-  - if [[ $DEVSTACK == 'credentials' ]]; then make dev.pull.credentials; fi
-  - if [[ $DEVSTACK == 'analytics_pipeline' ]]; then make dev.up.analytics_pipeline; fi
+  - |
+    if [[ $DEVSTACK == 'analytics_pipeline' ]]; then
+        make dev.up.analytics_pipeline
+    else
+        make dev.pull.${DEVSTACK}
+    fi
 
 script:
   - "./.travis/run.sh"

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -3,57 +3,22 @@
 set -e
 set -x
 
-if [[ $DEVSTACK == 'lms' ]]; then
-    make dev.pull.discovery
-    make dev.pull.forum
-    make dev.provision.lms
-    make dev.provision.discovery
-    make dev.provision.forum
-    make no_cache=True dev.up.lms
-    sleep 60  # LMS needs like 60 seconds to come up
-    make healthchecks.lms
-    make healthchecks.discovery
-    make healthchecks.forum
-    make validate-lms-volume
-    make up-marketing-detached
-fi
-
-if [[ $DEVSTACK == 'registrar' ]]; then
-    make dev.provision.registrar
-    make no_cache=True dev.up.registrar
-    sleep 60
-    make healthchecks.registrar
-
-fi
-
-if [[ $DEVSTACK == 'ecommerce' ]]; then
-    make dev.provision.ecommerce
-    make no_cache=True dev.up.ecommerce
-    sleep 60
-    make healthchecks.ecommerce
-
-fi
-
-if [[ $DEVSTACK == 'edx_notes_api' ]]; then
-    make dev.provision.edx_notes_api
-    make no_cache=True dev.up.edx_notes_api
-    sleep 60
-    make healthchecks.edx_notes_api
-
-fi
-
-if [[ $DEVSTACK == 'credentials' ]]; then
-    make dev.provision.credentials
-    make no_cache=True dev.up.credentials
-    sleep 60
-    make healthchecks.credentials
-
-fi
-
-
-if [[ $DEVSTACK == 'analytics_pipeline' ]]; then
+if [[ "$DEVSTACK" == "analytics_pipeline" ]]; then
     make dev.provision.analytics_pipeline
     make dev.up.analytics_pipeline
     sleep 30 # hadoop services need some time to be fully functional and out of safemode
     make analytics-pipeline-devstack-test
+elif [[ "$DEVSTACK" == "lms" ]]; then
+    make dev.pull.discovery dev.pull.forum
+    make dev.provision.services.lms+discovery+forum
+    make no_cache=True dev.up.lms
+    sleep 60  # LMS needs like 60 seconds to come up
+    make healthchecks.lms healthchecks.discovery validate-lms-volume
+    make up-marketing-detached
+else
+    service="$DEVSTACK"
+    make dev.provision.services."$service"
+    make no_cache=True dev.up."$service"
+    sleep 60
+    make healthchecks."$service"
 fi

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,13 @@
 
 .PHONY: analytics-pipeline-devstack-test analytics-pipeline-shell backup \
         build-courses check-memory create-test-course credentials-shell \
-        destroy dev.checkout dev.clone devpi-password dev.provision \
-        dev.provision.analytics_pipeline dev.provision.analytics_pipeline.run \
-        dev.provision.xqueue dev.provision.xqueue.run dev.pull dev.repo.reset \
-        dev.reset dev.status dev.sync.daemon.start dev.sync.provision \
-        dev.sync.requirements dev.sync.up dev.up dev.up.all \
+        destroy dev.checkout dev.clone dev.nfs.provision dev.nfs.setup \
+        dev.nfs.up dev.nfs.up.all dev.nfs.up.watchers devpi-password \
+        dev.provision dev.provision.analytics_pipeline \
+        dev.provision.analytics_pipeline.run dev.provision.nfs.run \
+        dev.provision.services dev.provision.xqueue dev.provision.xqueue.run \
+        dev.pull dev.repo.reset dev.reset dev.status dev.sync.daemon.start \
+        dev.sync.provision dev.sync.requirements dev.sync.up dev.up dev.up.all \
         dev.up.analytics_pipeline dev.up.watchers dev.up.xqueue \
         discovery-shell down e2e-shell e2e-tests ecommerce-shell \
         feature-toggle-state healthchecks help lms-restart lms-shell \
@@ -74,12 +76,13 @@ dev.checkout: ## Check out "openedx-release/$OPENEDX_RELEASE" in each repo if se
 dev.clone: ## Clone service repos to the parent directory
 	./repo.sh clone
 
-dev.provision.%: ## Provision specified service with local mounted directories
-	echo "CALLLING with %"
+dev.provision.services: ## Provision all services with local mounted directories
+	DOCKER_COMPOSE_FILES="$(STANDARD_COMPOSE_FILES)" $(WINPTY) bash ./provision.sh
+
+dev.provision.services.%: ## Provision specified services with local mounted directories, separated by plus signs
 	DOCKER_COMPOSE_FILES="$(STANDARD_COMPOSE_FILES)" $(WINPTY) bash ./provision.sh $*
 
-
-dev.provision: | check-memory dev.clone dev.provision.all stop ## Provision dev environment with all services stopped
+dev.provision: | check-memory dev.clone dev.provision.services stop ## Provision dev environment with all services stopped
 
 dev.provision.xqueue: | check-memory dev.provision.xqueue.run stop stop.xqueue  # Provision XQueue; run after other services are provisioned
 

--- a/README.rst
+++ b/README.rst
@@ -368,10 +368,12 @@ whether or not you need them.
 To instead only pull images required by your service and its dependencies,
 run ``make dev.pull.<service>``.
 
-Finally, ``make dev.provision.<service>`` can be used in place of
-``make dev.provision`` in order to run an expedited version of
-provisioning for that singular service. For example, if you mess up just your
-Course Discovery database, running ``make dev.provision.discovery``
+Finally, ``make dev.provision.services.<service1>+<service2>+...``
+can be used in place of ``make dev.provision`` in order to run an expedited version of
+provisioning for a specific set of services.
+For example, if you mess up just your
+Course Discovery and Registrar databases,
+running ``make dev.provision.services.discovery+registrar``
 will take much less time than the full provisioning process.
 However, note that some services' provisioning processes depend on other services
 already being correcty provisioned.
@@ -996,7 +998,7 @@ While provisioning, some have seen the following error:
    ...
    cwd = os.getcwdu()
    OSError: [Errno 2] No such file or directory
-   make: *** [dev.provision.run] Error 1
+   make: *** [dev.provision.services] Error 1
 
 This issue can be worked around, but there's no guaranteed method to do so.
 Rebooting and restarting Docker does *not* seem to correct the issue. It

--- a/provision.sh
+++ b/provision.sh
@@ -1,14 +1,30 @@
 #!/usr/bin/env bash
 
-# This script will provision the service specified in the first argument,
-# or all services if 'all' is passed as the argument.
-# 
+# This script will provision the services specified in the argument list,
+# or all services if no arguments are provided.
+#
+# Specifying invalid services will cause the script to exit early.
+# Specifying services more than once will cause them to be provisioned more
+# than once.
+#
+# To allow services to be passed in through a Makefile target,
+# services can be plus-sign-separated as well as space separated.
+#
 # Service(s) will generally be setup in the following manner
 # (but refer to  individual ./provision-{service} scripts to be sure):
 # 1. Migrations run,
 # 2. Tenants—as in multi-tenancy—setup,
 # 3. Service users and OAuth clients setup in LMS,
 # 4. Static assets compiled/collected.
+#
+# DEVSTACK DEVELOPERS -- To add a service to provisioning:
+#   * Create a provision-{service}.sh script for your new service.
+#   * Add the name of the service to ALL_SERVICES.
+#
+# Example usages:
+# ./provision.sh                          # Provision all services.
+# ./provision.sh lms ecommerce discovery  # Provision these three services.
+# ./provision.sh lms+ecommerce+discovery  # Same as previous command.
 
 set -e
 set -o pipefail
@@ -19,40 +35,81 @@ GREEN='\033[0;32m'
 YELLOW='\033[0;33m'
 NC='\033[0m' # No Color
 
-if [[ $# -ne 1 ]]; then
-	echo -e "${RED}Exactly one argument required: Name of service or 'all'.\n\
-	Example 1: ./provision.sh discovery\n\
-	Example 2: ./provision.sh all${NC}"
-	exit 1
+# All provisionable services.
+# Note: leading and trailing space are necessary for if-checks.
+ALL_SERVICES=" lms ecommerce discovery credentials e2e forum notes registrar "
+
+# What should we provision?
+if [[ $# -eq 0 ]]; then
+	requested_services=$ALL_SERVICES
+else
+	arg_string=" $@ "
+	# Replace plus signs with spaces in order to allow plus-sign-separated
+	# services in addition to space-separated services.
+	requested_services="${arg_string//+/ }"
 fi
 
-service=$1
-case $service in
-	all)
-		echo -e "${GREEN}Will provision all services.${NC}"
-		service=""
-		;;
-	lms|ecommerce|discovery|credentials|e2e|forum|registrar)
-		echo -e "${GREEN}Will provision one service: ${service}.${NC}"
-		;;
-	edx_notes_api)
-		echo -e "${GREEN}Will Provision edx_notes_api${NC}"
-		service="notes"
-		;;
-	studio)
-		echo -e "${YELLOW}Studio is provisioned along with LMS; try running './provision.sh lms'${NC}"
-		exit 0
-		;;
-	*)
-		echo -e "${YELLOW}Service '${service}' either doesn't exist or isn't provisionable. Exiting.${NC}"
+# Returns whether first arg contains second arg as substring.
+is_substring() {
+	local str="$1"
+	local substr="$2"
+	if [[ "$1" == *" ${2} "* ]]; then
+		return 0  # Note that '0' means 'success' (i.e., true) in bash.
+	else
+		return 1
+	fi
+}
+
+# Returns whether we need to boot mongo,
+# based on the space-separated list of services passed in the first argument.
+needs_mongo() {
+	local services="$1"
+	if is_substring "$services" lms || is_substring "$services" forum; then
+       	return 0
+    else
+    	return 1
+    fi
+}
+
+# Validate user input, building up list of services to provision.
+to_provision=" "
+for serv in $requested_services; do
+	case "$serv" in
+		studio)
+			echo -e "${YELLOW}Studio is provisioned alongside LMS.\nPass 'lms' as an argument to ensure that Studio is provisioned.${NC}"
+			continue
+			;;
+		edx_notes_api)
+			# Treat 'edx_notes_api' as an alias for 'notes'.
+			service="notes"
+			;;
+		*)
+			service="$serv"
+	esac
+	if is_substring "$ALL_SERVICES" "$service"; then
+		if ! is_substring "$to_provision" "$service"; then
+			to_provision="${to_provision}${service} "
+		fi
+	else
+		echo -e "${RED}Service '${service}' either doesn't exist or isn't provisionable. Exiting.${NC}"
 		exit 1
-esac		
+	fi
+done
+
+if [[ "$to_provision" = " " ]]; then
+	echo -e "${YELLOW}Nothing to provision; will exit.${NC}"
+	exit 0
+fi
+echo -e "${GREEN}Will provision the following:\n  ${to_provision}${NC}"
 
 # Bring the databases online.
-docker-compose up -d mysql mongo
+docker-compose up -d mysql
+if needs_mongo "$to_provision"; then
+	docker-compose up -d mongo
+fi
 
 # Ensure the MySQL server is online and usable
-echo "Waiting for MySQL"
+echo "${GREEN}Waiting for MySQL.${NC}"
 until docker exec -i edx.devstack.mysql mysql -uroot -se "SELECT EXISTS(SELECT 1 FROM mysql.user WHERE user = 'root')" &> /dev/null
 do
   printf "."
@@ -62,7 +119,7 @@ done
 # In the event of a fresh MySQL container, wait a few seconds for the server to restart
 # See https://github.com/docker-library/mysql/issues/245 for why this is necessary.
 sleep 20
-echo -e "MySQL ready"
+echo -e "${GREEN}MySQL ready.${NC}"
 
 # Ensure that the MySQL databases and users are created for all IDAs.
 # (A no-op for databases and users that already exist).
@@ -71,26 +128,25 @@ docker exec -i edx.devstack.mysql mysql -uroot mysql < provision.sql
 
 # If necessary, ensure the MongoDB server is online and usable
 # and create its users.
-case $service in
-	"lms"|"studio"|"forum"|"")
-		echo "Waiting for MongoDB"
-		until docker exec -i edx.devstack.mongo mongo --eval "printjson(db.serverStatus())" &> /dev/null
-		do
-		  printf "."
-		  sleep 1
-		done
-		echo -e "MongoDB ready"
-		echo -e "${GREEN}Creating MongoDB users...${NC}"
-		docker exec -i edx.devstack.mongo mongo < mongo-provision.js
-		;;
-	*)
-		echo -e "${GREEN}MongoDB preparation not required; skipping.${NC}"
-esac
+if needs_mongo "$to_provision"; then
+	echo -e "${GREEN}Waiting for MongoDB...${NC}"
+	until docker exec -i edx.devstack.mongo mongo --eval "printjson(db.serverStatus())" &> /dev/null
+	do
+	  printf "."
+	  sleep 1
+	done
+	echo -e "${GREEN}MongoDB ready.${NC}"
+	echo -e "${GREEN}Creating MongoDB users...${NC}"
+	docker exec -i edx.devstack.mongo mongo < mongo-provision.js
+else
+	echo -e "${GREEN}MongoDB preparation not required; skipping.${NC}"
+fi
 
 # Run the service-specific provisioning script(s)
-for serv in ${service:-lms ecommerce discovery credentials e2e forum notes registrar}; do
-	echo -e "${GREEN} Provisioning ${serv}...${NC}"
-	./provision-${serv}.sh
+for service in $to_provision; do
+	echo -e "${GREEN} Provisioning ${service}...${NC}"
+	./provision-${service}.sh
+	echo -e "${GREEN} Provisioned ${service}.${NC}"
 done
 
 docker image prune -f


### PR DESCRIPTION
This allows the passing of multiple arguments to `provision.sh`, and creates a Makefile rule that allows provisioning multiple services at once. For example:
```
make dev.provision.services.lms+ecommerce+forum
```

@jinder1s this is ready for review