### PR TITLE
Update instructions on how to enable comprehensive theming for devstack.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -781,7 +781,7 @@ Make sure that you enable the following code in ./edx-platform/lms/envs/devstack
    ENABLE_COMPREHENSIVE_THEMING = True
    COMPREHENSIVE_THEME_DIRS = [
        "/edx/app/edxapp/edx-platform/themes/",
-       "/edx/app/edx-themes"
+       "/edx/app/edx-themes/edx-platform/"
    ]
    TEMPLATES[1]["DIRS"] = _make_mako_template_dirs
    derive_settings(__name__)


### PR DESCRIPTION
The theme directory path for `/edx/app/edx-themes/` didn't include the `/edx-platform/` directory and was throwing an error that it couldn't find my theme. This path update should fix that.

Update for https://github.com/edx/devstack/pull/654