### PR TITLE
dev.clone should use ssh by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_install:
   - docker version
   - docker-compose --version
   - make requirements
-  - make dev.clone
+  - make dev.clone.https
   - make dev.pull."$SERVICES"
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 .PHONY: analytics-pipeline-devstack-test analytics-pipeline-shell \
         analyticspipeline-shell backup build-courses check-memory \
         create-test-course credentials-shell destroy dev.cache-programs \
-        dev.check dev.checkout dev.clone dev.clone.ssh dev.down dev.kill \
+        dev.check dev.checkout dev.clone dev.clone.https dev.down dev.kill \
         dev.nfs.setup devpi-password dev.provision \
         dev.provision.analytics_pipeline dev.provision.services \
         dev.provision.xqueue dev.ps dev.pull dev.repo.reset dev.reset \
@@ -122,10 +122,10 @@ dev.ps: ## View list of created services and their statuses.
 dev.checkout: ## Check out "openedx-release/$OPENEDX_RELEASE" in each repo if set, "master" otherwise
 	./repo.sh checkout
 
-dev.clone: ## Clone service repos using HTTPS method to the parent directory
+dev.clone.https: ## Clone service repos using HTTPS method to the parent directory
 	./repo.sh clone
 
-dev.clone.ssh: ## Clone service repos using SSH method to the parent directory
+dev.clone: ## Clone service repos using SSH method to the parent directory
 	./repo.sh clone_ssh
 
 dev.provision.services: ## Provision default services with local mounted directories
@@ -138,7 +138,7 @@ dev.provision.services: ## Provision default services with local mounted directo
 dev.provision.services.%: ## Provision specified services with local mounted directories, separated by plus signs
 	$(WINPTY) bash ./provision.sh $*
 
-dev.provision: check-memory dev.clone.ssh dev.provision.services stop ## Provision dev environment with default services, and then stop them.
+dev.provision: check-memory dev.clone dev.provision.services stop ## Provision dev environment with default services, and then stop them.
 
 dev.cache-programs: ## Copy programs from Discovery to Memcached for use in LMS.
 	$(WINPTY) bash ./programs/provision.sh cache

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 .PHONY: analytics-pipeline-devstack-test analytics-pipeline-shell \
         analyticspipeline-shell backup build-courses check-memory \
         create-test-course credentials-shell destroy dev.cache-programs \
-        dev.check dev.checkout dev.clone dev.clone.https dev.down dev.kill \
+        dev.check dev.checkout dev.clone dev.clone.ssh dev.clone.https dev.down dev.kill \
         dev.nfs.setup devpi-password dev.provision \
         dev.provision.analytics_pipeline dev.provision.services \
         dev.provision.xqueue dev.ps dev.pull dev.repo.reset dev.reset \
@@ -125,8 +125,10 @@ dev.checkout: ## Check out "openedx-release/$OPENEDX_RELEASE" in each repo if se
 dev.clone.https: ## Clone service repos using HTTPS method to the parent directory
 	./repo.sh clone
 
-dev.clone: ## Clone service repos using SSH method to the parent directory
+dev.clone.ssh: ## Clone service repos using SSH method to the parent directory
 	./repo.sh clone_ssh
+
+dev.clone: dev.clone.ssh ## Clone service repos to the parent directory
 
 dev.provision.services: ## Provision default services with local mounted directories
 	# We provision all default services as well as 'e2e' (end-to-end tests).
@@ -138,7 +140,7 @@ dev.provision.services: ## Provision default services with local mounted directo
 dev.provision.services.%: ## Provision specified services with local mounted directories, separated by plus signs
 	$(WINPTY) bash ./provision.sh $*
 
-dev.provision: check-memory dev.clone dev.provision.services stop ## Provision dev environment with default services, and then stop them.
+dev.provision: check-memory dev.clone.ssh dev.provision.services stop ## Provision dev environment with default services, and then stop them.
 
 dev.cache-programs: ## Copy programs from Discovery to Memcached for use in LMS.
 	$(WINPTY) bash ./programs/provision.sh cache

--- a/README.rst
+++ b/README.rst
@@ -110,7 +110,7 @@ All of the services can be run by following the steps below. For analyticstack, 
 
    .. code:: sh
 
-       make dev.clone  # or, `make dev.clone.ssh` if you have SSH keys set up.
+       make dev.clone  # or, `make dev.clone.https` if you don't have SSH keys set up.
 
    You may customize where the local repositories are found by setting the
    DEVSTACK\_WORKSPACE environment variable.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ build_script:
 # https://openedx.atlassian.net/browse/TE-2761
 #- docker-switch-linux
 - md X:\devstack
-- "\"%ProgramFiles%/Git/bin/bash.exe\" -c \"make dev.clone\""
+- "\"%ProgramFiles%/Git/bin/bash.exe\" -c \"make dev.clone.https\""
 # Stop here until we get provisioning to finish reliably
 #- "\"%ProgramFiles%/Git/bin/bash.exe\" -c \"make dev.pull\""
 

--- a/scripts/Jenkinsfiles/snapshot
+++ b/scripts/Jenkinsfiles/snapshot
@@ -15,7 +15,7 @@ pipeline {
                 withPythonEnv('System-CPython-2.7') {
                     dir('devstack') {
                         sh 'make requirements'
-                        sh 'make dev.clone'
+                        sh 'make dev.clone.https'
                         sh 'make dev.pull'
                         sh 'make dev.provision'
                         sh 'python scripts/snapshot.py ../devstack_snapshot'

--- a/update-dbs-init-sql-scripts.sh
+++ b/update-dbs-init-sql-scripts.sh
@@ -20,7 +20,7 @@ DBS=("ecommerce" "${EDXAPP_DBS[@]}")
 
 # create a docker devstack with LMS and ecommerce
 make destroy
-make dev.clone.ssh
+make dev.clone
 make dev.provision.services.lms+ecommerce
 
 # dump schema and data from mysql databases in the mysql docker container and copy them to current directory in docker host

--- a/update-dbs-init-sql-scripts.sh
+++ b/update-dbs-init-sql-scripts.sh
@@ -20,7 +20,7 @@ DBS=("ecommerce" "${EDXAPP_DBS[@]}")
 
 # create a docker devstack with LMS and ecommerce
 make destroy
-make dev.clone
+make dev.clone.ssh
 make dev.provision.services.lms+ecommerce
 
 # dump schema and data from mysql databases in the mysql docker container and copy them to current directory in docker host


### PR DESCRIPTION
Long-time annoyance for me, but both of the most recent engineering new-hires on my team have tripped over devstack cloning with http recently; no more!

I've done an org-wide search and the only places that needed updating were in devstack: https://github.com/search?q=org%3Aedx+%22dev.clone%22&type=Code