### PR TITLE
Remove the non-release services from the default devstack services

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -324,7 +324,7 @@ Alternatively, you can run these by modifying the ``DEFAULT_SERVICES`` option as
 | `gradebook`_              | http://localhost:1994/              | MFE (React.js) | Default    |
 +---------------------------+-------------------------------------+----------------+------------+
 | `registrar`_              | http://localhost:18374/api-docs/    | Python/Django  | Extra      |
-+---------------------------|-------------------------------------|----------------|------------|
++---------------------------+-------------------------------------+----------------+------------+
 | `program-console`_        | http://localhost:1976/              | MFE (React.js) | Extra      |
 +---------------------------+-------------------------------------+----------------+------------+
 | `frontend-app-learning`_  | http://localhost:2000/              | MFE (React.js) | Extra      |

--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,8 @@ It also includes the following extra components:
   primary extract, transform, and load (ETL) tool that extracts and analyzes
   data from the other Open edX services.
 * The Learning micro-frontend (A.K.A the new Courseware experience)
+* The Program Console micro-frontend
+* edX Registrar service.
 
 .. Because GitHub doesn't support `toctree`, the Table of Contents is hand-written.
 .. Please keep it up-to-date with all the top-level headings.
@@ -321,6 +323,10 @@ Alternatively, you can run these by modifying the ``DEFAULT_SERVICES`` option as
 +---------------------------+-------------------------------------+----------------+------------+
 | `gradebook`_              | http://localhost:1994/              | MFE (React.js) | Default    |
 +---------------------------+-------------------------------------+----------------+------------+
+| `registrar`_              | http://localhost:18374/api-docs/    | Python/Django  | Extra      |
++---------------------------|-------------------------------------|----------------|------------|
+| `program-console`_        | http://localhost:1976/              | MFE (React.js) | Extra      |
++---------------------------+-------------------------------------+----------------+------------+
 | `frontend-app-learning`_  | http://localhost:2000/              | MFE (React.js) | Extra      |
 +---------------------------+-------------------------------------+----------------+------------+
 | `xqueue`_                 | http://localhost:18040/api/v1/      | Python/Django  | Extra      |
@@ -338,6 +344,8 @@ Alternatively, you can run these by modifying the ``DEFAULT_SERVICES`` option as
 .. _frontend-app-publisher: https://github.com/edx/frontend-app-publisher
 .. _gradebook: https://github.com/edx/frontend-app-gradebook
 .. _lms: https://github.com/edx/edx-platform
+.. _program-console: https://github.com/edx/frontend-app-program-console
+.. _registrar: https://github.com/edx/registrar
 .. _studio: https://github.com/edx/edx-platform
 .. _lms: https://github.com/edx/edx-platform
 .. _analyticspipeline: https://github.com/edx/edx-analytics-pipeline

--- a/README.rst
+++ b/README.rst
@@ -18,8 +18,7 @@ A Devstack installation includes the following Open edX components by default:
 * Course Discovery
 * Open edX Search
 * A demonstration Open edX course
-* The Publisher, Gradebook, and Program Console micro-frontends
-* edX Registrar Service
+* The Publisher and Gradebook micro-frontends
 
 It also includes the following extra components:
 
@@ -318,13 +317,9 @@ Alternatively, you can run these by modifying the ``DEFAULT_SERVICES`` option as
 +---------------------------+-------------------------------------+----------------+------------+
 | `edx_notes_api`_          | http://localhost:18120/api/v1/      | Python/Django  | Default    |
 +---------------------------+-------------------------------------+----------------+------------+
-| `registrar`_              | http://localhost:18734/api-docs/    | Python/Django  | Default    |
-+---------------------------+-------------------------------------+----------------+------------+
 | `frontend-app-publisher`_ | http://localhost:18400/             | MFE (React.js) | Default    |
 +---------------------------+-------------------------------------+----------------+------------+
 | `gradebook`_              | http://localhost:1994/              | MFE (React.js) | Default    |
-+---------------------------+-------------------------------------+----------------+------------+
-| `program-console`_        | http://localhost:1976/              | MFE (React.js) | Default    |
 +---------------------------+-------------------------------------+----------------+------------+
 | `frontend-app-learning`_  | http://localhost:2000/              | MFE (React.js) | Extra      |
 +---------------------------+-------------------------------------+----------------+------------+
@@ -343,8 +338,6 @@ Alternatively, you can run these by modifying the ``DEFAULT_SERVICES`` option as
 .. _frontend-app-publisher: https://github.com/edx/frontend-app-publisher
 .. _gradebook: https://github.com/edx/frontend-app-gradebook
 .. _lms: https://github.com/edx/edx-platform
-.. _program-console: https://github.com/edx/frontend-app-program-console
-.. _registrar: https://github.com/edx/registrar
 .. _studio: https://github.com/edx/edx-platform
 .. _lms: https://github.com/edx/edx-platform
 .. _analyticspipeline: https://github.com/edx/edx-analytics-pipeline
@@ -398,8 +391,8 @@ you need them. To instead only start a single service and its dependencies, run
 
     make dev.up.lms
 
-That above command will bring up LMS (along with Memcached, MySQL, DevPI, et al), but it will not bring up Registrar,
-Credentials, Studio, or E-Commerce.
+That above command will bring up LMS (along with Memcached, MySQL, DevPI, et al), but it will not bring up
+Credentials, Studio, or E-Commerce or any of the other default services.
 
 You can also specify multiple services:
 
@@ -767,7 +760,7 @@ You can bring that same service back up with:
 
 .. code:: sh
 
-    make dev.up.<service> 
+    make dev.up.<service>
 
 Running LMS and Studio Tests
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/options.mk
+++ b/options.mk
@@ -68,7 +68,7 @@ FS_SYNC_STRATEGY ?= local-mounts
 #       The current value was chosen such that it would not change the existing
 #       Devstack behavior.
 DEFAULT_SERVICES ?= \
-credentials+discovery+ecommerce+edx_notes_api+forum+frontend-app-publisher+frontend-app-learning+gradebook+lms+program-console+registrar+studio
+credentials+discovery+ecommerce+edx_notes_api+forum+frontend-app-publisher+frontend-app-learning+gradebook+lms+studio
 
 # All edX services, whether or not they are run by default.
 # Separated by plus signs.


### PR DESCRIPTION
This PR removes the non-release services from the list of default devstack services. https://github.com/edx/devstack/pull/525 already did this partially and this PR fixes the remaining usages.

**JIRA tickets**:  Will be created

**Discussions**: [Discussion on Open edX Slack](https://openedx.slack.com/archives/CK94QNCQ0/p1594902913283000)

**Dependencies**: None

**Merge deadline**: None

**Testing instructions**:
1. Checkout this PR branch and try to provision a fresh devstack by following the instructions in the `README` file.
2. Verify that the images for the `registrar`, `program-console` services and their dependencies are not pulled when running `make dev.pull`.
3. Verify that the devstack provisions successfully and works okay.