### PR TITLE
latest registrar image for named releases

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -341,7 +341,7 @@ services:
       CELERY_BROKER_VHOST: 10
       CELERY_BROKER_PASSWORD: password
       DJANGO_WATCHMAN_TIMEOUT: 30
-    image: edxops/registrar:${OPENEDX_RELEASE:-latest}
+    image: edxops/registrar:latest
     networks:
       default:
         aliases:
@@ -375,7 +375,7 @@ services:
       CELERY_BROKER_VHOST: 10
       CELERY_BROKER_PASSWORD: password
       DJANGO_WATCHMAN_TIMEOUT: 30
-    image: edxops/registrar:${OPENEDX_RELEASE:-latest}
+    image: edxops/registrar:latest
     networks:
       default:
         aliases:


### PR DESCRIPTION
As edxops/registrar image in docker hub doesn't have any tags other than `latest`. Named releases fails to pull the image `edxops/registrar:named-release` (eg. `edxops/registrar:juniper.master`)

Links
- https://hub.docker.com/r/edxops/registrar/tags