### PR TITLE
Correct the service name to include underscore.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
     - SERVICES=ecommerce
     - SERVICES=edx_notes_api
     - SERVICES=credentials
-    - SERVICES=analyticspipeline
+    - SERVICES=analytics_pipeline
     - SERVICES=xqueue
     - SERVICES=marketing
 


### PR DESCRIPTION
https://hub.docker.com/repository/docker/edxops/analytics_pipeline This exists but `analyticspipeline` does not.