### PR TITLE
Do not use openedx release for registrar and edx-mktg docker images.

### DIFF
--- a/docker-compose-marketing-site.yml
+++ b/docker-compose-marketing-site.yml
@@ -25,6 +25,6 @@ services:
       - DRUPAL_EXTRA_SETTINGS=${DRUPAL_EXTRA_SETTINGS:-/var/www/html/sites/default/docker.settings.php}
       # IP address of your machine to enable debugging (IP_ADDRESS set in .env file)
       - XDEBUG_CONFIG=remote_host=${XDEBUG_IP_ADDRESS:-127.0.0.1}
-    image: edxops/edx-mktg:${OPENEDX_RELEASE:-latest}
+    image: edxops/edx-mktg:latest
     ports:
       - "8080:80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -277,7 +277,7 @@ services:
       CELERY_BROKER_VHOST: 10
       CELERY_BROKER_PASSWORD: password
       DJANGO_WATCHMAN_TIMEOUT: 30
-    image: edxops/registrar:${OPENEDX_RELEASE:-latest}
+    image: edxops/registrar:latest
     ports:
       - "18734:18734"
     volumes:
@@ -307,7 +307,7 @@ services:
       CELERY_BROKER_VHOST: 10
       CELERY_BROKER_PASSWORD: password
       DJANGO_WATCHMAN_TIMEOUT: 30
-    image: edxops/registrar:${OPENEDX_RELEASE:-latest}
+    image: edxops/registrar:latest
     ports:
       - "18735:18735"
     volumes:


### PR DESCRIPTION
This is the same of https://github.com/edx/devstack/pull/591 but for the juniper branch and also including the edx-mktg service.

make dev.pull is failing for when OPENEDX_RELEASE is defined (eg. juniper.master) because there is not such tag in docker hub for the registrar image.

I enabled the tests for this branch.