### PR TITLE
Upgrade notes to elasticsearch7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -246,7 +246,7 @@ services:
     hostname: edx_notes_api.devstack.edx
     depends_on:
       - devpi
-      - elasticsearch
+      - elasticsearch7
       - mysql
     image: edxops/notes:${OPENEDX_RELEASE:-latest}
     networks:
@@ -264,7 +264,7 @@ services:
       DB_USER: "notes001"
       DJANGO_WATCHMAN_TIMEOUT: 30
       ENABLE_DJANGO_TOOLBAR: 1
-      ELASTICSEARCH_URL: "http://edx.devstack.elasticsearch:9200"
+      ELASTICSEARCH_URL: "http://edx.devstack.elasticsearch7:9200"
 
   forum:
     command: bash -c 'source /edx/app/forum/ruby_env && source /edx/app/forum/devstack_forum_env && cd /edx/app/forum/cs_comments_service && bundle install && while true; do ruby app.rb -o 0.0.0.0 ; sleep 2; done'


### PR DESCRIPTION
Note: This depends on https://github.com/edx/devstack/pull/612 .
This branch will be rebased and the PR re-pointed to `master` following #612 merging to `master`.