### PR TITLE
Add separate mysql57 volume.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,7 @@ services:
     # ports:
     #   - "3506:3306"
     volumes:
-      - mysql_data:/var/lib/mysql
+      - mysql57_data:/var/lib/mysql
 
   redis:
     container_name: edx.devstack.redis
@@ -385,4 +385,5 @@ volumes:
   elasticsearch_data:
   mongo_data:
   mysql_data:
+  mysql57_data:
   devpi_data:


### PR DESCRIPTION
This PR intendeds to fix the issue introduced in https://github.com/edx/devstack/pull/497 where the two mysql containers were sharing a volume which causes the 5.7 container to upgrade the backend data and breaks the 5.6 container.