### PR TITLE
Upgrade lms/studio to elasticsearch7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -288,6 +288,7 @@ services:
     hostname: lms.devstack.edx
     depends_on:
       - devpi
+      - elasticsearch7
       - mysql
       - memcached
       - mongo
@@ -398,6 +399,7 @@ services:
     hostname: studio.devstack.edx
     depends_on:
       - devpi
+      - elasticsearch7
       - mysql
       - memcached
       - mongo


### PR DESCRIPTION
Note: This depends on https://github.com/edx/devstack/pull/612 .
This branch will be rebased and the PR re-pointed to `master` following #612 merging to `master`.