### PR TITLE
Feanil/notes es7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
     - SERVICES=discovery+lms+forum  # provision.sh should ensure LMS provisions first.
     - SERVICES=registrar+lms
     - SERVICES=ecommerce
-      # - SERVICES=edx_notes_api
+    - SERVICES=edx_notes_api
     - SERVICES=credentials
     - SERVICES=analyticspipeline
     - SERVICES=xqueue

--- a/README.rst
+++ b/README.rst
@@ -1350,9 +1350,11 @@ GitHub issue which explains the `current status of implementing delegated consis
 Known Issues
 ------------
 
-The Notes service has been disabled and removed from provisioning due to issues with getting it working with ES7.
-It will be added again after these issues have been resolved, but Notes will have to be provisioned separately once
-the fixes have been merged.
+Currently, some containers rely on Elasticsearch 7 and some rely on Elasticsearch 1.5. This is
+because services are in the process of being upgraded to Elasticsearch 7, but not all of them
+support Elasticsearch 7 yet. As we complete these migrations, we will update the dependencies
+of these containers.
+
 
 
 Advanced Configuration Options

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -241,12 +241,14 @@ services:
       - "18130:18130"
 
   edx_notes_api:
-    command: bash -c 'source /edx/app/edx_notes_api/edx_notes_api_env && while true; do python /edx/app/edx_notes_api/edx_notes_api/manage.py runserver 0.0.0.0:18120 --settings notesserver.settings.devstack; sleep 2; done'
+    # Sleep as a part of start up to give elasticsearch enough time to start up.
+    command: bash -c 'source /edx/app/edx_notes_api/edx_notes_api_env && while true; do python /edx/app/edx_notes_api/edx_notes_api/manage.py runserver 0.0.0.0:18120 --settings notesserver.settings.devstack; sleep 4; done'
     container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.edxnotesapi"
     hostname: edx_notes_api.devstack.edx
     depends_on:
       - devpi
-      - elasticsearch
+      - elasticsearch7
+      - lms
       - mysql
     image: edxops/notes:${OPENEDX_RELEASE:-latest}
     networks:
@@ -264,7 +266,7 @@ services:
       DB_USER: "notes001"
       DJANGO_WATCHMAN_TIMEOUT: 30
       ENABLE_DJANGO_TOOLBAR: 1
-      ELASTICSEARCH_URL: "http://edx.devstack.elasticsearch:9200"
+      ELASTICSEARCH_URL: "http://edx.devstack.elasticsearch7:9200"
 
   forum:
     command: bash -c 'source /edx/app/forum/ruby_env && source /edx/app/forum/devstack_forum_env && cd /edx/app/forum/cs_comments_service && bundle install && while true; do ruby app.rb -o 0.0.0.0 ; sleep 2; done'
@@ -511,7 +513,7 @@ services:
           - edx.devstack.course-authoring
     ports:
       - "2001:2001"
-    depends_on: 
+    depends_on:
       - studio
 
   frontend-app-library-authoring:

--- a/options.mk
+++ b/options.mk
@@ -67,9 +67,8 @@ FS_SYNC_STRATEGY ?= local-mounts
 # TODO: Re-evaluate this list and consider paring it down to a tighter core.
 #       The current value was chosen such that it would not change the existing
 #       Devstack behavior.
-# TODO: To resolve issues with notes provisioning with ES7, we are removing it from this list until it can be added again between ecommerce and forum.
 DEFAULT_SERVICES ?= \
-credentials+discovery+ecommerce+forum+frontend-app-publisher+frontend-app-learning+gradebook+lms+studio
+credentials+discovery+ecommerce+notes+forum+frontend-app-publisher+frontend-app-learning+gradebook+lms+studio
 
 # All edX services, whether or not they are run by default.
 # Separated by plus signs.


### PR DESCRIPTION
Updated version of https://github.com/edx/devstack/pull/621 . The ES container wasn't starting up fast enough, leading to connection failed errors.