### PR TITLE
add config for sharing src folder in sync containers

### DIFF
--- a/docker-compose-sync.yml
+++ b/docker-compose-sync.yml
@@ -4,30 +4,39 @@ services:
   credentials:
     volumes:
       - credentials-sync:/edx/app/credentials/credentials:nocopy
+      - source-sync:/edx/src:nocopy
   discovery:
     volumes:
       - discovery-sync:/edx/app/discovery/discovery:nocopy
+      - source-sync:/edx/src:nocopy
   ecommerce:
     volumes:
       - ecommerce-sync:/edx/app/ecommerce/ecommerce:nocopy
+      - source-sync:/edx/src:nocopy
   lms:
     volumes:
       - edxapp-sync:/edx/app/edxapp/edx-platform:nocopy
+      - source-sync:/edx/src:nocopy
   studio:
     volumes:
       - edxapp-sync:/edx/app/edxapp/edx-platform:nocopy
+      - source-sync:/edx/src:nocopy
   forum:
     volumes:
       - forum-sync:/edx/app/forum/cs_comments_service:nocopy
+      - source-sync:/edx/src:nocopy
   registrar:
     volumes:
       - registrar-sync:/edx/app/registrar/registrar:nocopy
+      - source-sync:/edx/src:nocopy
   gradebook:
     volumes:
       - gradebook-sync:/edx/app/gradebook/gradebook:nocopy
+      - source-sync:/edx/src:nocopy
   program-console:
     volumes:
       - program-console-sync:/edx/app/program-console:nocopy
+      - source-sync:/edx/src:nocopy
 
 volumes:
   credentials-sync:
@@ -46,3 +55,5 @@ volumes:
     external: true
   program-console-sync:
     external: true
+  source-sync:
+      external: true

--- a/docker-sync.yml
+++ b/docker-sync.yml
@@ -48,4 +48,8 @@ syncs:
   frontend-app-learning-sync:
     host_disk_mount_mode: 'cached'
     src: '../frontend-app-learning/'
+
+  source-sync:
+    host_disk_mount_mode: 'cached'
+    src: '../src/'
     sync_excludes: [ '.git', '.idea' ]


### PR DESCRIPTION
## Background:
I use docker-sync on my Macbook to have things a little bit faster but the problem is that there is no `src` folder shared in case of synced containers.

This PR adds `src` directory in the synced containers for sharing files with the host system.