### PR TITLE
Add ALWAYS_CACHE_PROGRAMS configuration option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ local.mk
 
 # Data used in feature toggle reporter
 feature-toggle-data/
+
+# Local option overrides
+options.local.mk

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,6 +115,7 @@ services:
     depends_on:
       - mysql
       - memcached
+      - lms
     # Allows attachment to the credentials service using 'docker attach <containerID>'.
     stdin_open: true
     tty: true

--- a/options.mk
+++ b/options.mk
@@ -1,0 +1,31 @@
+# DEFAULT DEVSTACK OPTIONS
+# Included into Makefile and exported to command environment.
+# Defaults are listed in this file.
+# For configuring your local Devstack, create a file called
+# 'options.local.mk' and add your preferred overrides.
+
+# Folder in which we looks for repositories.
+# Defaults to parent.
+DEVSTACK_WORKSPACE ?= $(shell pwd)/..
+
+# Name of Docker Compose project.
+# See https://docs.docker.com/compose/reference/envvars/#compose_project_name
+# Defaults to 'devstack'.
+COMPOSE_PROJECT_NAME=devstack
+
+# Set of Docker Compose YAML files that we use for normal commands.
+STANDARD_COMPOSE_FILES=-f docker-compose.yml -f docker-compose-host.yml -f docker-compose-themes.yml
+
+# Set of Docker Compose YAML files that we use for NFS commands.
+NFS_COMPOSE_FILES=-f docker-compose.yml -f docker-compose-host-nfs.yml -f docker-compose-themes-nfs.yml
+
+# Whether we should always copy programs to LMS cache upon LMS startup.
+# If 'true', then run `make dev.cache-programs` whenever we bring up
+# containers.
+# Defaults to false.
+ALWAYS_CACHE_PROGRAMS=false
+
+# Load local overrides to options.
+# The dash in front of 'include' makes it so we don't
+# fail if the overrides file doesn't exist.
+-include options.local.mk

--- a/programs/README.md
+++ b/programs/README.md
@@ -20,6 +20,10 @@ If you have an existing devstack with the demo program, but want to recache the 
 
     make dev.cache-programs
 
-To launch a service and recache the programs, run instead:
+To do this while launching a service, run:
 
-    make dev.up.<service> dev.cache-programs
+    make dev.up.with-programs.<service>
+
+To make this the default behavior for `dev.up.*`, add the following to `options.local.mk`, creating the file if it does not yet exist:
+
+	ALWAYS_CACHE_PROGRAMS=true


### PR DESCRIPTION
By request, a follow-up to @regisb 's PR, which disables default program caching: https://github.com/edx/devstack/pull/491

This will allow developers to revert back to behavior where programs are copied to LMS cache upon startup by default by creating an `options.local.mk` file. This system can also be used in the future for any Devstack configuration options.