### PR TITLE
load-db.sh should load the mysql snapshot into the mysql 5.7 container

### DIFF
--- a/load-db.sh
+++ b/load-db.sh
@@ -17,6 +17,6 @@ then
 fi
 
 echo "Loading the $1 database..."
-mysql_container=$(make -s dev.print-container.mysql)
+mysql_container=$(make -s dev.print-container.mysql57)
 docker exec -i "$mysql_container" mysql -uroot $1 < $1.sql
 echo "Finished loading the $1 database!"


### PR DESCRIPTION
If you attempt to upgrade edxapp to mysql 5.7, one of the steps is `make dev.provision.lms`, which will end up running `./load-db.sh edxapp`.  Without this change, that'll run against the old mysql 5.6 container, blowing away the presumably good state that you'd like to transfer over to your new mysql 5.7 container/volume.