### PR TITLE
Fix NFS issues for Mac version Catalina and up

### DIFF
--- a/setup_native_nfs_docker_osx.sh
+++ b/setup_native_nfs_docker_osx.sh
@@ -4,6 +4,8 @@
 #
 
 OS=`uname -s`
+MAC_VERSION=`sw_vers -productVersion | awk -F. '{ printf "%s.%s", $1, $2; }'`;
+CATALINA_VERSION="10.15";
 
 if [ $OS != "Darwin" ]; then
   echo "This script is OSX-only. Please do not run it on any other Unix."
@@ -52,7 +54,14 @@ G=`id -g`
 sudo chown -R "$U":"$G" .
 
 echo "== Setting up nfs..."
-LINE="/Users -alldirs -mapall=$U:$G localhost"
+
+# From catalina the directory has changed.
+if (( $(echo "$MAC_VERSION < $CATALINA_VERSION" |bc -l) )); then
+  LINE="/Users -alldirs -mapall=$U:$G localhost"
+else
+  LINE="/System/Volumes/Data -alldirs -mapall=$U:$G localhost"
+fi
+
 FILE=/etc/exports
 grep -xqF -- "$LINE" "$FILE" || sudo echo "$LINE" | sudo tee -a $FILE > /dev/null
 


### PR DESCRIPTION
## Description
Mac native NFS setup script is broken from Mac version Catalina and up. It is due to the change in the volume directory path. 

This PR is backward compatible. All versions before Catalina will be using ``/Users`` and from Catalina ``/System/Volumes/Data`` will be used.

## Supporting information
There was an attempt to fix that issue via https://github.com/edx/devstack/pull/521. But that PR seems to be closed without merging.

## Testing instructions
1. Pull this PR in a Mac Catalina or Big Sur
2. Try to setup NFS. It should work.
3. Setting up NFS should work across all versions of Mac.
