### PR TITLE
Fix a vitally important typo for registrar

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -323,7 +323,7 @@ Alternatively, you can run these by modifying the ``DEFAULT_SERVICES`` option as
 +---------------------------+-------------------------------------+----------------+------------+
 | `gradebook`_              | http://localhost:1994/              | MFE (React.js) | Default    |
 +---------------------------+-------------------------------------+----------------+------------+
-| `registrar`_              | http://localhost:18374/api-docs/    | Python/Django  | Extra      |
+| `registrar`_              | http://localhost:18734/api-docs/    | Python/Django  | Extra      |
 +---------------------------+-------------------------------------+----------------+------------+
 | `program-console`_        | http://localhost:1976/              | MFE (React.js) | Extra      |
 +---------------------------+-------------------------------------+----------------+------------+


### PR DESCRIPTION
I actually use this list to avoid needing to remember the port numbers
different services use, so this link being broken cost me more than an
hour :weeping: