### PR TITLE
Fix Unknown command: 'rebuild_index' error during the Devstack installation

### DIFF
--- a/provision-notes.sh
+++ b/provision-notes.sh
@@ -5,4 +5,4 @@
 
 # This will build the elasticsearch index for notes.
 echo -e "${GREEN}Creating indexes for edx_notes_api...${NC}"
-docker-compose exec edx_notes_api bash -c 'source /edx/app/$1/$1_env && cd /edx/app/$1/$1/ && python manage.py rebuild_index --noinput' -- edx_notes_api
+docker-compose exec edx_notes_api bash -c 'source /edx/app/$1/$1_env && cd /edx/app/$1/$1/ && python manage.py search_index --rebuild -f' -- edx_notes_api


### PR DESCRIPTION
This PR fixes the **Unknown command: 'rebuild_index'** error shown when running the provision command during the Devstack installation.

**Background:** After the [Haystack replacement](https://github.com/edx/edx-notes-api/pull/181/files) for edx-notes-api was made, the provision service for edx-notes-api returns the following error: `Unknown command: 'rebuild_index'`. This happens because the provision-notes file still executes the 'rebuild_index' management command that comes with Haystack to clear/update the indexes.

Replaced 'rebuild_index' with 'search_index --rebuild' (which is the [management command](https://django-elasticsearch-dsl.readthedocs.io/en/latest/management.html) that comes with Django elasticsearch DSL to recreate the indexes) in the devstack/provision-notes.sh file.

**Note**: despite having solved the unknown command error, the provision service for edx-notes-api returns another error (this one related to ElasticSearch).
Here's part of the stack trace.
```
elasticsearch.exceptions.RequestError: RequestError(400, 'MapperParsingException[mapping [properties]]; nested: MapperParsingException[Root type mapping not empty after parsing! Remaining fields:   [course_id : {type=keyword}] [quote : {analyzer=html_strip, type=text}] [ranges : {type=keyword}] [created : {type=date}] [text : {analyzer=html_strip, type=text}] [id : {type=integer}] [user : {type=keyword}] [updated : {type=date}] [usage_id : {type=keyword}] [tags : {analyzer=case_insensitive_keyword, type=text}]]; ', 'MapperParsingException[mapping [properties]]; nested: MapperParsingException[Root type mapping not empty after parsing! Remaining fields:   [course_id : {type=keyword}] [quote : {analyzer=html_strip, type=text}] [ranges : {type=keyword}] [created : {type=date}] [text : {analyzer=html_strip, type=text}] [id : {type=integer}] [user : {type=keyword}] [updated : {type=date}] [usage_id : {type=keyword}] [tags : {analyzer=case_insensitive_keyword, type=text}]]; ')
Makefile:224: recipe for target 'dev.provision.notes' failed
make: *** [dev.provision.notes] Error 1
```



@felipemontoya
@mariajgrimaldi 