### PR TITLE
Add back loading of local.mk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,9 @@ include options.mk
 # You can use this file to configure your Devstack. It is ignored by git.
 -include options.local.mk  # Prefix with hyphen to tolerate absence of file.
 
+# Include local makefile with additional targets.
+-include local.mk  # Prefix with hyphen to tolerate absence of file.
+
 # Docker Compose YAML files to define services and their volumes.
 # Depending on the value of FS_SYNC_STRATEGY, we use a slightly different set of
 # files, enabling use of different strategies to synchronize files between the host and


### PR DESCRIPTION
A previous PR accidentally disabled loading of the local.mk file by removing [this line|https://github.com/edx/devstack/pull/493/files#diff-b67911656ef5d18c4ae36cb6741b7965L57]. This PR adds back that feature. 

(I'm assuming this change was accidental.)