### PR TITLE
Fix Notes service name for make targets

### DIFF
--- a/options.mk
+++ b/options.mk
@@ -68,7 +68,7 @@ FS_SYNC_STRATEGY ?= local-mounts
 #       The current value was chosen such that it would not change the existing
 #       Devstack behavior.
 DEFAULT_SERVICES ?= \
-credentials+discovery+ecommerce+notes+forum+frontend-app-publisher+frontend-app-learning+gradebook+lms+studio
+credentials+discovery+ecommerce+edx_notes_api+forum+frontend-app-publisher+frontend-app-learning+gradebook+lms+studio
 
 # All edX services, whether or not they are run by default.
 # Separated by plus signs.


### PR DESCRIPTION
Fixes the service name for Notes component re-enabled for provisioning in 6c4c1405255fc792922a6e76756696d8cd33e9cc.

Previously, this would cause make targets making use of `DEFAULT_SERVICES` to error, as `notes` is not a known service.