### PR TITLE
fix(lms,studio): set DJANGO_SETTINGS_MODULE in order to fix pylint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -310,6 +310,7 @@ services:
     stdin_open: true
     tty: true
     environment:
+      DJANGO_SETTINGS_MODULE: lms.envs.devstack
       BOK_CHOY_HOSTNAME: edx.devstack.lms
       BOK_CHOY_LMS_PORT: 18003
       BOK_CHOY_CMS_PORT: 18031
@@ -420,6 +421,7 @@ services:
     stdin_open: true
     tty: true
     environment:
+      DJANGO_SETTINGS_MODULE: cms.envs.devstack
       BOK_CHOY_HOSTNAME: edx.devstack.studio
       BOK_CHOY_LMS_PORT: 18103
       BOK_CHOY_CMS_PORT: 18131


### PR DESCRIPTION
## Description

Any local use of pylint for LMS or Studio was being met with:
```
E5110: Django was not configured. For more information runpylint --load-plugins=pylint_django --help-msg=django-not-configured (django-not-configured)
```
Newer versions of pylint-django require `DJANGO_SETTINGS_MODULE` to be specified in order to analyze foreign key relationships. So, this commit specifies the settings module in docker-compose.yml.


This issue didn't surface on most IDAs because `DJANGO_SETTINGS_MODULE` was being specified otherwise (in its Dockerfile, or in Ansible, or in docker-compose.yml). This didn't surface in edx-platform PR builds because paver sets `DJANGO_SETTINGS_MODULE` equal to `{lms|cms}.envs.test`.

## Testing

on master:
```
~/devstack> make lms-up-without-deps-shell
root@lms> pylint lms/djangoapps/courseware/utils.py
************* Module lms.djangoapps.courseware.utils
lms/djangoapps/courseware/utils.py:1:0: E5110: Django was not configured. For more information runpylint --load-plugins=pylint_django --help-msg=django-not-configured (django-not-configured)
root@lms>
```
on my branch:
```
~/devstack> make down lms-up-without-deps-shell
root@lms> pylint lms/djangoapps/courseware/utils.py # should succeed (no output)
root@lms>
```
