### PR TITLE
[BD-14] Add elasticsearch as a Studio dependency

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -392,6 +392,7 @@ services:
     hostname: studio.devstack.edx
     depends_on:
       - devpi
+      - elasticsearch
       - mysql
       - memcached
       - mongo


### PR DESCRIPTION
It is need by the newly-improved Studio API: `/api/libraries/v2/`

See https://github.com/edx/edx-platform/pull/24530

@mavidser 
