### PR TITLE
Fix loading of database dumps

### DIFF
--- a/load-db.sh
+++ b/load-db.sh
@@ -18,5 +18,5 @@ fi
 
 echo "Loading the $1 database..."
 mysql_container=$(make -s dev.print-container.mysql)
-docker exec "$mysql_container" bash -c "mysql -uroot $1" < $1.sql
+docker exec -i "$mysql_container" mysql -uroot $1 < $1.sql
 echo "Finished loading the $1 database!"


### PR DESCRIPTION
This seems to have been unintentionally broken in #532 .

This fix will speed up migrations by correctly loading the pre-generated database dumps, which have most migrations already performed.