### PR TITLE
[BD-14] Add Content Libraries v2 authoring MFE

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,7 @@ It also includes the following extra components:
   data from the other Open edX services.
 * The Learning micro-frontend (A.K.A the new Courseware experience)
 * The Program Console micro-frontend
+* The Library Authoring micro-frontend
 * edX Registrar service.
 * The course-authoring micro-frontend
 
@@ -303,41 +304,43 @@ The extra services are provisioned/pulled/run when specifically requested (e.g.,
 ``make dev.provision.xqueue`` / ``make dev.pull.xqueue`` / ``make dev.up.xqueue``).
 Alternatively, you can run these by modifying the ``DEFAULT_SERVICES`` option as described in the `Advanced Configuration Options`_ section.
 
-+-----------------------------------+-------------------------------------+----------------+--------------+
-| Service                           | URL                                 | Type           | Role         |
-+===================================+=====================================+================+==============+
-| `lms`_                            | http://localhost:18000/             | Python/Django  | Default      |
-+-----------------------------------+-------------------------------------+----------------+--------------+
-| `studio`_                         | http://localhost:18010/             | Python/Django  | Default      |
-+-----------------------------------+-------------------------------------+----------------+--------------+
-| `forum`_                          | http://localhost:44567/api/v1/      | Ruby/Sinatra   | Default      |
-+-----------------------------------+-------------------------------------+----------------+--------------+
-| `discovery`_                      | http://localhost:18381/api-docs/    | Python/Django  | Default      |
-+-----------------------------------+-------------------------------------+----------------+--------------+
-| `ecommerce`_                      | http://localhost:18130/dashboard/   | Python/Django  | Default      |
-+-----------------------------------+-------------------------------------+----------------+--------------+
-| `credentials`_                    | http://localhost:18150/api/v2/      | Python/Django  | Default      |
-+-----------------------------------+-------------------------------------+----------------+--------------+
-| `edx_notes_api`_                  | http://localhost:18120/api/v1/      | Python/Django  | Default      |
-+-----------------------------------+-------------------------------------+----------------+--------------+
-| `frontend-app-publisher`_         | http://localhost:18400/             | MFE (React.js) | Default      |
-+-----------------------------------+-------------------------------------+----------------+--------------+
-| `gradebook`_                      | http://localhost:1994/              | MFE (React.js) | Default      |
-+-----------------------------------+-------------------------------------+----------------+--------------+
-| `registrar`_                      | http://localhost:18734/api-docs/    | Python/Django  | Extra        |
-+-----------------------------------+-------------------------------------+----------------+--------------+
-| `program-console`_                | http://localhost:1976/              | MFE (React.js) | Extra        |
-+-----------------------------------+-------------------------------------+----------------+--------------+
-| `frontend-app-learning`_          | http://localhost:2000/              | MFE (React.js) | Extra        |
-+-----------------------------------+-------------------------------------+----------------+--------------+
-| `course-authoring`_               | http://localhost:2001/              | MFE (React.js) | Extra        |
-+-----------------------------------+-------------------------------------+----------------+--------------+
-| `xqueue`_                         | http://localhost:18040/api/v1/      | Python/Django  | Extra        |
-+-----------------------------------+-------------------------------------+----------------+--------------+
-| `analyticspipeline`_              | http://localhost:4040/              | Python         | Extra        |
-+-----------------------------------+-------------------------------------+----------------+--------------+
-| `marketing`_                      | http://localhost:8080/              | PHP/Drupal     | edX.org-only |
-+-----------------------------------+-------------------------------------+----------------+--------------+
++------------------------------------+-------------------------------------+----------------+--------------+
+| Service                            | URL                                 | Type           | Role         |
++====================================+=====================================+================+==============+
+| `lms`_                             | http://localhost:18000/             | Python/Django  | Default      |
++------------------------------------+-------------------------------------+----------------+--------------+
+| `studio`_                          | http://localhost:18010/             | Python/Django  | Default      |
++------------------------------------+-------------------------------------+----------------+--------------+
+| `forum`_                           | http://localhost:44567/api/v1/      | Ruby/Sinatra   | Default      |
++------------------------------------+-------------------------------------+----------------+--------------+
+| `discovery`_                       | http://localhost:18381/api-docs/    | Python/Django  | Default      |
++------------------------------------+-------------------------------------+----------------+--------------+
+| `ecommerce`_                       | http://localhost:18130/dashboard/   | Python/Django  | Default      |
++------------------------------------+-------------------------------------+----------------+--------------+
+| `credentials`_                     | http://localhost:18150/api/v2/      | Python/Django  | Default      |
++------------------------------------+-------------------------------------+----------------+--------------+
+| `edx_notes_api`_                   | http://localhost:18120/api/v1/      | Python/Django  | Default      |
++------------------------------------+-------------------------------------+----------------+--------------+
+| `frontend-app-publisher`_          | http://localhost:18400/             | MFE (React.js) | Default      |
++------------------------------------+-------------------------------------+----------------+--------------+
+| `gradebook`_                       | http://localhost:1994/              | MFE (React.js) | Default      |
++------------------------------------+-------------------------------------+----------------+--------------+
+| `registrar`_                       | http://localhost:18734/api-docs/    | Python/Django  | Extra        |
++------------------------------------+-------------------------------------+----------------+--------------+
+| `program-console`_                 | http://localhost:1976/              | MFE (React.js) | Extra        |
++------------------------------------+-------------------------------------+----------------+--------------+
+| `frontend-app-learning`_           | http://localhost:2000/              | MFE (React.js) | Extra        |
++------------------------------------+-------------------------------------+----------------+--------------+
+| `frontend-app-library-authoring`_  | http://localhost:3001/              | MFE (React.js) | Extra        |
++------------------------------------+-------------------------------------+----------------+--------------+
+| `course-authoring`_                | http://localhost:2001/              | MFE (React.js) | Extra        |
++------------------------------------+-------------------------------------+----------------+--------------+
+| `xqueue`_                          | http://localhost:18040/api/v1/      | Python/Django  | Extra        |
++------------------------------------+-------------------------------------+----------------+--------------+
+| `analyticspipeline`_               | http://localhost:4040/              | Python         | Extra        |
++------------------------------------+-------------------------------------+----------------+--------------+
+| `marketing`_                       | http://localhost:8080/              | PHP/Drupal     | edX.org-only |
++------------------------------------+-------------------------------------+----------------+--------------+
 
 .. _credentials: https://github.com/edx/credentials
 .. _discovery: https://github.com/edx/course-discovery
@@ -354,6 +357,7 @@ Alternatively, you can run these by modifying the ``DEFAULT_SERVICES`` option as
 .. _analyticspipeline: https://github.com/edx/edx-analytics-pipeline
 .. _marketing: https://github.com/edx/edx-mktg
 .. _frontend-app-learning: https://github.com/edx/frontend-app-learning
+.. _frontend-app-library-authoring: https://github.com/edx/frontend-app-library-authoring
 .. _course-authoring: https://github.com/edx/frontend-app-course-authoring
 .. _xqueue: https://github.com/edx/xqueue
 

--- a/docker-compose-host-nfs.yml
+++ b/docker-compose-host-nfs.yml
@@ -65,6 +65,10 @@ services:
     volumes:
       - ${DEVSTACK_WORKSPACE}/frontend-app-publisher:/edx/app/frontend-app-publisher:cached
       - frontend_app_publisher_node_modules:/edx/app/frontend-app-publisher/node_modules
+  frontend-app-library-authoring:
+    volumes:
+      - ${DEVSTACK_WORKSPACE}/frontend-app-library-authoring:/edx/app/frontend-app-library-authoring:cached
+      - frontend_app_library_authoring:/edx/app/frontend-app-library-authoring/node_modules
 
 volumes:
   credentials_node_modules:
@@ -78,6 +82,7 @@ volumes:
   frontend_app_learning_node_modules:
   frontend_app_publisher_node_modules:
   course_authoring_node_modules:
+  frontend_app_library_authoring_node_modules:
   edx-nfs:
     driver: local
     driver_opts:

--- a/docker-compose-host.yml
+++ b/docker-compose-host.yml
@@ -65,6 +65,10 @@ services:
     volumes:
       - ${DEVSTACK_WORKSPACE}/frontend-app-course-authoring:/edx/app/frontend-app-course-authoring:cached
       - course_authoring_node_modules:/edx/app/frontend-app-course-authoring/node_modules
+  frontend-app-library-authoring:
+    volumes:
+      - ${DEVSTACK_WORKSPACE}/frontend-app-library-authoring:/edx/app/frontend-app-library-authoring:cached
+      - frontend_app_library_authoring_node_modules:/edx/app/frontend-app-library-authoring/node_modules
 
 volumes:
   credentials_node_modules:
@@ -78,3 +82,4 @@ volumes:
   frontend_app_publisher_node_modules:
   frontend_app_learning_node_modules:
   course_authoring_node_modules:
+  frontend_app_library_authoring_node_modules:

--- a/docker-compose-sync.yml
+++ b/docker-compose-sync.yml
@@ -41,6 +41,10 @@ services:
     volumes:
       - course-authoring-sync:/edx/app/frontend-app-course-authoring:nocopy
       - source-sync:/edx/src:nocopy
+  frontend-app-library-authoring:
+    volumes:
+      - frontend-app-library-authoring-sync:/edx/app/frontend-app-library-authoring:nocopy
+      - source-sync:/edx/src:nocopy
 
 volumes:
   credentials-sync:
@@ -60,6 +64,8 @@ volumes:
   program-console-sync:
     external: true
   course-authoring-sync:
+    external: true
+  frontend-app-library-authoring-sync:
     external: true
   source-sync:
       external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -506,6 +506,22 @@ services:
     depends_on: 
       - studio
 
+  frontend-app-library-authoring:
+    extends:
+      file: microfrontend.yml
+      service: microfrontend
+    working_dir: '/edx/app/frontend-app-library-authoring'
+    container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.frontend-app-library-authoring"
+    networks:
+      default:
+        aliases:
+          - edx.devstack.frontend-app-library-authoring
+    ports:
+      - "3001:3001"
+    depends_on:
+      - lms
+      - studio
+
 volumes:
   discovery_assets:
   edxapp_lms_assets:

--- a/docker-sync.yml
+++ b/docker-sync.yml
@@ -58,3 +58,8 @@ syncs:
     host_disk_mount_mode: 'cached'
     src: '../src/'
     sync_excludes: [ '.git', '.idea' ]
+
+  frontend-app-library-authoring-sync:
+    host_disk_mount_mode: 'cached'
+    src: '../frontend-app-library-authoring/'
+    sync_excludes: [ '.git', '.idea' ]

--- a/options.mk
+++ b/options.mk
@@ -74,7 +74,7 @@ credentials+discovery+ecommerce+edx_notes_api+forum+frontend-app-publisher+front
 # Separated by plus signs.
 # Separated by plus signs. Listed in alphabetical order for clarity.
 EDX_SERVICES ?= \
-analyticspipeline+course-authoring+credentials+discovery+ecommerce+edx_notes_api+forum+frontend-app-learning+frontend-app-publisher+gradebook+lms+lms_watcher+marketing+program-console+registrar+registrar-worker+studio+studio_watcher+xqueue+xqueue_consumer
+analyticspipeline+course-authoring+credentials+discovery+ecommerce+edx_notes_api+forum+frontend-app-learning+frontend-app-library-authoring+frontend-app-publisher+gradebook+lms+lms_watcher+marketing+program-console+registrar+registrar-worker+studio+studio_watcher+xqueue+xqueue_consumer
 
 # Services with database migrations.
 # Should be a subset of $(EDX_SERVICES).

--- a/repo.sh
+++ b/repo.sh
@@ -37,6 +37,7 @@ repos=(
 non_release_repos=(
     "https://github.com/edx/frontend-app-course-authoring.git"
     "https://github.com/edx/frontend-app-learning.git"
+    "https://github.com/edx/frontend-app-library-authoring.git"
     "https://github.com/edx/registrar.git"
     "https://github.com/edx/frontend-app-program-console.git"
 )
@@ -58,6 +59,7 @@ ssh_repos=(
 non_release_ssh_repos=(
     "git@github.com:edx/frontend-app-course-authoring.git"
     "git@github.com:edx/frontend-app-learning.git"
+    "git@github.com:edx/frontend-app-library-authoring.git"
     "git@github.com:edx/registrar.git"
     "git@github.com:edx/frontend-app-program-console.git"
 )


### PR DESCRIPTION
Adds the Content Libraries v2 MFE to the devstack.

See https://github.com/open-craft/frontend-app-library-authoring/pull/2 for testing instructions.