### PR TITLE
Update instructions for multiple devstacks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -499,7 +499,7 @@ You can have multiple isolated Devstacks provisioned on a single computer now. F
 
 #. If you haven't done so, follow the steps in the `Getting Started`_ section, to install the master devstack or any other named release. We recommend that you have at least one devstack on the master branch.
 #. Change directory to your devstack and activate the virtual env.
-#. Stop any running containers by issuing a ``make dev.stop``. Note that in older named releases ``make dev.stop`` may not be available. Use ``make stop`` instead. Make sure that all containers are stopped from the docker dashboard.
+#. Stop any running containers by issuing a ``make dev.stop``.
 #. Follow the steps in `Getting Started`_ section again, setting the additional OPENEDX_RELEASE you want to install in step 2
 
 The implication of this is that you can switch between isolated Devstack databases by changing the value of the ``OPENEDX_RELEASE`` environment variable.
@@ -507,7 +507,7 @@ The implication of this is that you can switch between isolated Devstack databas
 Switch between your Devstack releases by doing the following:
 *************************************************************
 
-#. Stop the containers by issuing a ``make dev.stop`` for the running release. Note that in older named releases ``make dev.stop`` may not be available. Use ``make stop`` instead.
+#. Stop the containers by issuing a ``make dev.stop`` for the running release.
 #. Edit the project name in ``options.local.mk`` or set the ``OPENEDX_RELEASE`` environment variable and let the ``COMPOSE_PROJECT_NAME`` be assigned automatically. 
 #. Check out the appropriate branch in devstack, e.g. ``git checkout open-release/ironwood.master``
 #. Use ``make dev.checkout`` to check out the correct branch in the local

--- a/README.rst
+++ b/README.rst
@@ -108,6 +108,8 @@ the ones installed globally on your system.
 Using the Latest Images
 -----------------------
 
+By default, these instructions will install the master branch. If you want to install a named release instead (e.g. juniper.master), follow the steps in `How do I run the images for a named Open edX release?`_ before pulling the docker images. You can learn more about named releases in the `official documentation <https://edx.readthedocs.io/projects/edx-developer-docs/en/latest/named_releases.html>`_.
+
 New images for our services are published frequently.  Assuming that you've followed the steps in `Getting Started`_
 below, run the following sequence of commands if you want to use the most up-to-date versions of *all* default devstack images.
 
@@ -178,8 +180,6 @@ The default devstack services can be run by following the steps below. For analy
    .. _step 3:
 3. Pull any changes made to the various images on which the devstack depends.
 
-   **NOTE:** These instructions will install the master release. If you want to install a named release instead (e.g. juniper.master), follow the steps in `How do I run the images for a named Open edX release?`_ before pulling the docker images.
-   
    .. code:: sh
 
        make dev.pull
@@ -483,16 +483,9 @@ By default, the steps above will install the devstack using the master branch of
 #. Set the ``OPENEDX_RELEASE`` environment variable to the appropriate image
    tag; "hawthorn.master", "zebrawood.rc1", etc.  Note that unlike a server
    install, ``OPENEDX_RELEASE`` should not have the "open-release/" prefix.
-
-   **NOTE:** The ``COMPOSE_PROJECT_NAME`` variable is used to define Docker namespaced volumes and network based on this value, so changing it will give you a separate set of databases. This is handled for you automatically by setting the ``OPENEDX_RELEASE`` environment variable in ``options.mk`` (e.g. ``COMPOSE_PROJECT_NAME=devstack-juniper.master``. Should you want to manually override this, edit the ``options.local.mk`` in the root of this repo and create the file if it does not exist. Change the devstack project name by adding the following line:
-   ``COMPOSE_PROJECT_NAME=<your-alternate-devstack-name>`` (e.g. ``COMPOSE_PROJECT_NAME=secondarydevstack``)
-
-   As a specific example, if ``OPENEDX_RELEASE`` is set in your environment as ``juniper.master``, then ``COMPOSE_PROJECT_NAME`` will default to ``devstack-juniper.master`` instead of ``devstack``.
-
 #. Check out the appropriate branch in devstack, e.g. ``git checkout open-release/ironwood.master``
 #. Use ``make dev.checkout`` to check out the correct branch in the local
-   checkout of each service repository once you've set the ``OPENEDX_RELEASE``
-   environment variable above.
+   checkout of each service repository
 #. Continue with `step 3`_ in the Getting Started guide to pull the correct docker images.
 
 All ``make`` target and ``docker-compose`` calls should now use the correct
@@ -502,11 +495,11 @@ an empty string.
 
 How do I run multiple named Open edX releases on same machine?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-You can have multiple isolated Devstacks provisioned on a single computer now. Follow these directions **after installing the master release devstack** to switch between the named releases.
+You can have multiple isolated Devstacks provisioned on a single computer now. Follow these directions **after installing at least two devstacks** to switch between them.
 
 #. If you haven't done so, follow the steps in the `Getting Started`_ section, to install the master devstack or any other named release. We recommend that you have at least one devstack on the master branch.
 #. Change directory to your devstack and activate the virtual env.
-#. Stop any running containers by issuing a ``make stop``. Make sure that all containers are stopped from the docker dashboard.
+#. Stop any running containers by issuing a ``make dev.stop``. Note that in older named releases ``make dev.stop`` may not be available. Use ``make stop`` instead. Make sure that all containers are stopped from the docker dashboard.
 #. Follow the steps in `Getting Started`_ section again, setting the additional OPENEDX_RELEASE you want to install in step 2
 
 The implication of this is that you can switch between isolated Devstack databases by changing the value of the ``OPENEDX_RELEASE`` environment variable.
@@ -514,7 +507,7 @@ The implication of this is that you can switch between isolated Devstack databas
 Switch between your Devstack releases by doing the following:
 *************************************************************
 
-#. Stop the containers by issuing a ``make stop`` for the running release.
+#. Stop the containers by issuing a ``make dev.stop`` for the running release. Note that in older named releases ``make dev.stop`` may not be available. Use ``make stop`` instead.
 #. Edit the project name in ``options.local.mk`` or set the ``OPENEDX_RELEASE`` environment variable and let the ``COMPOSE_PROJECT_NAME`` be assigned automatically. 
 #. Check out the appropriate branch in devstack, e.g. ``git checkout open-release/ironwood.master``
 #. Use ``make dev.checkout`` to check out the correct branch in the local
@@ -1427,6 +1420,18 @@ For more detail, refer to the comments in the file itself.
 If you're feeling brave, you can create an git-ignored overrides file called
 ``options.local.mk`` in the same directory and set your own values. In general,
 it's good to bring down containers before changing any settings.
+
+Changing the Docker Compose Project Name
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``COMPOSE_PROJECT_NAME`` variable is used to define Docker namespaced volumes 
+and network based on this value, so changing it will give you a separate set of databases. 
+This is handled for you automatically by setting the ``OPENEDX_RELEASE`` environment variable in ``options.mk`` 
+(e.g. ``COMPOSE_PROJECT_NAME=devstack-juniper.master``. Should you want to manually override this, edit the ``options.local.mk`` in the root of this repo and create the file if it does not exist. Change the devstack project name by adding the following line:
+   ``COMPOSE_PROJECT_NAME=<your-alternate-devstack-name>`` (e.g. ``COMPOSE_PROJECT_NAME=secondarydevstack``)
+
+As a specific example, if ``OPENEDX_RELEASE`` is set in your environment as ``juniper.master``, then ``COMPOSE_PROJECT_NAME`` will default to ``devstack-juniper.master`` instead of ``devstack``.
+
 
 .. _Docker Compose: https://docs.docker.com/compose/
 .. _Docker for Mac: https://docs.docker.com/docker-for-mac/

--- a/README.rst
+++ b/README.rst
@@ -905,8 +905,6 @@ LMS and Studio (a.k.a. CMS) read many configuration settings from the container 
 in the following locations:
 
 - ``/edx/etc/lms.yml``
-- ``/edx/etc/lms.yml``
-- ``/edx/etc/studio.yml``
 - ``/edx/etc/studio.yml``
 
 Changes to these files will *not* persist over a container restart, as they

--- a/README.rst
+++ b/README.rst
@@ -175,6 +175,7 @@ The default devstack services can be run by following the steps below. For analy
    (macOS only) Share the cloned service directories in Docker, using
    **Docker -> Preferences -> File Sharing** in the Docker menu.
 
+   .. _step 3:
 3. Pull any changes made to the various images on which the devstack depends.
 
    **NOTE:** These instructions will install the master release. If you want to install a named release instead (e.g. juniper.master), follow the steps in `How do I run the images for a named Open edX release?`_ before pulling the docker images.
@@ -477,13 +478,13 @@ Frequently Asked Questions
 
 How do I run the images for a named Open edX release?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-By default, the steps above will install the devstack using the master branch of all repos. If you want to install a named release instead, follow these steps before pulling the docker images in step 3 of the Getting Started guide:
+By default, the steps above will install the devstack using the master branch of all repos. If you want to install a named release instead, follow these steps before pulling the docker images in `step 3`_ of the Getting Started guide:
 
 #. Set the ``OPENEDX_RELEASE`` environment variable to the appropriate image
    tag; "hawthorn.master", "zebrawood.rc1", etc.  Note that unlike a server
    install, ``OPENEDX_RELEASE`` should not have the "open-release/" prefix.
 
-   **NOTE:** The ``COMPOSE_PROJECT_NAME`` variable is used to define Docker namespaced volumes and network based on this value, so changing it will give you a separate set of databases. This is handled for you automatically by setting the ``OPENEDX_RELEASE`` environment variable in ``options.mk`` (e.g. ``COMPOSE_PROJECT_NAME=devstack-juniper.master``. Should you want to manually override this edit the ``options.local.mk`` in the root of this repo and create the file if it does not exist. Change the devstack project name by adding the following line:
+   **NOTE:** The ``COMPOSE_PROJECT_NAME`` variable is used to define Docker namespaced volumes and network based on this value, so changing it will give you a separate set of databases. This is handled for you automatically by setting the ``OPENEDX_RELEASE`` environment variable in ``options.mk`` (e.g. ``COMPOSE_PROJECT_NAME=devstack-juniper.master``. Should you want to manually override this, edit the ``options.local.mk`` in the root of this repo and create the file if it does not exist. Change the devstack project name by adding the following line:
    ``COMPOSE_PROJECT_NAME=<your-alternate-devstack-name>`` (e.g. ``COMPOSE_PROJECT_NAME=secondarydevstack``)
 
    As a specific example, if ``OPENEDX_RELEASE`` is set in your environment as ``juniper.master``, then ``COMPOSE_PROJECT_NAME`` will default to ``devstack-juniper.master`` instead of ``devstack``.
@@ -492,7 +493,7 @@ By default, the steps above will install the devstack using the master branch of
 #. Use ``make dev.checkout`` to check out the correct branch in the local
    checkout of each service repository once you've set the ``OPENEDX_RELEASE``
    environment variable above.
-#. Continue with step 3 in the Getting Started guide to pull the correct docker images.
+#. Continue with `step 3`_ in the Getting Started guide to pull the correct docker images.
 
 All ``make`` target and ``docker-compose`` calls should now use the correct
 images until you change or unset ``OPENEDX_RELEASE`` again.  To work on the
@@ -503,10 +504,10 @@ How do I run multiple named Open edX releases on same machine?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 You can have multiple isolated Devstacks provisioned on a single computer now. Follow these directions **after installing the master release devstack** to switch between the named releases.
 
-#. If you haven't done so, follow the `Getting Started`_ guide to install the master devstack or any other named release. We recommend that you have at least one devstack on the master branch.
+#. If you haven't done so, follow the steps in the `Getting Started`_ section, to install the master devstack or any other named release. We recommend that you have at least one devstack on the master branch.
 #. Change directory to your devstack and activate the virtual env.
 #. Stop any running containers by issuing a ``make stop``. Make sure that all containers are stopped from the docker dashboard.
-#. Follow the steps in `Getting Started`_ section, setting the additional OPENEDX_RELEASE you want to install in step 2
+#. Follow the steps in `Getting Started`_ section again, setting the additional OPENEDX_RELEASE you want to install in step 2
 
 The implication of this is that you can switch between isolated Devstack databases by changing the value of the ``OPENEDX_RELEASE`` environment variable.
 
@@ -517,8 +518,7 @@ Switch between your Devstack releases by doing the following:
 #. Edit the project name in ``options.local.mk`` or set the ``OPENEDX_RELEASE`` environment variable and let the ``COMPOSE_PROJECT_NAME`` be assigned automatically. 
 #. Check out the appropriate branch in devstack, e.g. ``git checkout open-release/ironwood.master``
 #. Use ``make dev.checkout`` to check out the correct branch in the local
-   checkout of each service repository once you've set the ``OPENEDX_RELEASE``
-   environment variable above.
+   copy of each service repository
 #. Bring up the containers with ``make dev.up``, ``make dev.nfs.up`` or ``make dev.sync.up``.
 
 **NOTE:** Additional instructions on switching releases using ``direnv`` can be found in `How do I switch releases using 'direnv'?`_ section.

--- a/README.rst
+++ b/README.rst
@@ -177,6 +177,8 @@ The default devstack services can be run by following the steps below. For analy
 
 3. Pull any changes made to the various images on which the devstack depends.
 
+   **NOTE:** These instructions will install the master release. If you want to install a named release instead (e.g. juniper.master), follow the steps in `How do I run the images for a named Open edX release?`_ before pulling the docker images.
+   
    .. code:: sh
 
        make dev.pull
@@ -475,15 +477,22 @@ Frequently Asked Questions
 
 How do I run the images for a named Open edX release?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+By default, the steps above will install the devstack using the master branch of all repos. If you want to install a named release instead, follow these steps before pulling the docker images in step 3 of the Getting Started guide:
 
 #. Set the ``OPENEDX_RELEASE`` environment variable to the appropriate image
    tag; "hawthorn.master", "zebrawood.rc1", etc.  Note that unlike a server
    install, ``OPENEDX_RELEASE`` should not have the "open-release/" prefix.
+
+   **NOTE:** The ``COMPOSE_PROJECT_NAME`` variable is used to define Docker namespaced volumes and network based on this value, so changing it will give you a separate set of databases. This is handled for you automatically by setting the ``OPENEDX_RELEASE`` environment variable in ``options.mk`` (e.g. ``COMPOSE_PROJECT_NAME=devstack-juniper.master``. Should you want to manually override this edit the ``options.local.mk`` in the root of this repo and create the file if it does not exist. Change the devstack project name by adding the following line:
+   ``COMPOSE_PROJECT_NAME=<your-alternate-devstack-name>`` (e.g. ``COMPOSE_PROJECT_NAME=secondarydevstack``)
+
+   As a specific example, if ``OPENEDX_RELEASE`` is set in your environment as ``juniper.master``, then ``COMPOSE_PROJECT_NAME`` will default to ``devstack-juniper.master`` instead of ``devstack``.
+
 #. Check out the appropriate branch in devstack, e.g. ``git checkout open-release/ironwood.master``
 #. Use ``make dev.checkout`` to check out the correct branch in the local
    checkout of each service repository once you've set the ``OPENEDX_RELEASE``
    environment variable above.
-#. ``make dev.pull`` to get the correct images.
+#. Continue with step 3 in the Getting Started guide to pull the correct docker images.
 
 All ``make`` target and ``docker-compose`` calls should now use the correct
 images until you change or unset ``OPENEDX_RELEASE`` again.  To work on the
@@ -492,25 +501,25 @@ an empty string.
 
 How do I run multiple named Open edX releases on same machine?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-You can have multiple isolated Devstacks provisioned on a single computer now. Follow these directions to switch between the named releases.
+You can have multiple isolated Devstacks provisioned on a single computer now. Follow these directions **after installing the master release devstack** to switch between the named releases.
 
-#. Stop any running containers by issuing a ``make dev.stop``.
-#. The ``COMPOSE_PROJECT_NAME`` variable is used to define Docker namespaced volumes and network based on this value, so changing it will give you a separate set of databases. This is handled for you automatically by setting the ``OPENEDX_RELEASE`` environment variable in ``options.mk`` (e.g. ``COMPOSE_PROJECT_NAME=devstack-juniper.master``. Should you want to manually override this edit the ``options.local.mk`` in the root of this repo and create the file if it does not exist. Change the devstack project name by adding the following line:
-   ``COMPOSE_PROJECT_NAME=<your-alternate-devstack-name>`` (e.g. ``COMPOSE_PROJECT_NAME=secondarydevstack``)
-#. Perform steps in `How do I run the images for a named Open edX release?`_ for specific release.
-#. Follow the steps in `Getting Started`_ section to update requirements (e.g. ``make requirements``) and provision (e.g. ``make dev.provision``) the new named release containers.
-
-As a specific example, if ``OPENEDX_RELEASE`` is set in your environment as ``juniper.master``, then ``COMPOSE_PROJECT_NAME`` will default to ``devstack-juniper.master`` instead of ``devstack``.
+#. If you haven't done so, follow the `Getting Started`_ guide to install the master devstack or any other named release. We recommend that you have at least one devstack on the master branch.
+#. Change directory to your devstack and activate the virtual env.
+#. Stop any running containers by issuing a ``make stop``. Make sure that all containers are stopped from the docker dashboard.
+#. Follow the steps in `Getting Started`_ section, setting the additional OPENEDX_RELEASE you want to install in step 2
 
 The implication of this is that you can switch between isolated Devstack databases by changing the value of the ``OPENEDX_RELEASE`` environment variable.
 
 Switch between your Devstack releases by doing the following:
 *************************************************************
 
-#. Stop the containers by issuing a ``make dev.stop`` for the running release.
-#. Follow the instructions from the `How do I run multiple named Open edX releases on same machine?`_ section.
+#. Stop the containers by issuing a ``make stop`` for the running release.
 #. Edit the project name in ``options.local.mk`` or set the ``OPENEDX_RELEASE`` environment variable and let the ``COMPOSE_PROJECT_NAME`` be assigned automatically. 
-#. Bring up the containers with ``make dev.up``.
+#. Check out the appropriate branch in devstack, e.g. ``git checkout open-release/ironwood.master``
+#. Use ``make dev.checkout`` to check out the correct branch in the local
+   checkout of each service repository once you've set the ``OPENEDX_RELEASE``
+   environment variable above.
+#. Bring up the containers with ``make dev.up``, ``make dev.nfs.up`` or ``make dev.sync.up``.
 
 **NOTE:** Additional instructions on switching releases using ``direnv`` can be found in `How do I switch releases using 'direnv'?`_ section.
 


### PR DESCRIPTION
Update the instructions for installing multiple releases in one machine and switching among them.