### PR TITLE
Improve attachment, debugging, restarting for MFEs & Forum

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -275,6 +275,8 @@ services:
       - memcached
       - elasticsearch
     image: edxops/forum:${OPENEDX_RELEASE:-latest}
+    stdin_open: true
+    tty: true
     networks:
       default:
         aliases:

--- a/microfrontend.yml
+++ b/microfrontend.yml
@@ -4,7 +4,9 @@ version: "2.1"
 
 services:
   microfrontend:
-    command: bash -c 'npm install && npm run start'
+    command: bash -c 'npm install; while true; do npm start; sleep 2; done'
+    stdin_open: true
+    tty: true
     image: node:12
     environment:
       - NODE_ENV=development


### PR DESCRIPTION
Currently, you can attach to MFEs/Forum with `make dev.attach.frontend-app...` and `make dev.attach.forum`, respectively. However, once attached, certain things don't work that *do* work when attaching to LMS, Discovery, etc. Notably:
* command-line debugging is weird; sometimes things don't print.
* colored output is often broken.
* restart via Ctrl+C doesn't work.
* detachment via Ctrl+P Ctrl+Q doesn't work.

To fix that problem, this PR:
* allocates a TTY for MFEs and forum
* opens stdin for MFEs and forum
* runs `npm start` on a loop for MFEs

These are all things that we do for the other services, but just don't do for MFEs and Forum because nobody thought to configure them.