### PR TITLE
Adding note to readme to suggest using NFS with mac

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1087,10 +1087,10 @@ package versions installed.
 Performance
 -----------
 
-Improve Mac OSX Performace using nfs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Improve Mac OSX Performance using nfs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The option to use docker with nfs on mac was added recently. This can potentially increase preformance in mac osx. However, this option is still in testing phase. If you find any corrections that should be made, please start a PR with corrections.
+The option to use docker with nfs on mac was added recently. This can potentially increase performance in mac osx. However, this option is still in testing phase. If you find any corrections that should be made, please start a PR with corrections.
 
 
 Improve Mac OSX Performance with docker-sync

--- a/README.rst
+++ b/README.rst
@@ -1090,7 +1090,7 @@ Performance
 Improve Mac OSX Performace using nfs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The option to use docker with nfs on mac was added recently. The instructions to use this method are above in readme(look nfs). This can potentially increase preformance in mac osx. However, this option is still in testing phase. If you find any corrections that should be made, please start a PR with corrections.
+The option to use docker with nfs on mac was added recently. This can potentially increase preformance in mac osx. However, this option is still in testing phase. If you find any corrections that should be made, please start a PR with corrections.
 
 
 Improve Mac OSX Performance with docker-sync

--- a/README.rst
+++ b/README.rst
@@ -1087,7 +1087,8 @@ package versions installed.
 Performance
 -----------
 
-**NOTE**
+**NOTE:**
+
 docker-sync is no longer actively supported. We now recommend using nfs on MacOS
 to greatly increase performance.
 

--- a/README.rst
+++ b/README.rst
@@ -1087,13 +1087,20 @@ package versions installed.
 Performance
 -----------
 
-**NOTE:**
+Improve Mac OSX Performace using nfs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-docker-sync is no longer actively supported. We now recommend using nfs on MacOS
-to greatly increase performance.
+The option to use docker with nfs on mac was added recently. The instructions to use this method are above in readme(look nfs). This can potentially increase preformance in mac osx. However, this option is still in testing phase. If you find any corrections that should be made, please start a PR with corrections.
+
 
 Improve Mac OSX Performance with docker-sync
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+**NOTE:**
+
+docker-sync is no longer actively supported. See section for nfs above for
+possible alternative.
 
 Docker for Mac has known filesystem issues that significantly decrease
 performance for certain use cases, for example running tests in edx-platform. To

--- a/README.rst
+++ b/README.rst
@@ -153,7 +153,7 @@ All of the services can be run by following the steps below. For analyticstack, 
 
        make dev.sync.provision
 
-    Provision using `nfs`_:
+   Provision using `nfs`_:
 
    .. code:: sh
 
@@ -1086,6 +1086,10 @@ package versions installed.
 
 Performance
 -----------
+
+**NOTE**
+docker-sync is no longer actively supported. We now recommend using nfs on MacOS
+to greatly increase performance.
 
 Improve Mac OSX Performance with docker-sync
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Creating this to note that edx has mostly decided against docker-sync. Eventually, we should modify the docs to include more info on nfs setup. For now, I wanted to add the quick note so people might look at nfs option if they want to increase performance in devstack.