### PR TITLE
Fix typo'd frontend_app_library_authoring_node_modules NFS volume

### DIFF
--- a/docker-compose-host-nfs.yml
+++ b/docker-compose-host-nfs.yml
@@ -68,7 +68,7 @@ services:
   frontend-app-library-authoring:
     volumes:
       - ${DEVSTACK_WORKSPACE}/frontend-app-library-authoring:/edx/app/frontend-app-library-authoring:cached
-      - frontend_app_library_authoring:/edx/app/frontend-app-library-authoring/node_modules
+      - frontend_app_library_authoring_node_modules:/edx/app/frontend-app-library-authoring/node_modules
 
 volumes:
   credentials_node_modules:


### PR DESCRIPTION
@mattdrayer reports that `make dev.nfs.provision` gives:
```
Will provision the following:
   lms ecommerce discovery credentials e2e forum notes 
+ docker-compose up -d mysql
ERROR: Named volume "frontend_app_library_authoring:/edx/app/frontend-app-library-authoring/node_modules:rw" is used in service "frontend-app-library-authoring" but no declaration was found in the volumes section.
make[1]: *** [dev.provision] Error 1
make: *** [dev.nfs.provision] Error 2
```
frontend-app-library-authoring was recently added to Devstack for BD-14, and it looks like the NFS node modules volume name was typoed. This hopefully fixes it, but I haven't tested it yet.