### PR TITLE
Only update database if service is "installed"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -307,7 +307,7 @@ studio-update-db: ## Run migrations for the Studio container
 lms-update-db: ## Run migrations LMS container
 	docker exec -t edx.devstack.lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && paver update_db'
 
-update-db: | studio-update-db lms-update-db discovery-update-db ecommerce-update-db credentials-update-db ## Run the migrations for all services
+update-db: | $(DB_MIGRATION_TARGETS) ## Run the migrations for DEFAULT_SERVICES
 
 forum-restart-devserver: ## Kill the forum's Sinatra development server. The watcher process will restart it.
 	docker exec -t edx.devstack.forum bash -c 'kill $$(ps aux | grep "ruby app.rb" | egrep -v "while|grep" | awk "{print \$$2}")'

--- a/options.mk
+++ b/options.mk
@@ -35,3 +35,16 @@ FS_SYNC_STRATEGY ?= local-mounts
 #       The current value was chosen such that it would not change the existing
 #       Devstack behavior.
 DEFAULT_SERVICES ?= lms+studio+ecommerce+discovery+credentials+forum+edx_notes_api+registrar+gradebook+program-console+frontend-app-publisher
+
+# List of all services with database migrations.
+# Services must provide a Makefile target named: $(service)-update-db
+# Note: This list should contain _all_ db-backed services, even if not
+# configured to run; the list will be filtered later against $(DEFAULT_SERVICES)
+DB_SERVICES ?= credentials discovery ecommerce lms registrar studio
+
+# List of Makefile targets to run database migrations, in the form $(service)-update-db
+# Services will only have their migrations added here
+# if the service is present in both $(DEFAULT_SERVICES) and $(DB_SERVICES).
+DB_MIGRATION_TARGETS = $(foreach db_service,$(DB_SERVICES),\
+	$(if $(filter $(db_service),$(subst +, ,$(DEFAULT_SERVICES))),\
+		$(db_service)-update-db))


### PR DESCRIPTION
by virtue of being set inside `DEFAULT_SERVICES`.

This is needed to prevent errors when running with a custom
`options.local.mk`, specifically where a service is _omitted_ from
`DEFAULT_SERVICES`, but `make update-db` attempts to run the migrations
in a stopped container.

eg: set `DEFAULT_SERVICES=lms+studio+discovery+credentials+forum` and
see `make update-db` (without this patch) break trying to migrate ecommerce.

Now, we maintain a list of updatable database services and only migrate
them if the service is also present in `DEFAULT_SERVICES`.