### PR TITLE
Drop python 3.5 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: required
 language: python
 
 python:
-  - 3.5
   - 3.8
 
 branches:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,33 +4,72 @@
 #
 #    make upgrade
 #
-attrs==20.3.0             # via jsonschema
-bcrypt==3.1.7             # via paramiko
-cached-property==1.5.2    # via docker-compose
-certifi==2020.12.5        # via requests
-cffi==1.14.4              # via bcrypt, cryptography, pynacl
-chardet==4.0.0            # via requests
-cryptography==3.2.1       # via paramiko
-distro==1.5.0             # via docker-compose
-docker-compose==1.27.4    # via -r requirements/base.in
-docker[ssh]==4.4.1        # via docker-compose
-dockerpty==0.4.1          # via docker-compose
-docopt==0.6.2             # via docker-compose
-idna==2.10                # via requests
-importlib-metadata==2.1.1  # via jsonschema
-jsonschema==3.2.0         # via docker-compose
-paramiko==2.7.2           # via docker
-pycparser==2.20           # via cffi
-pynacl==1.4.0             # via paramiko
-pyrsistent==0.17.3        # via jsonschema
-python-dotenv==0.15.0     # via docker-compose
-pyyaml==5.3.1             # via -r requirements/base.in, docker-compose
-requests==2.25.1          # via docker, docker-compose
-six==1.15.0               # via bcrypt, cryptography, docker, dockerpty, jsonschema, pynacl, websocket-client
-texttable==1.6.3          # via docker-compose
-urllib3==1.26.2           # via requests
-websocket-client==0.57.0  # via docker, docker-compose
-zipp==1.2.0               # via importlib-metadata
+attrs==20.3.0
+    # via jsonschema
+bcrypt==3.2.0
+    # via paramiko
+cached-property==1.5.2
+    # via docker-compose
+certifi==2020.12.5
+    # via requests
+cffi==1.14.4
+    # via
+    #   bcrypt
+    #   cryptography
+    #   pynacl
+chardet==4.0.0
+    # via requests
+cryptography==3.3.1
+    # via paramiko
+distro==1.5.0
+    # via docker-compose
+docker-compose==1.28.2
+    # via -r requirements/base.in
+docker[ssh]==4.4.1
+    # via docker-compose
+dockerpty==0.4.1
+    # via docker-compose
+docopt==0.6.2
+    # via docker-compose
+idna==2.10
+    # via requests
+jsonschema==3.2.0
+    # via docker-compose
+paramiko==2.7.2
+    # via docker
+pycparser==2.20
+    # via cffi
+pynacl==1.4.0
+    # via paramiko
+pyrsistent==0.17.3
+    # via jsonschema
+python-dotenv==0.15.0
+    # via docker-compose
+pyyaml==5.4.1
+    # via
+    #   -r requirements/base.in
+    #   docker-compose
+requests==2.25.1
+    # via
+    #   docker
+    #   docker-compose
+six==1.15.0
+    # via
+    #   bcrypt
+    #   cryptography
+    #   docker
+    #   dockerpty
+    #   jsonschema
+    #   pynacl
+    #   websocket-client
+texttable==1.6.3
+    # via docker-compose
+urllib3==1.26.3
+    # via requests
+websocket-client==0.57.0
+    # via
+    #   docker
+    #   docker-compose
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,47 +4,148 @@
 #
 #    make upgrade
 #
-appdirs==1.4.4            # via virtualenv
-attrs==20.3.0             # via -r requirements/base.txt, jsonschema
-bcrypt==3.1.7             # via -r requirements/base.txt, paramiko
-cached-property==1.5.2    # via -r requirements/base.txt, docker-compose
-certifi==2020.12.5        # via -r requirements/base.txt, requests
-cffi==1.14.4              # via -r requirements/base.txt, bcrypt, cryptography, pynacl
-chardet==4.0.0            # via -r requirements/base.txt, requests
-click==7.1.2              # via -r requirements/pip-tools.txt, pip-tools
-cryptography==3.2.1       # via -r requirements/base.txt, paramiko
-distlib==0.3.1            # via virtualenv
-distro==1.5.0             # via -r requirements/base.txt, docker-compose
-docker-compose==1.27.4    # via -r requirements/base.txt
-docker[ssh]==4.4.1        # via -r requirements/base.txt, docker-compose
-dockerpty==0.4.1          # via -r requirements/base.txt, docker-compose
-docopt==0.6.2             # via -r requirements/base.txt, docker-compose
-filelock==3.0.12          # via tox, virtualenv
-idna==2.10                # via -r requirements/base.txt, requests
-importlib-metadata==2.1.1  # via -r requirements/base.txt, jsonschema, pluggy, tox, virtualenv
-importlib-resources==3.2.1  # via virtualenv
-jsonschema==3.2.0         # via -r requirements/base.txt, docker-compose
-packaging==20.8           # via tox
-paramiko==2.7.2           # via -r requirements/base.txt, docker
-pip-tools==5.5.0          # via -r requirements/pip-tools.txt
-pluggy==0.13.1            # via tox
-py==1.10.0                # via tox
-pycparser==2.20           # via -r requirements/base.txt, cffi
-pynacl==1.4.0             # via -r requirements/base.txt, paramiko
-pyparsing==2.4.7          # via packaging
-pyrsistent==0.17.3        # via -r requirements/base.txt, jsonschema
-python-dotenv==0.15.0     # via -r requirements/base.txt, docker-compose
-pyyaml==5.3.1             # via -r requirements/base.txt, docker-compose
-requests==2.25.1          # via -r requirements/base.txt, docker, docker-compose
-six==1.15.0               # via -r requirements/base.txt, bcrypt, cryptography, docker, dockerpty, jsonschema, pynacl, tox, virtualenv, websocket-client
-texttable==1.6.3          # via -r requirements/base.txt, docker-compose
-toml==0.10.2              # via tox
-tox-battery==0.6.1        # via -r requirements/dev.in
-tox==3.20.1               # via -r requirements/dev.in, tox-battery
-urllib3==1.26.2           # via -r requirements/base.txt, requests
-virtualenv==20.2.2        # via tox
-websocket-client==0.57.0  # via -r requirements/base.txt, docker, docker-compose
-zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata, importlib-resources
+appdirs==1.4.4
+    # via virtualenv
+attrs==20.3.0
+    # via
+    #   -r requirements/base.txt
+    #   jsonschema
+bcrypt==3.2.0
+    # via
+    #   -r requirements/base.txt
+    #   paramiko
+cached-property==1.5.2
+    # via
+    #   -r requirements/base.txt
+    #   docker-compose
+certifi==2020.12.5
+    # via
+    #   -r requirements/base.txt
+    #   requests
+cffi==1.14.4
+    # via
+    #   -r requirements/base.txt
+    #   bcrypt
+    #   cryptography
+    #   pynacl
+chardet==4.0.0
+    # via
+    #   -r requirements/base.txt
+    #   requests
+click==7.1.2
+    # via
+    #   -r requirements/pip-tools.txt
+    #   pip-tools
+cryptography==3.3.1
+    # via
+    #   -r requirements/base.txt
+    #   paramiko
+distlib==0.3.1
+    # via virtualenv
+distro==1.5.0
+    # via
+    #   -r requirements/base.txt
+    #   docker-compose
+docker-compose==1.28.2
+    # via -r requirements/base.txt
+docker[ssh]==4.4.1
+    # via
+    #   -r requirements/base.txt
+    #   docker-compose
+dockerpty==0.4.1
+    # via
+    #   -r requirements/base.txt
+    #   docker-compose
+docopt==0.6.2
+    # via
+    #   -r requirements/base.txt
+    #   docker-compose
+filelock==3.0.12
+    # via
+    #   tox
+    #   virtualenv
+idna==2.10
+    # via
+    #   -r requirements/base.txt
+    #   requests
+jsonschema==3.2.0
+    # via
+    #   -r requirements/base.txt
+    #   docker-compose
+packaging==20.8
+    # via tox
+paramiko==2.7.2
+    # via
+    #   -r requirements/base.txt
+    #   docker
+pip-tools==5.5.0
+    # via -r requirements/pip-tools.txt
+pluggy==0.13.1
+    # via tox
+py==1.10.0
+    # via tox
+pycparser==2.20
+    # via
+    #   -r requirements/base.txt
+    #   cffi
+pynacl==1.4.0
+    # via
+    #   -r requirements/base.txt
+    #   paramiko
+pyparsing==2.4.7
+    # via packaging
+pyrsistent==0.17.3
+    # via
+    #   -r requirements/base.txt
+    #   jsonschema
+python-dotenv==0.15.0
+    # via
+    #   -r requirements/base.txt
+    #   docker-compose
+pyyaml==5.4.1
+    # via
+    #   -r requirements/base.txt
+    #   docker-compose
+requests==2.25.1
+    # via
+    #   -r requirements/base.txt
+    #   docker
+    #   docker-compose
+six==1.15.0
+    # via
+    #   -r requirements/base.txt
+    #   bcrypt
+    #   cryptography
+    #   docker
+    #   dockerpty
+    #   jsonschema
+    #   pynacl
+    #   tox
+    #   virtualenv
+    #   websocket-client
+texttable==1.6.3
+    # via
+    #   -r requirements/base.txt
+    #   docker-compose
+toml==0.10.2
+    # via tox
+tox-battery==0.6.1
+    # via -r requirements/dev.in
+tox==3.21.3
+    # via
+    #   -r requirements/dev.in
+    #   tox-battery
+urllib3==1.26.3
+    # via
+    #   -r requirements/base.txt
+    #   requests
+virtualenv==20.4.0
+    # via tox
+websocket-client==0.57.0
+    # via
+    #   -r requirements/base.txt
+    #   docker
+    #   docker-compose
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,59 +4,183 @@
 #
 #    make upgrade
 #
-alabaster==0.7.12         # via sphinx
-attrs==20.3.0             # via -r requirements/base.txt, jsonschema
-babel==2.9.0              # via sphinx
-bcrypt==3.1.7             # via -r requirements/base.txt, paramiko
-bleach==3.2.1             # via readme-renderer
-cached-property==1.5.2    # via -r requirements/base.txt, docker-compose
-certifi==2020.12.5        # via -r requirements/base.txt, requests
-cffi==1.14.4              # via -r requirements/base.txt, bcrypt, cryptography, pynacl
-chardet==4.0.0            # via -r requirements/base.txt, doc8, requests
-cryptography==3.2.1       # via -r requirements/base.txt, paramiko
-distro==1.5.0             # via -r requirements/base.txt, docker-compose
-doc8==0.8.1               # via -r requirements/doc.in
-docker-compose==1.27.4    # via -r requirements/base.txt
-docker[ssh]==4.4.1        # via -r requirements/base.txt, docker-compose
-dockerpty==0.4.1          # via -r requirements/base.txt, docker-compose
-docopt==0.6.2             # via -r requirements/base.txt, docker-compose
-docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
-edx-sphinx-theme==1.6.0   # via -r requirements/doc.in
-idna==2.10                # via -r requirements/base.txt, requests
-imagesize==1.2.0          # via sphinx
-importlib-metadata==2.1.1  # via -r requirements/base.txt, jsonschema
-jinja2==2.11.2            # via sphinx
-jsonschema==3.2.0         # via -r requirements/base.txt, docker-compose
-markupsafe==1.1.1         # via jinja2
-packaging==20.8           # via bleach, sphinx
-paramiko==2.7.2           # via -r requirements/base.txt, docker
-pbr==5.5.1                # via stevedore
-pycparser==2.20           # via -r requirements/base.txt, cffi
-pygments==2.7.3           # via doc8, readme-renderer, sphinx
-pynacl==1.4.0             # via -r requirements/base.txt, paramiko
-pyparsing==2.4.7          # via packaging
-pyrsistent==0.17.3        # via -r requirements/base.txt, jsonschema
-python-dotenv==0.15.0     # via -r requirements/base.txt, docker-compose
-pytz==2020.5              # via babel
-pyyaml==5.3.1             # via -r requirements/base.txt, docker-compose
-readme-renderer==28.0     # via -r requirements/doc.in
-requests==2.25.1          # via -r requirements/base.txt, docker, docker-compose, sphinx
-restructuredtext-lint==1.3.2  # via doc8
-six==1.15.0               # via -r requirements/base.txt, bcrypt, bleach, cryptography, doc8, docker, dockerpty, edx-sphinx-theme, jsonschema, pynacl, readme-renderer, stevedore, websocket-client
-snowballstemmer==2.0.0    # via sphinx
-sphinx==3.4.2             # via -r requirements/doc.in, edx-sphinx-theme
-sphinxcontrib-applehelp==1.0.2  # via sphinx
-sphinxcontrib-devhelp==1.0.2  # via sphinx
-sphinxcontrib-htmlhelp==1.0.3  # via sphinx
-sphinxcontrib-jsmath==1.0.1  # via sphinx
-sphinxcontrib-qthelp==1.0.3  # via sphinx
-sphinxcontrib-serializinghtml==1.1.4  # via sphinx
-stevedore==1.32.0         # via doc8
-texttable==1.6.3          # via -r requirements/base.txt, docker-compose
-urllib3==1.26.2           # via -r requirements/base.txt, requests
-webencodings==0.5.1       # via bleach
-websocket-client==0.57.0  # via -r requirements/base.txt, docker, docker-compose
-zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata
+alabaster==0.7.12
+    # via sphinx
+attrs==20.3.0
+    # via
+    #   -r requirements/base.txt
+    #   jsonschema
+babel==2.9.0
+    # via sphinx
+bcrypt==3.2.0
+    # via
+    #   -r requirements/base.txt
+    #   paramiko
+bleach==3.2.3
+    # via readme-renderer
+cached-property==1.5.2
+    # via
+    #   -r requirements/base.txt
+    #   docker-compose
+certifi==2020.12.5
+    # via
+    #   -r requirements/base.txt
+    #   requests
+cffi==1.14.4
+    # via
+    #   -r requirements/base.txt
+    #   bcrypt
+    #   cryptography
+    #   pynacl
+chardet==4.0.0
+    # via
+    #   -r requirements/base.txt
+    #   doc8
+    #   requests
+cryptography==3.3.1
+    # via
+    #   -r requirements/base.txt
+    #   paramiko
+distro==1.5.0
+    # via
+    #   -r requirements/base.txt
+    #   docker-compose
+doc8==0.8.1
+    # via -r requirements/doc.in
+docker-compose==1.28.2
+    # via -r requirements/base.txt
+docker[ssh]==4.4.1
+    # via
+    #   -r requirements/base.txt
+    #   docker-compose
+dockerpty==0.4.1
+    # via
+    #   -r requirements/base.txt
+    #   docker-compose
+docopt==0.6.2
+    # via
+    #   -r requirements/base.txt
+    #   docker-compose
+docutils==0.16
+    # via
+    #   doc8
+    #   readme-renderer
+    #   restructuredtext-lint
+    #   sphinx
+edx-sphinx-theme==1.6.1
+    # via -r requirements/doc.in
+idna==2.10
+    # via
+    #   -r requirements/base.txt
+    #   requests
+imagesize==1.2.0
+    # via sphinx
+jinja2==2.11.2
+    # via sphinx
+jsonschema==3.2.0
+    # via
+    #   -r requirements/base.txt
+    #   docker-compose
+markupsafe==1.1.1
+    # via jinja2
+packaging==20.8
+    # via
+    #   bleach
+    #   sphinx
+paramiko==2.7.2
+    # via
+    #   -r requirements/base.txt
+    #   docker
+pbr==5.5.1
+    # via stevedore
+pycparser==2.20
+    # via
+    #   -r requirements/base.txt
+    #   cffi
+pygments==2.7.4
+    # via
+    #   doc8
+    #   readme-renderer
+    #   sphinx
+pynacl==1.4.0
+    # via
+    #   -r requirements/base.txt
+    #   paramiko
+pyparsing==2.4.7
+    # via packaging
+pyrsistent==0.17.3
+    # via
+    #   -r requirements/base.txt
+    #   jsonschema
+python-dotenv==0.15.0
+    # via
+    #   -r requirements/base.txt
+    #   docker-compose
+pytz==2020.5
+    # via babel
+pyyaml==5.4.1
+    # via
+    #   -r requirements/base.txt
+    #   docker-compose
+readme-renderer==28.0
+    # via -r requirements/doc.in
+requests==2.25.1
+    # via
+    #   -r requirements/base.txt
+    #   docker
+    #   docker-compose
+    #   sphinx
+restructuredtext-lint==1.3.2
+    # via doc8
+six==1.15.0
+    # via
+    #   -r requirements/base.txt
+    #   bcrypt
+    #   bleach
+    #   cryptography
+    #   doc8
+    #   docker
+    #   dockerpty
+    #   edx-sphinx-theme
+    #   jsonschema
+    #   pynacl
+    #   readme-renderer
+    #   websocket-client
+snowballstemmer==2.1.0
+    # via sphinx
+sphinx==3.4.3
+    # via
+    #   -r requirements/doc.in
+    #   edx-sphinx-theme
+sphinxcontrib-applehelp==1.0.2
+    # via sphinx
+sphinxcontrib-devhelp==1.0.2
+    # via sphinx
+sphinxcontrib-htmlhelp==1.0.3
+    # via sphinx
+sphinxcontrib-jsmath==1.0.1
+    # via sphinx
+sphinxcontrib-qthelp==1.0.3
+    # via sphinx
+sphinxcontrib-serializinghtml==1.1.4
+    # via sphinx
+stevedore==3.3.0
+    # via doc8
+texttable==1.6.3
+    # via
+    #   -r requirements/base.txt
+    #   docker-compose
+urllib3==1.26.3
+    # via
+    #   -r requirements/base.txt
+    #   requests
+webencodings==0.5.1
+    # via bleach
+websocket-client==0.57.0
+    # via
+    #   -r requirements/base.txt
+    #   docker
+    #   docker-compose
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,8 +4,10 @@
 #
 #    make upgrade
 #
-click==7.1.2              # via pip-tools
-pip-tools==5.5.0          # via -r requirements/pip-tools.in
+click==7.1.2
+    # via pip-tools
+pip-tools==5.5.0
+    # via -r requirements/pip-tools.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip


### PR DESCRIPTION
**Issue:** [BOM-2273](https://openedx.atlassian.net/browse/BOM-2273)

### Description
- `Python3.5` tests are not required anymore so removed `Python3.5` from `Travis`.