### PR TITLE
Adding lms as a dependencies of discovery

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -200,6 +200,7 @@ services:
       - mysql
       - elasticsearch
       - memcached
+      - lms
     # Allows attachment to the discovery service using 'docker attach <containerID>'.
     stdin_open: true
     tty: true


### PR DESCRIPTION
lms is a run time dependency of discovery, especially for login. It was missing from docker-compose.yml.