### PR TITLE
Add docker-compose-hosts.yml file for sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,8 +92,9 @@ endif
 
 # Files for use with Docker Sync.
 ifeq ($(FS_SYNC_STRATEGY),docker-sync)
-COMPOSE_FILE := docker-compose-sync.yml
-COMPOSE_FILE := docker-sync-marketing-site.yml
+COMPOSE_FILE := docker-compose-host.yml
+COMPOSE_FILE := $(COMPOSE_FILE):docker-compose-sync.yml
+COMPOSE_FILE := $(COMPOSE_FILE):docker-sync-marketing-site.yml
 endif
 
 ifndef COMPOSE_FILE


### PR DESCRIPTION
## Description
While using the sync containers, I noticed that some of the services (like gradebook) didn't get their volumes mounted correctly. The reason was the docker-compose-host.yml file was not included in case of sync file system strategy. 

This PR fixes that issue.