### PR TITLE
Reset and clean git repository before checking out another branch

### DIFF
--- a/repo.sh
+++ b/repo.sh
@@ -140,6 +140,7 @@ _checkout_and_update_branch ()
         git pull origin ${OPENEDX_GIT_BRANCH}
     else
         git fetch origin ${OPENEDX_GIT_BRANCH}:${OPENEDX_GIT_BRANCH}
+        git reset --hard HEAD; git clean -dfx
         git checkout ${OPENEDX_GIT_BRANCH}
     fi
     find . -name '*.pyc' -not -path './.git/*' -delete
@@ -195,19 +196,23 @@ status ()
     cd - &> /dev/null
 }
 
-if [ "$1" == "checkout" ]; then
-    checkout
-elif [ "$1" == "clone" ]; then
-    clone
-elif [ "$1" == "clone_ssh" ]; then
-    clone_ssh
-elif [ "$1" == "whitelabel" ]; then
-    clone_private
-elif [ "$1" == "reset" ]; then
-    read -p "This will override any uncommited changes in your local git checkouts. Would you like to proceed? [y/n] " -r
-    if [[ $REPLY =~ ^[Yy]$ ]]; then
+if [ "$1" == "status" ]; then
+    status
+else
+    read -p "This will delete any uncommited changes in your local git repositories. Would you like to proceed? [y/n] " -r
+    if ! [[ $REPLY =~ ^[Yy]$ ]]; then
+        exit 0
+    fi
+
+    if [ "$1" == "checkout" ]; then
+        checkout
+    elif [ "$1" == "clone" ]; then
+        clone
+    elif [ "$1" == "clone_ssh" ]; then
+        clone_ssh
+    elif [ "$1" == "whitelabel" ]; then
+        clone_private
+    elif [ "$1" == "reset" ]; then
         reset
     fi
-elif [ "$1" == "status" ]; then
-    status
 fi


### PR DESCRIPTION
If an Open edX git repository already exists in your workstation, "sudo make dev.provision"
automatically downloads any new changes (git fetch) and changes the local branch to the
target one if needed (git checkout). However, a simple "git checkout" may fail if there
are files in the current branch which will conflict with the target branch. An even worse
problem is that some untracked files (eg migrations) may not conflict with the target
branch, but they may make the devstack creation fail. The solution is to delete all
uncommitted and untracked files in the git repo directory and this is implemented in
this patch using "git reset" and "git clean", respectively.