### PR TITLE
Don't fail when MFEs are passed to provisioning script

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -3,7 +3,7 @@
 # This script will provision the services specified in the argument list,
 # or all services if no arguments are provided.
 #
-# Specifying invalid services will cause the script to exit early.
+# Non-existant services will be ignored.
 # Specifying services more than once will cause them to be provisioned more
 # than once.
 #
@@ -104,8 +104,7 @@ for serv in $requested_services; do
 			to_provision="${to_provision}${service} "
 		fi
 	else
-		echo -e "${RED}Service '${service}' either doesn't exist or isn't provisionable. Exiting.${NC}"
-		exit 1
+		echo -e "${YELLOW}Service '${service}' either doesn't exist or isn't provisionable.${NC}"
 	fi
 done
 


### PR DESCRIPTION
PR #528 includes MFEs in the list of `DEFAULT_SERVICES`.

However, that will cause `make dev.provision` to fail, because `gradebook`, `program-console`, and `frontend-app-publisher` are not provisionable. The user would see:
```
Service 'gradebook' either doesn't exist or isn't provisionable. Exiting.
```

CI did not catch this, because it provisions specific services, instead of all default services.

This PR prevents those MFE service names from breaking the provisioning script.