### PR TITLE
Increase timeout for provision step.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,6 @@ before_install:
 
 script:
   - set -e  # If one of these commands fails, exit immediately.
-  - make dev.provision.services."$SERVICES"
+  - travis_wait 30 make dev.provision.services."$SERVICES"
   - make dev.up."$SERVICES"
   - make dev.check."$SERVICES"


### PR DESCRIPTION
The provision step might not have output for a while because ansible is quiet
while running a task and some tasks take over 10 mins.

https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received