### PR TITLE
Add a new Elasticsearch 5.6 container for testing upgrades.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,12 @@ services:
       - elasticsearch_data:/usr/share/elasticsearch/data
       - elasticsearch_data:/usr/share/elasticsearch/logs
 
+  # This is meant to be used to test ES upgrades so that we do not have to upgrade all of our services to ES5 at once.
+  elasticsearch-5:
+    container_name: edx.devstack.elasticsearch-5
+    hostname: elasticsearch-5.devstack.edx
+    image: elasticsearch:5.6.16
+
   firefox:
     container_name: edx.devstack.firefox
     hostname: firefox.devstack.edx


### PR DESCRIPTION
This is done as part of [ES Upgrade](https://openedx.atlassian.net/wiki/spaces/AC/pages/1073742677/Elasticsearch+Upgrade+Task+Force) work.