### PR TITLE
feat: Warn developers about accidentally using default-services commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,10 @@ dev.clone.ssh: ## Clone service repos using SSH method to the parent directory.
 # Developer interface: Docker image management.
 ########################################################################################
 
-dev.pull: dev.pull.$(DEFAULT_SERVICES) ## Pull latest Docker images required by default services.
+dev.pull: ## Deprecated: Use dev.pull.default or a set of service names, e.g. dev.pull.lms+studio
+	@scripts/make_warn_generic.sh "$@"
+
+dev.pull.default: dev.pull.$(DEFAULT_SERVICES) ## Pull latest Docker images required by default services.
 
 dev.pull.%: ## Pull latest Docker images for services and their dependencies.
 	docker-compose pull --include-deps $$(echo $* | tr + " ")
@@ -212,7 +215,10 @@ dev.pull.without-deps.%: ## Pull latest Docker images for specific services.
 # Developer interface: Database management.
 ########################################################################################
 
-dev.provision: dev.check-memory ## Provision dev environment with default services, and then stop them.
+dev.provision: ## Deprecated: Use dev.provision.default or a set of service names, e.g. dev.provision.lms+studio
+	@scripts/make_warn_generic.sh "$@"
+
+dev.provision.default: dev.check-memory ## Provision dev environment with default services, and then stop them.
 	# We provision all default services as well as 'e2e' (end-to-end tests).
 	# e2e is not part of `DEFAULT_SERVICES` because it isn't a service;
 	# it's just a way to tell ./provision.sh that the fake data for end-to-end
@@ -268,7 +274,10 @@ dev.drop-db.%: ## Irreversably drop the contents of a MySQL database in each mys
 # Developer interface: Container management.
 ########################################################################################
 
-dev.up: dev.up.$(DEFAULT_SERVICES) ## Bring up default services.
+dev.up: ## Deprecated: Use dev.up.default or a set of service names, e.g. dev.up.lms+studio
+	@scripts/make_warn_generic.sh "$@"
+
+dev.up.default: dev.up.$(DEFAULT_SERVICES) ## Bring up default services.
 
 dev.up.%: dev.check-memory ## Bring up services and their dependencies.
 	docker-compose up -d $$(echo $* | tr + " ")
@@ -356,7 +365,10 @@ dev.check-memory: ## Check if enough memory has been allocated to Docker.
 dev.stats: ## Get per-container CPU and memory utilization data.
 	docker stats --format "table {{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}"
 
-dev.check: dev.check.$(DEFAULT_SERVICES) ## Run checks for the default service set.
+dev.check: ## Deprecated: Use dev.check.default or a set of service names, e.g. dev.check.lms+studio
+	@scripts/make_warn_generic.sh "$@"
+
+dev.check.default: dev.check.$(DEFAULT_SERVICES) ## Run checks for the default service set.
 
 dev.check.%:  # Run checks for a given service or set of services.
 	$(WINPTY) bash ./check.sh $*

--- a/README.rst
+++ b/README.rst
@@ -151,7 +151,7 @@ The default devstack services can be run by following the steps below.
 
    .. code:: sh
 
-       make dev.pull
+       make dev.pull.default
 
 .. Update rst to point to readthedocs once published.
 
@@ -181,7 +181,7 @@ The default devstack services can be run by following the steps below.
 
    .. code:: sh
 
-       make dev.provision
+       make dev.provision.default
 
    Provision using `docker-sync`_:
 
@@ -199,16 +199,16 @@ The default devstack services can be run by following the steps below.
 
    **NOTE:** This command will bring up both MySQL 5.6 and 5.7 databases until all services are upgraded to 5.7.
 
-5. Start the services. This command will mount the repositories under the
+5. Start the desired services. This command will mount the repositories under the
    ``DEVSTACK_WORKSPACE`` directory.
 
-   **NOTE:** it may take up to 60 seconds for the LMS to start, even after the ``make dev.up`` command outputs ``done``.
+   **NOTE:** it may take up to 60 seconds for the LMS to start, even after the ``dev.up.*`` command outputs ``done``.
 
    Default:
 
    .. code:: sh
 
-       make dev.up
+       make dev.up.default
 
    Start using `docker-sync`_:
 
@@ -302,10 +302,10 @@ The table below provides links to the homepage, API root, or API docs of each se
 as well as links to the repository where each service's code lives.
 
 The services marked as ``Default`` are provisioned/pulled/run whenever you run
-``make dev.provision`` / ``make dev.pull`` / ``make dev.up``, respectively.
+``make dev.provision.default`` / ``make dev.pull.default`` / ``make dev.up.default``, respectively.
 
-The extra services are provisioned/pulled/run when specifically requested (e.g.,
-``make dev.provision.xqueue`` / ``make dev.pull.xqueue`` / ``make dev.up.xqueue``).
+The other services are provisioned/pulled/run when specifically requested (e.g.,
+``make dev.provision.lms+xqueue`` / ``make dev.pull.lms+xqueue`` / ``make dev.up.lms+xqueue``).
 Alternatively, you can run these by modifying the ``DEFAULT_SERVICES`` option as described in the `Advanced Configuration Options`_ section.
 
 +------------------------------------+-------------------------------------+----------------+--------------+

--- a/scripts/make_warn_generic.sh
+++ b/scripts/make_warn_generic.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Warn the developer that they've run a make command that uses a broad
+# service set and that often is not the best tool for the job.
+
+target="$1"
+
+cat <<"EOCOW" >&2
+ _________________________________________________________________________
+/                                                                         \
+| Are you sure you want to run this command for *all* Open edX services?  |
+|                                                                         |
+| Commands like "make dev.pull" will operate on a large default set of    |
+| services and their dependencies. This can make your work take           |
+| longer—you're probably pulling down Docker images you don't need and    |
+| taking up memory and CPU by running services you don't need for your    |
+| work. You might even run into bugs in unrelated services.               |
+|                                                                         |
+| You may prefer to use commands like "make dev.pull.lms+studio" to       |
+| target a smaller set of services.                                       |
+|                                                                         |
+| Learn more about the commands you can run at:                           |
+|                                                                         |
+| https://github.com/edx/devstack/blob/master/docs/devstack_interface.rst |
+|                                                                         |
+| (And if you *really* want the default set of services, you can use      |
+| commands like "make dev.pull.default".)                                 |
+\_________________________________________________________________________/
+       \
+        \   ^__^
+         \  (oo)\_______
+            (__)\       )\/\
+                ||----w |
+                ||     ||
+
+EOCOW
+
+read -r -p $'(You can cancel the command now or press ENTER to continue.)\n'
+
+make "$target.default"

--- a/scripts/make_warn_generic.sh
+++ b/scripts/make_warn_generic.sh
@@ -12,7 +12,6 @@ cat <<"EOCOW" >&2
 /                                                                         \
 | Are you sure you want to run this command for *all* Open edX services?  |
 \_________________________________________________________________________/
-       \
         \   ^__^
          \  (oo)\_______
             (__)\       )\/\

--- a/scripts/make_warn_generic.sh
+++ b/scripts/make_warn_generic.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Warn the developer that they've run a make command that uses a broad
 # service set and that often is not the best tool for the job.
+#
+# This script is used in the Makefile for commands that should be run
+# as `make $target.default` instead.
 
 target="$1"
 
@@ -8,22 +11,6 @@ cat <<"EOCOW" >&2
  _________________________________________________________________________
 /                                                                         \
 | Are you sure you want to run this command for *all* Open edX services?  |
-|                                                                         |
-| Commands like "make dev.pull" will operate on a large default set of    |
-| services and their dependencies. This can make your work take           |
-| longer—you're probably pulling down Docker images you don't need and    |
-| taking up memory and CPU by running services you don't need for your    |
-| work. You might even run into bugs in unrelated services.               |
-|                                                                         |
-| You may prefer to use commands like "make dev.pull.lms+studio" to       |
-| target a smaller set of services.                                       |
-|                                                                         |
-| Learn more about the commands you can run at:                           |
-|                                                                         |
-| https://github.com/edx/devstack/blob/master/docs/devstack_interface.rst |
-|                                                                         |
-| (And if you *really* want the default set of services, you can use      |
-| commands like "make dev.pull.default".)                                 |
 \_________________________________________________________________________/
        \
         \   ^__^
@@ -33,6 +20,26 @@ cat <<"EOCOW" >&2
                 ||     ||
 
 EOCOW
+
+cat <<EOF >&2
+The command "make $target" will operate on a large default set of
+services and their dependencies. This can make your task take longer
+than necessary.
+
+You may prefer to use something like "make $target.lms+studio" to
+target a smaller set of services.  Learn more about the commands you
+can run at:
+
+  https://github.com/edx/devstack/blob/master/docs/devstack_interface.rst
+
+Without an explicit list of services, many devstack Make targets pull
+down Docker images you don't need or take up extra memory and CPU. You
+might even run into bugs in unrelated services.
+
+(If you *really* want the default set of services, you can use the
+command "make $target.default".)
+
+EOF
 
 read -r -p $'(You can cancel the command now or press ENTER to continue.)\n'
 


### PR DESCRIPTION
- Pause and warn when pull/provision/up/check are run without a service
  specified
- Introduce a `*.default` variation for when using the default set is
  intentional

We've seen that a lot of developers use `dev.pull` and `dev.up` and then
experience the resulting pain around bandwidth and memory. This is an
experiment in education -- rather than responding in chat when someone
asks where all the RAM has gone, can we guide people away from these
commands in a tighter loop?

ARCHBOM-1672