### PR TITLE
feat: adds scripts to start/stop all enterprise services

### DIFF
--- a/enterprise/down.sh
+++ b/enterprise/down.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+if [[ -z "${DEVSTACK_WORKSPACE}" ]]; then
+  echo "DEVSTACK_WORKSPACE environment variable undefined. Exiting..."
+  exit 1
+fi
+
+cd $DEVSTACK_WORKSPACE/enterprise-catalog/ && make dev.down
+cd ../license-manager/ && make dev.down
+cd ../devstack/ && make dev.down
+
+MFE_PORTS=(
+  "8734"
+  "1991"
+)
+for port in ${MFE_PORTS[*]}; do
+  echo "Killing MFE listening on port ${port}"
+  kill $(lsof -i tcp:$port | grep LISTEN | awk '{print $2}')
+done
+
+exit 0
+

--- a/enterprise/up.sh
+++ b/enterprise/up.sh
@@ -13,16 +13,16 @@ if [[ $(lsof -i tcp:8734 | grep LISTEN | awk '{print $2}') ]]
 then
   echo "INFO: Enterprise Learner Portal already running"
 else
-  echo "INFO: Silently starting Enterprise Learner Portal"
-  cd ../frontend-app-learner-portal-enterprise/ && npm run --quiet start &
+  echo "INFO: Starting Enterprise Learner Portal"
+  cd ../frontend-app-learner-portal-enterprise/ && npm start &
 fi
 
 if [[ $(lsof -i tcp:1991 | grep LISTEN | awk '{print $2}') ]]
 then
   echo "INFO: Enterprise Admin Portal already running"
 else
-  echo "INFO: Silently starting Enterprise Admin Portal"
-  cd ../frontend-app-admin-portal/ && npm run --quiet start &
+  echo "INFO: Starting Enterprise Admin Portal"
+  cd ../frontend-app-admin-portal/ && npm start &
 fi
 
 exit 0

--- a/enterprise/up.sh
+++ b/enterprise/up.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+if [[ -z "${DEVSTACK_WORKSPACE}" ]]; then
+  echo "DEVSTACK_WORKSPACE environment variable undefined. Exiting..."
+  exit 1
+fi
+
+cd $DEVSTACK_WORKSPACE/devstack/ && make dev.up.lms
+cd ../enterprise-catalog/ && make dev.up
+cd ../license-manager/ && make dev.up
+
+exit 0

--- a/enterprise/up.sh
+++ b/enterprise/up.sh
@@ -5,8 +5,25 @@ if [[ -z "${DEVSTACK_WORKSPACE}" ]]; then
   exit 1
 fi
 
-cd $DEVSTACK_WORKSPACE/devstack/ && make dev.up.lms
+cd $DEVSTACK_WORKSPACE/devstack/ && make dev.up.lms+ecommerce
 cd ../enterprise-catalog/ && make dev.up
 cd ../license-manager/ && make dev.up
 
+if [[ $(lsof -i tcp:8734 | grep LISTEN | awk '{print $2}') ]]
+then
+  echo "INFO: Enterprise Learner Portal already running"
+else
+  echo "INFO: Silently starting Enterprise Learner Portal"
+  cd ../frontend-app-learner-portal-enterprise/ && npm run --quiet start &
+fi
+
+if [[ $(lsof -i tcp:1991 | grep LISTEN | awk '{print $2}') ]]
+then
+  echo "INFO: Enterprise Admin Portal already running"
+else
+  echo "INFO: Silently starting Enterprise Admin Portal"
+  cd ../frontend-app-admin-portal/ && npm run --quiet start &
+fi
+
 exit 0
+


### PR DESCRIPTION
### Description

* Adds bash scripts to start/stop the following enterprise services (and their dependencies):
  * LMS (edx-enterprise)
  * ecommerce
  * enterprise-catalog
  * license-manager
* Also starts/stops the enterprise learner portal and admin portal MFEs
  * `npm start &` used to start each MFE as a background job
  * Logs for above command are still output to the terminal, it'd be nice for them not to be
* Script requires the `DEVSTACK_WORKSPACE` environment variable to be defined

Note: This script doesn't start any of the enterprise frontend applications - would we like it to?

### Testing instructions

* Stop all docker containers running on your machine
* Run the new script (`enterprise/up.sh`) and observe all enterprise backend services being started