### PR TITLE
MST-306 Add course-authoring MFE to the devstack

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,7 @@ It also includes the following extra components:
 * The Learning micro-frontend (A.K.A the new Courseware experience)
 * The Program Console micro-frontend
 * edX Registrar service.
+* The course-authoring micro-frontend
 
 .. Because GitHub doesn't support `toctree`, the Table of Contents is hand-written.
 .. Please keep it up-to-date with all the top-level headings.
@@ -302,39 +303,41 @@ The extra services are provisioned/pulled/run when specifically requested (e.g.,
 ``make dev.provision.xqueue`` / ``make dev.pull.xqueue`` / ``make dev.up.xqueue``).
 Alternatively, you can run these by modifying the ``DEFAULT_SERVICES`` option as described in the `Advanced Configuration Options`_ section.
 
-+---------------------------+-------------------------------------+----------------+------------+
-| Service                   | URL                                 | Type           | Role       |
-+===========================+=====================================+================+============+
-| `lms`_                    | http://localhost:18000/             | Python/Django  | Default    |
-+---------------------------+-------------------------------------+----------------+------------+
-| `studio`_                 | http://localhost:18010/             | Python/Django  | Default    |
-+---------------------------+-------------------------------------+----------------+------------+
-| `forum`_                  | http://localhost:44567/api/v1/      | Ruby/Sinatra   | Default    |
-+---------------------------+-------------------------------------+----------------+------------+
-| `discovery`_              | http://localhost:18381/api-docs/    | Python/Django  | Default    |
-+---------------------------+-------------------------------------+----------------+------------+
-| `ecommerce`_              | http://localhost:18130/dashboard/   | Python/Django  | Default    |
-+---------------------------+-------------------------------------+----------------+------------+
-| `credentials`_            | http://localhost:18150/api/v2/      | Python/Django  | Default    |
-+---------------------------+-------------------------------------+----------------+------------+
-| `edx_notes_api`_          | http://localhost:18120/api/v1/      | Python/Django  | Default    |
-+---------------------------+-------------------------------------+----------------+------------+
-| `frontend-app-publisher`_ | http://localhost:18400/             | MFE (React.js) | Default    |
-+---------------------------+-------------------------------------+----------------+------------+
-| `gradebook`_              | http://localhost:1994/              | MFE (React.js) | Default    |
-+---------------------------+-------------------------------------+----------------+------------+
-| `registrar`_              | http://localhost:18734/api-docs/    | Python/Django  | Extra      |
-+---------------------------+-------------------------------------+----------------+------------+
-| `program-console`_        | http://localhost:1976/              | MFE (React.js) | Extra      |
-+---------------------------+-------------------------------------+----------------+------------+
-| `frontend-app-learning`_  | http://localhost:2000/              | MFE (React.js) | Extra      |
-+---------------------------+-------------------------------------+----------------+------------+
-| `xqueue`_                 | http://localhost:18040/api/v1/      | Python/Django  | Extra      |
-+---------------------------+-------------------------------------+----------------+------------+
-| `analyticspipeline`_      | http://localhost:4040/              | Python         | Extra      |
-+---------------------------+-------------------------------------+----------------+------------+
-| `marketing`_              | http://localhost:8080/              | PHP/Drupal     | Extra      |
-+---------------------------+-------------------------------------+----------------+------------+
++-----------------------------------+-------------------------------------+----------------+------------+
+| Service                           | URL                                 | Type           | Role       |
++===================================+=====================================+================+============+
+| `lms`_                            | http://localhost:18000/             | Python/Django  | Default    |
++-----------------------------------+-------------------------------------+----------------+------------+
+| `studio`_                         | http://localhost:18010/             | Python/Django  | Default    |
++-----------------------------------+-------------------------------------+----------------+------------+
+| `forum`_                          | http://localhost:44567/api/v1/      | Ruby/Sinatra   | Default    |
++-----------------------------------+-------------------------------------+----------------+------------+
+| `discovery`_                      | http://localhost:18381/api-docs/    | Python/Django  | Default    |
++-----------------------------------+-------------------------------------+----------------+------------+
+| `ecommerce`_                      | http://localhost:18130/dashboard/   | Python/Django  | Default    |
++-----------------------------------+-------------------------------------+----------------+------------+
+| `credentials`_                    | http://localhost:18150/api/v2/      | Python/Django  | Default    |
++-----------------------------------+-------------------------------------+----------------+------------+
+| `edx_notes_api`_                  | http://localhost:18120/api/v1/      | Python/Django  | Default    |
++-----------------------------------+-------------------------------------+----------------+------------+
+| `frontend-app-publisher`_         | http://localhost:18400/             | MFE (React.js) | Default    |
++-----------------------------------+-------------------------------------+----------------+------------+
+| `gradebook`_                      | http://localhost:1994/              | MFE (React.js) | Default    |
++-----------------------------------+-------------------------------------+----------------+------------+
+| `registrar`_                      | http://localhost:18734/api-docs/    | Python/Django  | Extra      |
++-----------------------------------+-------------------------------------+----------------+------------+
+| `program-console`_                | http://localhost:1976/              | MFE (React.js) | Extra      |
++-----------------------------------+-------------------------------------+----------------+------------+
+| `frontend-app-learning`_          | http://localhost:2000/              | MFE (React.js) | Extra      |
++-----------------------------------+-------------------------------------+----------------+------------+
+| `course-authoring`_               | http://localhost:2001/              | MFE (React.js) | Extra      |
++-----------------------------------+-------------------------------------+----------------+------------+
+| `xqueue`_                         | http://localhost:18040/api/v1/      | Python/Django  | Extra      |
++-----------------------------------+-------------------------------------+----------------+------------+
+| `analyticspipeline`_              | http://localhost:4040/              | Python         | Extra      |
++-----------------------------------+-------------------------------------+----------------+------------+
+| `marketing`_                      | http://localhost:8080/              | PHP/Drupal     | Extra      |
++-----------------------------------+-------------------------------------+----------------+------------+
 
 .. _credentials: https://github.com/edx/credentials
 .. _discovery: https://github.com/edx/course-discovery
@@ -351,6 +354,7 @@ Alternatively, you can run these by modifying the ``DEFAULT_SERVICES`` option as
 .. _analyticspipeline: https://github.com/edx/edx-analytics-pipeline
 .. _marketing: https://github.com/edx/edx-mktg
 .. _frontend-app-learning: https://github.com/edx/frontend-app-learning
+.. _course-authoring: https://github.com/edx/frontend-app-course-authoring
 .. _xqueue: https://github.com/edx/xqueue
 
 Useful Commands

--- a/docker-compose-host-nfs.yml
+++ b/docker-compose-host-nfs.yml
@@ -57,6 +57,10 @@ services:
     volumes:
       - ${DEVSTACK_WORKSPACE}/frontend-app-learning:/edx/app/frontend-app-learning:cached
       - frontend_app_learning_node_modules:/edx/app/frontend-app-learning/node_modules
+  course-authoring:
+    volumes:
+      - ${DEVSTACK_WORKSPACE}/frontend-app-course-authoring:/edx/app/frontend-app-course-authoring:cached
+      - course_authoring_node_modules:/edx/app/frontend-app-course-authoring/node_modules
   frontend-app-publisher:
     volumes:
       - ${DEVSTACK_WORKSPACE}/frontend-app-publisher:/edx/app/frontend-app-publisher:cached
@@ -73,6 +77,7 @@ volumes:
   program_console_node_modules:
   frontend_app_learning_node_modules:
   frontend_app_publisher_node_modules:
+  course_authoring_node_modules:
   edx-nfs:
     driver: local
     driver_opts:

--- a/docker-compose-host.yml
+++ b/docker-compose-host.yml
@@ -61,6 +61,10 @@ services:
     volumes:
       - ${DEVSTACK_WORKSPACE}/frontend-app-learning:/edx/app/frontend-app-learning:cached
       - frontend_app_learning_node_modules:/edx/app/frontend-app-learning/node_modules
+  course-authoring:
+    volumes:
+      - ${DEVSTACK_WORKSPACE}/frontend-app-course-authoring:/edx/app/frontend-app-course-authoring:cached
+      - course_authoring_node_modules:/edx/app/frontend-app-course-authoring/node_modules
 
 volumes:
   credentials_node_modules:
@@ -73,3 +77,4 @@ volumes:
   program_console_node_modules:
   frontend_app_publisher_node_modules:
   frontend_app_learning_node_modules:
+  course_authoring_node_modules:

--- a/docker-compose-sync.yml
+++ b/docker-compose-sync.yml
@@ -37,6 +37,10 @@ services:
     volumes:
       - program-console-sync:/edx/app/program-console:nocopy
       - source-sync:/edx/src:nocopy
+  course-authoring:
+    volumes:
+      - course-authoring-sync:/edx/app/frontend-app-course-authoring:nocopy
+      - source-sync:/edx/src:nocopy
 
 volumes:
   credentials-sync:
@@ -54,6 +58,8 @@ volumes:
   gradebook-sync:
     external: true
   program-console-sync:
+    external: true
+  course-authoring-sync:
     external: true
   source-sync:
       external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -489,6 +489,21 @@ services:
       - lms
       - registrar
 
+  course-authoring:
+    extends:
+      file: microfrontend.yml
+      service: microfrontend
+    working_dir: '/edx/app/frontend-app-course-authoring'
+    container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.course-authoring"
+    networks:
+      default:
+        aliases:
+          - edx.devstack.course-authoring
+    ports:
+      - "2001:2001"
+    depends_on: 
+      - studio
+
 volumes:
   discovery_assets:
   edxapp_lms_assets:

--- a/docker-sync.yml
+++ b/docker-sync.yml
@@ -49,6 +49,11 @@ syncs:
     host_disk_mount_mode: 'cached'
     src: '../frontend-app-learning/'
 
+  course-authoring-sync:
+    host_disk_mount_mode: 'cached'
+    src: '../frontend-app-course-authoring/'
+    sync_excludes: [ '.git', '.idea' ]
+
   source-sync:
     host_disk_mount_mode: 'cached'
     src: '../src/'

--- a/options.mk
+++ b/options.mk
@@ -74,7 +74,7 @@ credentials+discovery+ecommerce+edx_notes_api+forum+frontend-app-publisher+front
 # Separated by plus signs.
 # Separated by plus signs. Listed in alphabetical order for clarity.
 EDX_SERVICES ?= \
-analyticspipeline+credentials+discovery+ecommerce+edx_notes_api+forum+frontend-app-learning+frontend-app-publisher+gradebook+lms+lms_watcher+marketing+program-console+registrar+registrar-worker+studio+studio_watcher+xqueue+xqueue_consumer
+analyticspipeline+course-authoring+credentials+discovery+ecommerce+edx_notes_api+forum+frontend-app-learning+frontend-app-publisher+gradebook+lms+lms_watcher+marketing+program-console+registrar+registrar-worker+studio+studio_watcher+xqueue+xqueue_consumer
 
 # Services with database migrations.
 # Should be a subset of $(EDX_SERVICES).

--- a/repo.sh
+++ b/repo.sh
@@ -35,6 +35,7 @@ repos=(
 )
 
 non_release_repos=(
+    "https://github.com/edx/frontend-app-course-authoring.git"
     "https://github.com/edx/frontend-app-learning.git"
     "https://github.com/edx/registrar.git"
     "https://github.com/edx/frontend-app-program-console.git"
@@ -55,6 +56,7 @@ ssh_repos=(
 )
 
 non_release_ssh_repos=(
+    "git@github.com:edx/frontend-app-course-authoring.git"
     "git@github.com:edx/frontend-app-learning.git"
     "git@github.com:edx/registrar.git"
     "git@github.com:edx/frontend-app-program-console.git"


### PR DESCRIPTION
@edx/masters-devs-cosmonauts @kdmccormick This is the PR to add course-authoring MFE into devstack. I chose the short name `course-authoring` instead of the long form `frontend-app-course-authoring`
Still testing this change out. But I want to get some feedback here
