### PR TITLE
Upgrade forums to elasticsearch7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -273,7 +273,7 @@ services:
     depends_on:
       - mongo
       - memcached
-      - elasticsearch
+      - elasticsearch7
     image: edxops/forum:${OPENEDX_RELEASE:-latest}
     networks:
       default:


### PR DESCRIPTION
Note: This depends on https://github.com/edx/devstack/pull/612 .
This branch will be rebased and the PR re-pointed to `master` following #612 merging to `master`.