### PR TITLE
Make Registrar a not-by-default service

### DIFF
--- a/options.mk
+++ b/options.mk
@@ -31,4 +31,4 @@ FS_SYNC_STRATEGY ?= local-mounts
 # TODO: Re-evaluate this list and consider paring it down to a tighter core.
 #       The current value was chosen such that it would not change the existing
 #       Devstack behavior.
-DEFAULT_SERVICES ?= lms+studio+ecommerce+discovery+credentials+forum+edx_notes_api+registrar
+DEFAULT_SERVICES ?= lms+studio+ecommerce+discovery+credentials+forum+edx_notes_api

--- a/repo.sh
+++ b/repo.sh
@@ -34,9 +34,7 @@ repos=(
     "https://github.com/edx/edx-platform.git"
     "https://github.com/edx/xqueue.git"
     "https://github.com/edx/edx-analytics-pipeline.git"
-    "https://github.com/edx/registrar.git"
     "https://github.com/edx/frontend-app-gradebook.git"
-    "https://github.com/edx/frontend-app-program-console.git"
     "https://github.com/edx/frontend-app-publisher.git"
 )
 
@@ -50,9 +48,7 @@ ssh_repos=(
     "git@github.com:edx/edx-platform.git"
     "git@github.com:edx/xqueue.git"
     "git@github.com:edx/edx-analytics-pipeline.git"
-    "git@github.com:edx/registrar.git"
     "git@github.com:edx/frontend-app-gradebook.git"
-    "git@github.com:edx/frontend-app-program-console.git"
     "git@github.com:edx/frontend-app-publisher.git"
 )
 


### PR DESCRIPTION
```
Registrar is not part of the current Open edX release.
Specifically, it does not have a `juniper.rc1` branch.
Thus, it cannot be part of the default Open edX devstack.
```
https://openedx.atlassian.net/browse/CRI-193
@edx/masters-devs 

The impact of this to Master's devs is that new devs would need to specifically check out Registrar and Program Manager, as well as adding the following to `options.local.mk`:
```Makefile
DEFAULT_SERVICES = $(DEFAULT_SERVICES)+registrar
```
If we merge this, I can add those instructions to our wiki or the Registrar README.
