### PR TITLE
Don't limit devstack clones to a single branch

### DIFF
--- a/repo.sh
+++ b/repo.sh
@@ -129,9 +129,9 @@ _clone ()
             cd ..
         else
             if [ "${SHALLOW_CLONE}" == "1" ]; then
-                git clone --single-branch -b ${OPENEDX_GIT_BRANCH} -c core.symlinks=true --depth=1 "${repo}"
+                git clone -b ${OPENEDX_GIT_BRANCH} -c core.symlinks=true --depth=1 "${repo}"
             else
-                git clone --single-branch -b ${OPENEDX_GIT_BRANCH} -c core.symlinks=true "${repo}"
+                git clone -b ${OPENEDX_GIT_BRANCH} -c core.symlinks=true "${repo}"
             fi
         fi
     done


### PR DESCRIPTION
This option had caused clones to have a `remote.origin.fetch` config value
of `+refs/heads/master:refs/remotes/origin/master`, which resulted in
developers not being able to see other remote branches, but only in repos
cloned by `make clone`.

(The usual value is `+refs/heads/*:refs/remotes/origin/*`)

The behavior was originally introduced in a PR for checking out
a specified branch after clone (https://github.com/edx/devstack/pull/345)
and I don't think the single-branch behavior is required for that goal.