### PR TITLE
Fix enterprise worker permissions provisioning

### DIFF
--- a/enterprise/provision.sh
+++ b/enterprise/provision.sh
@@ -1,2 +1,2 @@
 docker-compose exec -T lms bash -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker manage_user enterprise_worker enterprise_worker@example.com --staff'
-cat $DEVSTACK_WORKSPACE/devstack/enterprise/worker_permissions.py | docker-compose exec -T lms bash -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms shell  --settings=devstack_docker'
+cat enterprise/worker_permissions.py | docker-compose exec -T lms bash -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms shell  --settings=devstack_docker'


### PR DESCRIPTION
Fixes the `cat: /tmp/devstack/enterprise/worker_permissions.py: No such file or directory` occasionally seen in automated builds.