### PR TITLE
fix mongodb error while provisioning devstack

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -167,7 +167,8 @@ docker-compose exec -T mysql57 bash -c "mysql -uroot mysql" < provision.sql
 # and create its users.
 if needs_mongo "$to_provision_ordered"; then
 	echo -e "${GREEN}Waiting for MongoDB...${NC}"
-	until docker-compose exec -T mongo bash -c 'mongo --eval "printjson(db.serverStatus())"' &> /dev/null
+	# mongo container and mongo process/shell inside the container
+	until docker-compose exec -T mongo mongo --eval "db.serverStatus()" &> /dev/null
 	do
 	  printf "."
 	  sleep 1

--- a/upgrade_mongo_3_6.sh
+++ b/upgrade_mongo_3_6.sh
@@ -14,7 +14,7 @@ make dev.up.mongo
 mongo_container="$(make -s dev.print-container.mongo)"
 
 echo -e "${GREEN}Waiting for MongoDB...${NC}"
-until docker exec "$mongo_container" bash -c 'mongo --eval \"printjson(db.serverStatus())\"' &> /dev/null
+until docker exec "$mongo_container" mongo --eval 'db.serverStatus()' &> /dev/null
 do
     if docker logs "$mongo_container" | grep -q "BadValue: Invalid value for version, found 3.6, expected '3.4' or '3.2'"; then
         echo -e "${YELLOW}Already upgraded to Mongo 3.6, exiting${NC}"
@@ -47,7 +47,7 @@ make dev.up.mongo
 mongo_container="$(make -s dev.print-container.mongo)"
 
 echo -e "${GREEN}Waiting for MongoDB...${NC}"
-until docker exec "$mongo_container" bash -c 'mongo --eval \"printjson(db.serverStatus())\"' &> /dev/null
+until docker exec "$mongo_container" mongo --eval 'db.serverStatus()' &> /dev/null
 do
     printf "."
     sleep 1


### PR DESCRIPTION
have been facing issues while performing `make dev.provision` and running `upgrade_mongo_3_6.sh` (to migrate 3.4 mongodb to 3.6),
I got this output while running without `/dev/null`

```
▶ docker exec 9c418d58eeb804d5eaec10f9d1c929a51fa1cddb9cfa6812cb9e93f3360e676c bash -c 'mongo --eval \"printjson(db.serverStatus())\"'
bash: -c: line 0: syntax error near unexpected token `('
bash: -c: line 0: `mongo --eval \"printjson(db.serverStatus())\"'
```
I updated the script to directly use mongo shell.