### PR TITLE
Remove `xqueue` from `DEFAULT_SERVICES` fix for PR #564.

### DIFF
--- a/options.mk
+++ b/options.mk
@@ -47,7 +47,7 @@ FS_SYNC_STRATEGY ?= local-mounts
 # TODO: Re-evaluate this list and consider paring it down to a tighter core.
 #       The current value was chosen such that it would not change the existing
 #       Devstack behavior.
-DEFAULT_SERVICES ?= lms+studio+ecommerce+discovery+xqueue+credentials+forum+edx_notes_api+gradebook+frontend-app-publisher
+DEFAULT_SERVICES ?= lms+studio+ecommerce+discovery+credentials+forum+edx_notes_api+gradebook+frontend-app-publisher
 
 # List of all services with database migrations.
 # Services must provide a Makefile target named: $(service)-update-db


### PR DESCRIPTION
As discussed with @kdmccormick here https://github.com/edx/devstack/commit/57455fe789fd2ca39327ff901781f825537fa379#commitcomment-41529836 we decided to remove `xqueue` since it is not needed by default devstack setup. 

This is a fix to recent PR https://github.com/edx/devstack/pull/564 and only applies to Juniper release at the moment.

cc: @kdmccormick, @regisb 