### PR TITLE
CRI-171 Adds forum environment variable MONGOID_AUTH_MECH

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -211,6 +211,8 @@ services:
     image: edxops/forum:${OPENEDX_RELEASE:-latest}
     ports:
       - "44567:4567"
+    environment:
+      MONGOID_AUTH_MECH: ":scram"
 
   lms:
     command: bash -c 'source /edx/app/edxapp/edxapp_env && while true; do python /edx/app/edxapp/edx-platform/manage.py lms runserver 0.0.0.0:18000 --settings devstack_docker; sleep 2; done'


### PR DESCRIPTION
Will be set in `devstack_forum_env` by https://github.com/edx/configuration/pull/5755, but required here so that people don't have to fully rebuild their devstacks when https://github.com/edx/cs_comments_service/pull/316 merges.

**JIRA tickets**: [CRI-186](https://openedx.atlassian.net/browse/CRI-186), [OSPR-4410](https://openedx.atlassian.net/browse/OSPR-4410), [SE-2321](https://tasks.opencraft.com/browse/SE-2321)

**Discussions**: [Discussion forum errors in latest master with mongo 3.2](https://discuss.openedx.org/t/discussion-forum-errors-in-latest-master-with-mongo-3-2/1843/5)

**Dependencies**: Relates to https://github.com/edx/configuration/pull/5755, https://github.com/edx/cs_comments_service/pull/316

**Sandbox URL**: See https://github.com/edx/cs_comments_service/pull/316

**Merge deadline**: ASAP, fix needed for Juniper.

**Testing instructions**:

See https://github.com/edx/cs_comments_service/pull/316

**Reviewers**
- [ ] @toxinu
- [ ] edX reviewer[s] TBD

FYI @bderusha 