### PR TITLE
Revert "Increase timeout for provision step."

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,6 @@ before_install:
 
 script:
   - set -e  # If one of these commands fails, exit immediately.
-  - travis_wait 30 make dev.provision.services."$SERVICES"
+  - make dev.provision.services."$SERVICES"
   - make dev.up."$SERVICES"
   - make dev.check."$SERVICES"


### PR DESCRIPTION
Reverts edx/devstack#531

Reverting to see if this is what's causing the analytics api failure.