### PR TITLE
docs: Adding more docs on useful commands in readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 #     make dev.pull.registrar+studio
 #     make dev.up.lms
 #     make dev.up.without-deps.lms+forum+discovery+mysql+elasticsearch+memcached
-#     make dev.restart.mysql+lms
+#     make dev.restart-container.mysql+lms
 
 # There are also "prefix-form" targets, which are simply an alternate way to spell
 # the 'dev.' targets.

--- a/README.rst
+++ b/README.rst
@@ -379,8 +379,77 @@ Alternatively, you can run these by modifying the ``DEFAULT_SERVICES`` option as
 .. _course-authoring: https://github.com/edx/frontend-app-course-authoring
 .. _xqueue: https://github.com/edx/xqueue
 
-Useful Commands
----------------
+Devstack Interface
+------------------
+
+Devstack comes built in with many useful make commands that act as an user interface. This UI is essentially a make wrapper around docker-compose commands. We attempt to give a short summary of what the make commands do below, but it would be a good idea for you to familiarize yourself with some knowledge of docker-compose.
+
+Due to the organic nature of how this user interface came into being, there are often multiple ways to do the same thing. The two main variants of commands are of the form: ``dev.ACTION.SERVICE`` vs ``SERVICE-ACTION``. The ``SERVICE-ACTION`` variant tends to be more automatic command-completion friendly.
+
+Examples:
+
+.. code:: sh
+
+    make dev.up.registrar
+    make registrar-up
+
+    make dev.shell.lms
+    make lms-shell
+
+    make dev.logs.gradebook
+    make gradebook-logs
+
+The user interface for devstack often also gives you both big hammers(``make dev.pull``) and small hammers(``make dev.pull.<service>``) to do things. It is recommend you opt for the small hammer commands, because they often tend to be alot faster.
+
+Useful Commands and Summary
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- dev.pull.<service> - Pull latest Docker images required by default services
+  This will pull all the images necessary to run <service>. The setting for which images are pulled can be found in the docker-compose.yml.
+  When you are working on a specific service, it is recommended you use this command to pull only images necessary for your service i.e if working in lms, use ``make dev.pull.lms`` to update images for lms and its dependencies
+
+  variation: ``make dev.pull`` or ``make pull`` will pull all images supported in default devstack TODO(jinder): fix this wording
+
+  variation: ``make dev.pull.<service1>+<service2>`` will pull images for <service1>, <service2>, and their dependencies
+
+- dev.up.<service> - Create and start containers. i.e. brings up the <service> container and its dependencies
+
+  When you are working on a specific service, it is recommended you use this command to bring up the necessary containers for your service i.e if working in lms, use ``make dev.up.lms`` to bring up containers for lms and its dependencies
+
+  variation: ``make dev.up`` or ``make up`` will bring up containers for everything in default devstack
+
+  variation: ``make dev.pull.<service1>+<service2>`` will pull images for <service1>, <service2>, and their dependencies
+
+- dev.stop: only stops the container
+  TODO(jinder) what does that mean
+  When to use: When you are stopping working on devstack and want to pick back up from where you left off. Next time you use dev.up to bring up containers, you should be able to mostly pick back up from where you started. TODO(jinder): verify how true this is. TODO(reviewer): Is this true in your experience.
+
+- dev.down.<container>: stops the specified container and also removes the stopped containers as well as any networks that were created. Next time you use dev.up to bring up container, your container have reverted back to the pulled image.  This will not affect content of the databases.
+
+  When to use: use this command only if you are okay with removing any changes you might have made to the container
+
+  Variation: ``make dev.down`` will stop all your containers
+
+- dev.shell.<service>: used to enter the shell of a service. You can use this to for: upgrading python packages, running migrations, any shell commands you want to run on the running service
+
+  Variation: ``make <service>-shell``
+
+- dev.attach.<container>: dev.up is setup to bring up the container/service in the backgroud. This attaches the container to your shell. This is used to see logs and to enter debugger if you put a breakpoint somewhere in your code. Do not use this command if you just want to see the logs for your service: use dev.log.<service>
+
+  Variation: ``make <service>-shell``
+
+- dev.logs.<container>: View the logs of the specified service <container>
+
+  Variation: ``make dev.logs`` to view logs for all running containers. This is likely very overwhelming.
+
+  Variation: ``make <container>-logs``
+
+- dev.restart-container.<container> - restarts container. TODO(jinder): change any references to this in documentation
+  Note: this will only restart <container> and not its dependencies
+  When to use: TODO
+
+  Variation: ``make dev.restart-container.<container1>+<container2>`` will restart both <container1> and <container2>
+  TODO(jinder): figure out an use case for this
 
 Abbreviated versions of commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -451,69 +451,6 @@ Useful Commands and Summary
   Variation: ``make dev.restart-container.<container1>+<container2>`` will restart both <container1> and <container2>
   TODO(jinder): figure out an use case for this
 
-Abbreviated versions of commands
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-You may notice that many Devstack commands come in the form ``dev.ACTION.SERVICE``.
-As examples:
-
-.. code:: sh
-
-    make dev.up.registrar
-    make dev.shell.lms
-    make dev.attach.studio
-    make dev.down.credentials
-    make dev.migrate.edx_notes_api
-    make dev.static.ecommerce
-    make dev.restart-devserver.forum
-    make dev.logs.gradebook
-
-In general, these commands can also be given in the form ``SERVICE-ACTION``,
-which saves some keystrokes and is often more friendly for automatic command-completion
-by hitting TAB. As examples:
-
-.. code:: sh
-
-    make registrar-up
-    make lms-shell
-    make studio-attach
-    make credentials-down
-    make edx_notes_api-migrate
-    make ecommerce-static
-    make forum-restart-devserver
-    make gradebook-logs
-
-Bringing up fewer services
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-``make dev.up`` can take a long time, as it starts all services, whether or not
-you need them. To instead only start a single service and its dependencies, run
-``make dev.up.<services>``. For example:
-
-.. code:: sh
-
-    make dev.up.lms
-
-That above command will bring up LMS (along with Memcached, MySQL, DevPI, et al), but it will not bring up
-Credentials, Studio, or E-Commerce or any of the other default services.
-
-You can also specify multiple services:
-
-.. code:: sh
-
-    make dev.up.ecommerce+studio
-
-Pulling fewer images
-~~~~~~~~~~~~~~~~~~~~
-
-Similarly, ``make dev.pull`` can take a long time, as it pulls all services' images,
-whether or not you need them.
-To instead only pull images required by your service and its dependencies,
-run ``make dev.pull.<services>``. For example:
-
-.. code:: sh
-
-    make dev.pull.discovery
 
 Restarting servers and containers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,7 @@ Where to Find Help
 There are a number of places to get help, including mailing lists and real-time chat. Please choose an appropriate venue for your question. This helps ensure that you get good prompt advice, and keeps discussion focused. For details of your options, see the `Community`_ pages.
 
 - See the `most common development workflow`_ (after you've finished `Getting Started`_).
+- See the `Devstack Interface`_
 - See some `helpful troubleshooting tips`_.
 - See the `Frequently Asked Questions`_.
 - Or learn about `testing and debugging your code in devstack`_.
@@ -64,6 +65,7 @@ There are a number of places to get help, including mailing lists and real-time 
 You can also browse all the documentation in `Read the Docs`_.
 
 .. _most common development workflow: https://edx.readthedocs.io/projects/open-edx-devstack/en/latest/workflow.html
+.. _Devstack Interface: https://edx.readthedocs.io/projects/open-edx-devstack/en/latest/devstack_interface.html
 .. _helpful troubleshooting tips: https://edx.readthedocs.io/projects/open-edx-devstack/en/latest/troubleshoot_general_tips.html
 .. _Frequently Asked Questions: https://edx.readthedocs.io/projects/open-edx-devstack/en/latest/devstack_faq.html
 .. _testing and debugging your code in devstack:

--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,6 @@ Table of Contents
 * `Getting Started`_
 * `Usernames and Passwords`_
 * `Service List`_
-* `Useful Commands`_
 * `Known Issues`_
 * `Advanced Configuration Options`_
 
@@ -379,96 +378,6 @@ Alternatively, you can run these by modifying the ``DEFAULT_SERVICES`` option as
 .. _course-authoring: https://github.com/edx/frontend-app-course-authoring
 .. _xqueue: https://github.com/edx/xqueue
 
-Devstack Interface
-------------------
-
-Devstack comes built in with many useful make commands that act as an user interface. This UI is essentially a make wrapper around docker-compose commands. We attempt to give a short summary of what the make commands do below, but it would be a good idea for you to familiarize yourself with some knowledge of docker-compose.
-
-Due to the organic nature of how this user interface came into being, there are often multiple ways to do the same thing. The two main variants of commands are of the form: ``dev.ACTION.SERVICE`` vs ``SERVICE-ACTION``. The ``SERVICE-ACTION`` variant tends to be more automatic command-completion friendly.
-
-Examples:
-
-.. code:: sh
-
-    make dev.up.registrar
-    make registrar-up
-
-    make dev.shell.lms
-    make lms-shell
-
-    make dev.logs.gradebook
-    make gradebook-logs
-
-The user interface for devstack often also gives you both big hammers(``make dev.pull``) and small hammers(``make dev.pull.<service>``) to do things. It is recommend you opt for the small hammer commands, because they often tend to be alot faster.
-
-Useful Commands and Summary
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-- dev.pull.<service> - Pull latest Docker images required by default services
-  This will pull all the images necessary to run <service>. The setting for which images are pulled can be found in the docker-compose.yml.
-  When you are working on a specific service, it is recommended you use this command to pull only images necessary for your service i.e if working in lms, use ``make dev.pull.lms`` to update images for lms and its dependencies
-
-  variation: ``make dev.pull`` or ``make pull`` will pull all images supported in default devstack TODO(jinder): fix this wording
-
-  variation: ``make dev.pull.<service1>+<service2>`` will pull images for <service1>, <service2>, and their dependencies
-
-- dev.up.<service> - Create and start containers. i.e. brings up the <service> container and its dependencies
-
-  When you are working on a specific service, it is recommended you use this command to bring up the necessary containers for your service i.e if working in lms, use ``make dev.up.lms`` to bring up containers for lms and its dependencies
-
-  variation: ``make dev.up`` or ``make up`` will bring up containers for everything in default devstack
-
-  variation: ``make dev.pull.<service1>+<service2>`` will pull images for <service1>, <service2>, and their dependencies
-
-- dev.stop: only stops the container
-  TODO(jinder) what does that mean
-  When to use: When you are stopping working on devstack and want to pick back up from where you left off. Next time you use dev.up to bring up containers, you should be able to mostly pick back up from where you started. TODO(jinder): verify how true this is. TODO(reviewer): Is this true in your experience.
-
-- dev.down.<container>: stops the specified container and also removes the stopped containers as well as any networks that were created. Next time you use dev.up to bring up container, your container have reverted back to the pulled image.  This will not affect content of the databases.
-
-  When to use: use this command only if you are okay with removing any changes you might have made to the container
-
-  Variation: ``make dev.down`` will stop all your containers
-
-- dev.shell.<service>: used to enter the shell of a service. You can use this to for: upgrading python packages, running migrations, any shell commands you want to run on the running service
-
-  Variation: ``make <service>-shell``
-
-- dev.attach.<container>: dev.up is setup to bring up the container/service in the backgroud. This attaches the container to your shell. This is used to see logs and to enter debugger if you put a breakpoint somewhere in your code. Do not use this command if you just want to see the logs for your service: use dev.log.<service>
-
-  Variation: ``make <service>-shell``
-
-- dev.logs.<container>: View the logs of the specified service <container>
-
-  Variation: ``make dev.logs`` to view logs for all running containers. This is likely very overwhelming.
-
-  Variation: ``make <container>-logs``
-
-- dev.restart-container.<container> - restarts container. TODO(jinder): change any references to this in documentation
-  Note: this will only restart <container> and not its dependencies
-  When to use: TODO
-
-  Variation: ``make dev.restart-container.<container1>+<container2>`` will restart both <container1> and <container2>
-  TODO(jinder): figure out an use case for this
-
-
-Restarting servers and containers
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Sometimes you may need to manually restart a particular application server To do so,
-the quickest command to run is ``make dev.restart-devserver.<service>``, which restarts the Django/Sinatra server inside the container without restarting the container itself. For example:
-
-.. code:: sh
-
-    make dev.restart-devserver.credentials
-
-This can be helpful, for example, if automatic code reloading isn't working for some reason.
-
-If you wish to restart the *container itself*, which takes a bit longer but may resolve a larger class of issues, use ``make dev.restart-container.<services>``. For example:
-
-.. code:: sh
-
-    make dev.restart-container.credentials
 
 Known Issues
 ------------

--- a/docs/devstack_interface.rst
+++ b/docs/devstack_interface.rst
@@ -31,7 +31,7 @@ Useful Commands and Summary
 
   Variations:
 
-  +  ``make dev.pull`` or ``make pull`` will pull all images in the default devstack.
+  + ``make dev.pull`` or ``make pull`` will pull all images in the default devstack.
 
     When to use: Probably only when you are first setting up devstack. Do not use this often. This will take a lot of time.
 

--- a/docs/devstack_interface.rst
+++ b/docs/devstack_interface.rst
@@ -49,7 +49,7 @@ Useful Commands and Summary
 
   + ``make dev.up`` or ``make up`` will bring up containers for *everything* in default devstack
 
-  + ``make dev.up.<service1>+<service2>`` will pull images for <service1>, <service2>, and their dependencies
+  + ``make dev.up.<service1>+<service2>`` will bring up <service1>, <service2>, and their dependencies
 
   + ``make dev.up.without-deps.<service>`` will only bring up the <service> container
 

--- a/docs/devstack_interface.rst
+++ b/docs/devstack_interface.rst
@@ -28,6 +28,7 @@ Useful Commands and Summary
 - ``dev.pull.<service>`` - Pull latest Docker images for the service and its dependencies
 
   When to use: When you only want to update images for a subset of devstack. Such as when you are only working on lms, use ``make dev.pull.lms`` to pull images for lms and it dependencies
+  Variations:
 
   + Variation: ``make dev.pull`` or ``make pull`` will pull all images in the default devstack.
 

--- a/docs/devstack_interface.rst
+++ b/docs/devstack_interface.rst
@@ -61,7 +61,7 @@ Useful Commands and Summary
 
   When to use: When you are pausing your work on this container/devstack and you want to pick back up from where you left off. Next time you use dev.up to bring up containers, you should be able to mostly pick back up from where you started.  TODO(reviewer): Is this true in your experience.
 
-- dev.down.<container>: stops the specified container and also removes the stopped containers as well as any networks that were created. Next time you use dev.up to bring up container, your container have reverted back to the pulled image.  This will not affect content of the databases.
+- ``dev.down.<container>``: stops the specified container and also removes the stopped containers as well as any networks that were created. Next time you use dev.up to bring up container, your container have reverted back to the pulled image.  This will not affect content of the databases.
 
   When to use: use this command only if you are okay with removing any changes you might have made to the container
 

--- a/docs/devstack_interface.rst
+++ b/docs/devstack_interface.rst
@@ -63,7 +63,7 @@ Useful Commands and Summary
 
   Variation: ``make dev.down`` will stop all your containers
 
-- ``dev.shell.<container>``: used to enter the shell of the specified conntainer.
+- ``dev.shell.<container>``: used to enter the shell of the specified container.
 
   When to use: To update python packages, to run migrations, or any shell commands you want to run on the running service
 
@@ -71,7 +71,7 @@ Useful Commands and Summary
 
 - ``dev.attach.<container>``: dev.up is setup to bring up the container/service in the background. This attaches the container to your shell.
 
-  When to use: If you put a breakpoint somewher in your code, the pdb shell will show up in here. TODO(reviewer): help with words to explain this use case.
+  When to use: If you put a breakpoint somewhere in your code, the pdb shell will show up in here. TODO(reviewer): help with words to explain this use case.
 
   Variation: ``make <service>-shell``
 

--- a/docs/devstack_interface.rst
+++ b/docs/devstack_interface.rst
@@ -29,7 +29,7 @@ Useful Commands and Summary
 
   When to use: If you have not used Devstack for a while or pulled new images for a while, the installed requirements in your containers might no longer match those used by your code. So it is recommended you pull new images whenever you want your containers to have the latest requirements(python libraries...) installed.
 
-  Note: for new service images to be used, you first need to bring down those services and then bring them back after a pull.
+  Note: for new service images to be used, you first need to bring down those services and then bring them back up after a pull.
 
   Variations:
 

--- a/docs/devstack_interface.rst
+++ b/docs/devstack_interface.rst
@@ -27,7 +27,11 @@ Useful Commands and Summary
 
 - ``dev.pull.<service>`` - Pull latest Docker images for the service and its dependencies
 
-  When to use: When you want to start working with a service (testing out changes, running unit tests, etc.) and want the latest built image since it has been a few days since you last worked with it. Particularly useful when the Python requirements files have changed recently.
+  When to use: When you want your containers to have the latest requirements(python libraries...) installed.
+
+  Alternative: You could run ``make requirements`` from inside the container shell, but the requirements will go back to outdated requirements when you bring down the container. Pulling is recommended.
+
+  Note: for new service images to be used, you first need to bring down those services and then bring them back after a pull.
 
   Variations:
 
@@ -57,7 +61,7 @@ Useful Commands and Summary
 
   + ``make dev.up.without-deps.<service>`` will only bring up the <service> container
 
-- ``dev.stop.<container>``: only stops the container. This does not remove the container or the networks it has created
+- ``dev.stop.<service>``: only stops the container. This does not remove the container or the networks it has created
 
   When to use: When you are pausing your work on this container/devstack and you want to pick back up from where you left off. Next time you use dev.up to bring up containers, you should be able to mostly pick back up from where you started.  TODO(reviewer): Is this true in your experience.
 
@@ -67,32 +71,35 @@ Useful Commands and Summary
 
   Variation: ``make dev.down`` will stop all your containers
 
-- ``dev.shell.<container>``: used to enter the shell of the specified container.
+- ``dev.shell.<service>``: used to enter the shell of the specified service container.
 
   When to use: To update python packages, to run migrations, or any shell commands you want to run on the running service
 
   Variation: ``make <service>-shell``
 
-- ``dev.attach.<container>``: dev.up is setup to bring up the container/service in the background. This attaches the container to your shell.
+- ``dev.attach.<service>``: dev.up is setup to bring up the service container in the background. This attaches the container to your shell.
 
-  When to use: If you put a breakpoint somewhere in your code, the pdb shell will show up in here. TODO(reviewer): help with words to explain this use case.
+  When to use: If you put a breakpoint somewhere in your code, the pdb shell will show up in here.
+
+  Tip: use ``Ctrl+c`` to restart the devserver
+  Tip: use ``Ctrl+p Ctrl+q`` to detach without closing your terminal
 
   Variation: ``make <service>-attach``
 
-- ``dev.logs.<container>``: View the logs of the specified service <container>
+- ``dev.logs.<service>``: View the logs of the specified service <service>
 
   When to use: during debugging, this would help you see live logs coming out of your container.
 
   Variation: ``make dev.logs`` to view logs for all running containers. Do not use this! This is likely very overwhelming.
 
-  Variation: ``make <container>-logs``
-
-- ``dev.restart-container.<container>`` restarts container. TODO(jinder): change any references to this in documentation
-  Note: this will only restart <container> and not its dependencies
-  When to use: TODO(reviewer): help
-
-  Variation: ``make dev.restart-container.<container1>+<container2>`` will restart both <container1> and <container2>
+  Variation: ``make <service>-logs``
 
 - ``dev.restart-devserver.<service>`` restarts the Django/Sinatra server inside container without restarting the container itself.
 
   When to use: When automatic code reloading is not working and you need to manually restart a particular application server.
+
+- ``dev.restart-container.<service>`` restarts service container. This is essentially a stronger version of ``dev.restrart-devserver``
+
+  Note: this will only restart <container> and not its dependencies
+
+  Variation: ``make dev.restart-container.<service1>+<service2>`` will restart both <service> and <service>

--- a/docs/devstack_interface.rst
+++ b/docs/devstack_interface.rst
@@ -3,7 +3,7 @@ Devstack Interface
 
 Devstack comes built in with many useful make commands that act as an user interface. This UI is essentially a make wrapper around docker-compose commands. We attempt to give a short summary of what the make commands do below, but it would be a good idea for you to familiarize yourself with some knowledge of docker-compose.
 
-Due to the organic nature of how this user interface came into being, there are often multiple ways to do the same thing. The two main variants of commands are of the form: ``dev.ACTION.SERVICE`` vs ``SERVICE-ACTION``. The ``SERVICE-ACTION`` variant tends to be more automatic command-completion friendly.
+Due to the organic nature of how this user interface came into being, there are often multiple ways to do the same thing. The two main variants of commands are of the form: ``dev.ACTION.SERVICE`` vs ``SERVICE-ACTION``. The ``SERVICE-ACTION`` variant tends to be more tab-completion friendly.
 
 Examples:
 

--- a/docs/devstack_interface.rst
+++ b/docs/devstack_interface.rst
@@ -31,25 +31,27 @@ Useful Commands and Summary
 
   Variations:
 
-  + Variation: ``make dev.pull`` or ``make pull`` will pull all images in the default devstack.
+  +  ``make dev.pull`` or ``make pull`` will pull all images in the default devstack.
 
     When to use: Probably only when you are first setting up devstack. Do not use this often. This will take a lot of time.
 
-  + Variation: ``make dev.pull.<service1>+<service2>`` will pull images for <service1>, <service2>, and their dependencies
+  + ``make dev.pull.<service1>+<service2>`` will pull images for <service1>, <service2>, and their dependencies
 
-  + Variation: ``make dev.pull.without-deps.<service>`` will only pull <service> image.
+  + ``make dev.pull.without-deps.<service>`` will only pull <service> image.
 
     When to use: If you only want to update one image and do not mind if the other images are behind latest.
 
 - ``dev.up.<service>`` - Create and start containers. i.e. brings up the <service> container and its dependencies
 
-  When you are working on a specific service, it is recommended you use this command to bring up the necessary containers for your service i.e if working in lms, use ``make dev.up.lms`` to bring up containers for lms and its dependencies
+  When you are working on a specific service, it is recommended you use this command to bring up the necessary containers for your service i.e if working in lms, use ``make dev.up.lms`` to bring up containers for lms and its dependencies.
 
-  Variation: ``make dev.up`` or ``make up`` will bring up containers for everything in default devstack
+  Variations:
 
-  Variation: ``make dev.up.<service1>+<service2>`` will pull images for <service1>, <service2>, and their dependencies
+  + ``make dev.up`` or ``make up`` will bring up containers for everything in default devstack
 
-  Variation: ``make dev.up.without-deps.<service>`` will only bring up the <service> container
+  + ``make dev.up.<service1>+<service2>`` will pull images for <service1>, <service2>, and their dependencies
+
+  + ``make dev.up.without-deps.<service>`` will only bring up the <service> container
 
 - ``dev.stop.<container>``: only stops the container. This does not remove the container or the networks it has created
 

--- a/docs/devstack_interface.rst
+++ b/docs/devstack_interface.rst
@@ -27,7 +27,7 @@ Useful Commands and Summary
 
 - ``dev.pull.<service>`` - Pull latest Docker images for the service and its dependencies
 
-  When to use: When you want your containers to have the latest requirements(python libraries...) installed.
+  When to use: If you have not used Devstack for a while or pulled new images for a while, the installed requirements in your containers might no longer match those used by your code. So it is recommended you pull new images whenever you want your containers to have the latest requirements(python libraries...) installed.
 
   Note: for new service images to be used, you first need to bring down those services and then bring them back after a pull.
 

--- a/docs/devstack_interface.rst
+++ b/docs/devstack_interface.rst
@@ -29,8 +29,6 @@ Useful Commands and Summary
 
   When to use: When you want your containers to have the latest requirements(python libraries...) installed.
 
-  Alternative: You could run ``make requirements`` from inside the container shell, but the requirements will go back to outdated requirements when you bring down the container. Pulling is recommended.
-
   Note: for new service images to be used, you first need to bring down those services and then bring them back after a pull.
 
   Variations:

--- a/docs/devstack_interface.rst
+++ b/docs/devstack_interface.rst
@@ -27,15 +27,17 @@ Useful Commands and Summary
 
 - ``dev.pull.<service>`` - Pull latest Docker images for the service and its dependencies
 
-  This will pull all the images necessary to run <service>. The setting for which images are pulled can be found in the docker-compose.yml.
+  When to use: When you only want to update images for a subset of devstack. Such as when you are only working on lms, use ``make dev.pull.lms`` to pull images for lms and it dependencies
 
-  When you are working on a specific service, it is recommended you use this command to pull only images necessary for your service i.e if working in lms, use ``make dev.pull.lms`` to update images for lms and its dependencies
+  + Variation: ``make dev.pull`` or ``make pull`` will pull all images in the default devstack.
 
-  Variation: ``make dev.pull`` or ``make pull`` will pull all images supported in default devstack TODO(jinder): fix this wording
+    When to use: Probably only when you are first setting up devstack. Do not use this often. This will take a lot of time.
 
-  Variation: ``make dev.pull.<service1>+<service2>`` will pull images for <service1>, <service2>, and their dependencies
+  + Variation: ``make dev.pull.<service1>+<service2>`` will pull images for <service1>, <service2>, and their dependencies
 
-  Variation: ``make dev.pull.without-deps.<service>`` will only pull <service> image.
+  + Variation: ``make dev.pull.without-deps.<service>`` will only pull <service> image.
+
+    When to use: If you only want to update one image and do not mind if the other images are behind latest.
 
 - ``dev.up.<service>`` - Create and start containers. i.e. brings up the <service> container and its dependencies
 

--- a/docs/devstack_interface.rst
+++ b/docs/devstack_interface.rst
@@ -73,7 +73,7 @@ Useful Commands and Summary
 
   When to use: If you put a breakpoint somewhere in your code, the pdb shell will show up in here. TODO(reviewer): help with words to explain this use case.
 
-  Variation: ``make <service>-shell``
+  Variation: ``make <service>-attach``
 
 - ``dev.logs.<container>``: View the logs of the specified service <container>
 

--- a/docs/devstack_interface.rst
+++ b/docs/devstack_interface.rst
@@ -45,6 +45,10 @@ Useful Commands and Summary
 
   When you are working on a specific service, it is recommended you use this command to bring up the necessary containers for your service i.e if working in lms, use ``make dev.up.lms`` to bring up containers for lms and its dependencies.
 
+  Especially if you are running devstack after a few days of break, you will likely want to use ``make dev.pull.<service>`` before this using this command.
+
+  Also see below at ``dev.stop`` and ``dev.down`` for opposite counterparts of this command
+
   Variations:
 
   + ``make dev.up`` or ``make up`` will bring up containers for *everything* in default devstack

--- a/docs/devstack_interface.rst
+++ b/docs/devstack_interface.rst
@@ -61,9 +61,9 @@ Useful Commands and Summary
 
 - ``dev.stop.<service>``: only stops the container. This does not remove the container or the networks it has created
 
-  When to use: When you are pausing your work on this container/devstack and you want to pick back up from where you left off. Next time you use dev.up to bring up containers, you should be able to mostly pick back up from where you started.  TODO(reviewer): Is this true in your experience.
+  When to use: When you are pausing your work on this container/devstack and you want to pick back up from where you left off. Next time you use dev.up to bring up containers, you should be able to mostly pick back up from where you started.
 
-- ``dev.down.<container>``: stops the specified container and also removes the stopped containers as well as any networks that were created. Next time you use dev.up to bring up container, your container have reverted back to the pulled image.  This will not affect content of the databases.
+- ``dev.down.<service>``: stops the specified container and also removes the stopped containers as well as any networks that were created. Next time you use dev.up to bring up container, your container have reverted back to the pulled image.  This will not affect content of the databases. This will not bring down <service>'s dependencies.
 
   When to use: use this command only if you are okay with removing any changes you might have made to the container
 

--- a/docs/devstack_interface.rst
+++ b/docs/devstack_interface.rst
@@ -27,7 +27,7 @@ Useful Commands and Summary
 
 - ``dev.pull.<service>`` - Pull latest Docker images for the service and its dependencies
 
-  When to use: When you only want to update images for a subset of devstack. Such as when you are only working on lms, use ``make dev.pull.lms`` to pull images for lms and it dependencies
+  When to use: When you want to start working with a service (testing out changes, running unit tests, etc.) and want the latest built image since it has been a few days since you last worked with it. Particularly useful when the Python requirements files have changed recently.
 
   Variations:
 

--- a/docs/devstack_interface.rst
+++ b/docs/devstack_interface.rst
@@ -47,7 +47,7 @@ Useful Commands and Summary
 
   Variations:
 
-  + ``make dev.up`` or ``make up`` will bring up containers for everything in default devstack
+  + ``make dev.up`` or ``make up`` will bring up containers for *everything* in default devstack
 
   + ``make dev.up.<service1>+<service2>`` will pull images for <service1>, <service2>, and their dependencies
 

--- a/docs/devstack_interface.rst
+++ b/docs/devstack_interface.rst
@@ -28,6 +28,7 @@ Useful Commands and Summary
 - ``dev.pull.<service>`` - Pull latest Docker images for the service and its dependencies
 
   When to use: When you only want to update images for a subset of devstack. Such as when you are only working on lms, use ``make dev.pull.lms`` to pull images for lms and it dependencies
+
   Variations:
 
   + Variation: ``make dev.pull`` or ``make pull`` will pull all images in the default devstack.

--- a/docs/devstack_interface.rst
+++ b/docs/devstack_interface.rst
@@ -25,7 +25,7 @@ Useful Commands and Summary
 
 .. Note: this document does not contain all commands in Makefile. To see full range of the make interface, please see Makefile
 
--``dev.pull.<service>`` - Pull latest Docker images for the service and its dependencies
+- ``dev.pull.<service>`` - Pull latest Docker images for the service and its dependencies
 
   This will pull all the images necessary to run <service>. The setting for which images are pulled can be found in the docker-compose.yml.
 

--- a/docs/devstack_interface.rst
+++ b/docs/devstack_interface.rst
@@ -1,0 +1,88 @@
+Devstack Interface
+------------------
+
+Devstack comes built in with many useful make commands that act as an user interface. This UI is essentially a make wrapper around docker-compose commands. We attempt to give a short summary of what the make commands do below, but it would be a good idea for you to familiarize yourself with some knowledge of docker-compose.
+
+Due to the organic nature of how this user interface came into being, there are often multiple ways to do the same thing. The two main variants of commands are of the form: ``dev.ACTION.SERVICE`` vs ``SERVICE-ACTION``. The ``SERVICE-ACTION`` variant tends to be more automatic command-completion friendly.
+
+Examples:
+
+.. code:: sh
+
+    make dev.up.registrar
+    make registrar-up
+
+    make dev.shell.lms
+    make lms-shell
+
+    make dev.logs.gradebook
+    make gradebook-logs
+
+The user interface for devstack often also gives you both big hammers(``make dev.pull``) and small hammers(``make dev.pull.<service>``) to do things. It is recommend you opt for the small hammer commands, because they often tend to be alot faster.
+
+Useful Commands and Summary
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. Note: this document does not contain all commands in Makefile. To see full range of the make interface, please see Makefile
+
+-``dev.pull.<service>`` - Pull latest Docker images for the service and its dependencies
+
+  This will pull all the images necessary to run <service>. The setting for which images are pulled can be found in the docker-compose.yml.
+
+  When you are working on a specific service, it is recommended you use this command to pull only images necessary for your service i.e if working in lms, use ``make dev.pull.lms`` to update images for lms and its dependencies
+
+  Variation: ``make dev.pull`` or ``make pull`` will pull all images supported in default devstack TODO(jinder): fix this wording
+
+  Variation: ``make dev.pull.<service1>+<service2>`` will pull images for <service1>, <service2>, and their dependencies
+
+  Variation: ``make dev.pull.without-deps.<service>`` will only pull <service> image.
+
+- ``dev.up.<service>`` - Create and start containers. i.e. brings up the <service> container and its dependencies
+
+  When you are working on a specific service, it is recommended you use this command to bring up the necessary containers for your service i.e if working in lms, use ``make dev.up.lms`` to bring up containers for lms and its dependencies
+
+  Variation: ``make dev.up`` or ``make up`` will bring up containers for everything in default devstack
+
+  Variation: ``make dev.up.<service1>+<service2>`` will pull images for <service1>, <service2>, and their dependencies
+
+  Variation: ``make dev.up.without-deps.<service>`` will only bring up the <service> container
+
+- ``dev.stop.<container>``: only stops the container. This does not remove the container or the networks it has created
+
+  When to use: When you are pausing your work on this container/devstack and you want to pick back up from where you left off. Next time you use dev.up to bring up containers, you should be able to mostly pick back up from where you started.  TODO(reviewer): Is this true in your experience.
+
+- dev.down.<container>: stops the specified container and also removes the stopped containers as well as any networks that were created. Next time you use dev.up to bring up container, your container have reverted back to the pulled image.  This will not affect content of the databases.
+
+  When to use: use this command only if you are okay with removing any changes you might have made to the container
+
+  Variation: ``make dev.down`` will stop all your containers
+
+- ``dev.shell.<container>``: used to enter the shell of the specified conntainer.
+
+  When to use: To update python packages, to run migrations, or any shell commands you want to run on the running service
+
+  Variation: ``make <service>-shell``
+
+- ``dev.attach.<container>``: dev.up is setup to bring up the container/service in the background. This attaches the container to your shell.
+
+  When to use: If you put a breakpoint somewher in your code, the pdb shell will show up in here. TODO(reviewer): help with words to explain this use case.
+
+  Variation: ``make <service>-shell``
+
+- ``dev.logs.<container>``: View the logs of the specified service <container>
+
+  When to use: during debugging, this would help you see live logs coming out of your container.
+
+  Variation: ``make dev.logs`` to view logs for all running containers. Do not use this! This is likely very overwhelming.
+
+  Variation: ``make <container>-logs``
+
+- ``dev.restart-container.<container>`` restarts container. TODO(jinder): change any references to this in documentation
+  Note: this will only restart <container> and not its dependencies
+  When to use: TODO(reviewer): help
+
+  Variation: ``make dev.restart-container.<container1>+<container2>`` will restart both <container1> and <container2>
+
+- ``dev.restart-devserver.<service>`` restarts the Django/Sinatra server inside container without restarting the container itself.
+
+  When to use: When automatic code reloading is not working and you need to manually restart a particular application server.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,7 @@ Contents:
    :maxdepth: 2
 
    readme
+   devstack_interface
    devstack_faq
    workflow
    building-images


### PR DESCRIPTION
https://openedx.atlassian.net/browse/ARCHBOM-1673

This PR moves some documentation from README.rst into its own document. For now, devstack_interface.rst gives a brief summary of devstack interface and some of the commonly used commands. Eventually, the hope is that others will right more commands in doc until the document appears like cli doc for devstack

I only added "when to use" section for some of the commands cause it did not seem necessary for some. Feel free to let me know if I should add a "when to use" use section to some of the commands.