### PR TITLE
Add new rule to clone repos using SSH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 
 .PHONY: analytics-pipeline-devstack-test analytics-pipeline-shell backup \
         build-courses check-memory create-test-course credentials-shell \
-        destroy dev.checkout dev.clone dev.nfs.provision dev.nfs.setup \
+        destroy dev.checkout dev.clone dev.clone.ssh dev.nfs.provision dev.nfs.setup \
         dev.nfs.up dev.nfs.up.all dev.nfs.up.watchers devpi-password \
         dev.provision dev.provision.analytics_pipeline \
         dev.provision.analytics_pipeline.run dev.provision.nfs.run \
@@ -73,8 +73,11 @@ upgrade: ## Upgrade requirements with pip-tools
 dev.checkout: ## Check out "openedx-release/$OPENEDX_RELEASE" in each repo if set, "master" otherwise
 	./repo.sh checkout
 
-dev.clone: ## Clone service repos to the parent directory
+dev.clone: ## Clone service repos using HTTPS method to the parent directory
 	./repo.sh clone
+
+dev.clone.ssh: ## Clone service repos using SSH method to the parent directory
+	./repo.sh clone_ssh
 
 dev.provision.services: ## Provision all services with local mounted directories
 	DOCKER_COMPOSE_FILES="$(STANDARD_COMPOSE_FILES)" $(WINPTY) bash ./provision.sh
@@ -82,7 +85,7 @@ dev.provision.services: ## Provision all services with local mounted directories
 dev.provision.services.%: ## Provision specified services with local mounted directories, separated by plus signs
 	DOCKER_COMPOSE_FILES="$(STANDARD_COMPOSE_FILES)" $(WINPTY) bash ./provision.sh $*
 
-dev.provision: | check-memory dev.clone dev.provision.services stop ## Provision dev environment with all services stopped
+dev.provision: | check-memory dev.clone.ssh dev.provision.services stop ## Provision dev environment with all services stopped
 
 dev.provision.xqueue: | check-memory dev.provision.xqueue.run stop stop.xqueue  # Provision XQueue; run after other services are provisioned
 

--- a/repo.sh
+++ b/repo.sh
@@ -23,6 +23,7 @@ else
     OPENEDX_GIT_BRANCH=master
 fi
 
+# When you add new services should add them to both repos and ssh_repos
 repos=(
     "https://github.com/edx/course-discovery.git"
     "https://github.com/edx/credentials.git"
@@ -37,6 +38,22 @@ repos=(
     "https://github.com/edx/frontend-app-gradebook.git"
     "https://github.com/edx/frontend-app-program-manager.git"
     "https://github.com/edx/frontend-app-publisher.git"
+)
+
+ssh_repos=(
+    "git@github.com:edx/course-discovery.git"
+    "git@github.com:edx/credentials.git"
+    "git@github.com:edx/cs_comments_service.git"
+    "git@github.com:edx/ecommerce.git"
+    "git@github.com:edx/edx-e2e-tests.git"
+    "git@github.com:edx/edx-notes-api.git"
+    "git@github.com:edx/edx-platform.git"
+    "git@github.com:edx/xqueue.git"
+    "git@github.com:edx/edx-analytics-pipeline.git"
+    "git@github.com:edx/registrar.git"
+    "git@github.com:edx/frontend-app-gradebook.git"
+    "git@github.com:edx/frontend-app-program-manager.git"
+    "git@github.com:edx/frontend-app-publisher.git"
 )
 
 private_repos=(
@@ -74,7 +91,7 @@ checkout ()
 
 _clone ()
 {
-    # for repo in ${repos[*]}
+
     repos_to_clone=("$@")
     for repo in "${repos_to_clone[@]}"
     do
@@ -123,6 +140,11 @@ clone ()
     _clone "${repos[@]}"
 }
 
+clone_ssh ()
+{
+    _clone "${ssh_repos[@]}"
+}
+
 clone_private ()
 {
     _clone "${private_repos[@]}"
@@ -167,6 +189,8 @@ if [ "$1" == "checkout" ]; then
     checkout
 elif [ "$1" == "clone" ]; then
     clone
+elif [ "$1" == "clone_ssh" ]; then
+    clone_ssh
 elif [ "$1" == "whitelabel" ]; then
     clone_private
 elif [ "$1" == "reset" ]; then


### PR DESCRIPTION
Issue
Need to change `.git/config.url` manually after each provision.

Description
I think it is due to 2FA that I need to change that value from HTTPS to SSH manually. 

Solution
Adding a new rule `make dev.clone.ssh` to use ssh links by default for new installations. 