### PR TITLE
Re-establish the service provisioning order in provision.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ env:
     - DEVSTACK_WORKSPACE=/tmp
     - SHALLOW_CLONE=1
   matrix:
-    - SERVICES=lms+discovery+forum
-    - SERVICES=lms+registrar
+    - SERVICES=discovery+lms+forum  # provision.sh should ensure LMS provisions first.
+    - SERVICES=registrar+lms
     - SERVICES=ecommerce
     - SERVICES=edx_notes_api
     - SERVICES=credentials

--- a/options.mk
+++ b/options.mk
@@ -59,6 +59,11 @@ FS_SYNC_STRATEGY ?= local-mounts
 # when no services are specified manually.
 # Should be a subset of $(EDX_SERVICES).
 # Separated by plus signs. Listed in alphabetical order for clarity.
+# WARNING: You may remove services from this list in order to make Devstack lighter,
+#          but beware that some services have implicit, undocumented dependencies on
+#          other ones. For example, Discovery depends on both LMS and Ecommerce being
+#          provisioned and started in order to provision correctly.
+#          Tread at your own risk.
 # TODO: Re-evaluate this list and consider paring it down to a tighter core.
 #       The current value was chosen such that it would not change the existing
 #       Devstack behavior.


### PR DESCRIPTION
Changing DEFAULT_SERVICES in the previous commit ended up
changing the order in which services are provisioned.
This broke provisioning for Discovery (at least) which depended
on LMS and Ecommerce being started and provisioned.

This commit mandates the order in provision.sh without relying
on that order being defined in DEFAULT_SERVICES.

@Dillon-Dumesnil 