### PR TITLE
Making edx-mktg slightly easier to set up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ COMPOSE_FILE := $(COMPOSE_FILE):docker-compose-watchers.yml
 COMPOSE_FILE := $(COMPOSE_FILE):docker-compose-xqueue.yml
 COMPOSE_FILE := $(COMPOSE_FILE):docker-compose-analytics-pipeline.yml
 COMPOSE_FILE := $(COMPOSE_FILE):docker-compose-marketing-site.yml
+COMPOSE_FILE := $(COMPOSE_FILE):docker-compose-marketing-site-host.yml
 endif
 
 # Files for use with Network File System -based synchronization.


### PR DESCRIPTION
was following
https://openedx.atlassian.net/wiki/spaces/ENG/pages/159162183/Marketing+Site
but was surprised to find that repo didn't have any required volumes
mounted.

working on some simple testing of
https://github.com/edx/edx-mktg/pull/3017