### PR TITLE
feat: add "Edit on Github" button in breadcrumbs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -82,6 +82,15 @@ author = edx_theme.AUTHOR
 project_title = 'devstack'
 documentation_title = "{project_title}".format(project_title=project_title)
 
+
+html_context = {
+    "display_github": True, # Integrate GitHub
+    "github_user": "edx", # Username
+    "github_repo": "devstack", # Repo name
+    "github_version": "master", # Version
+    "conf_py_path": "/docs/", # Path in the checkout to the docs root
+}
+
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,8 +8,6 @@ attrs==20.3.0
     # via jsonschema
 bcrypt==3.2.0
     # via paramiko
-cached-property==1.5.2
-    # via docker-compose
 certifi==2020.12.5
     # via requests
 cffi==1.14.5
@@ -19,11 +17,11 @@ cffi==1.14.5
     #   pynacl
 chardet==4.0.0
     # via requests
-cryptography==3.4.6
+cryptography==3.4.7
     # via paramiko
 distro==1.5.0
     # via docker-compose
-docker-compose==1.28.5
+docker-compose==1.28.6
     # via -r requirements/base.in
 docker[ssh]==4.4.4
     # via docker-compose
@@ -43,7 +41,7 @@ pynacl==1.4.0
     # via paramiko
 pyrsistent==0.17.3
     # via jsonschema
-python-dotenv==0.15.0
+python-dotenv==0.16.0
     # via docker-compose
 pyyaml==5.4.1
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -14,10 +14,6 @@ bcrypt==3.2.0
     # via
     #   -r requirements/base.txt
     #   paramiko
-cached-property==1.5.2
-    # via
-    #   -r requirements/base.txt
-    #   docker-compose
 certifi==2020.12.5
     # via
     #   -r requirements/base.txt
@@ -36,7 +32,7 @@ click==7.1.2
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-cryptography==3.4.6
+cryptography==3.4.7
     # via
     #   -r requirements/base.txt
     #   paramiko
@@ -46,7 +42,7 @@ distro==1.5.0
     # via
     #   -r requirements/base.txt
     #   docker-compose
-docker-compose==1.28.5
+docker-compose==1.28.6
     # via -r requirements/base.txt
 docker[ssh]==4.4.4
     # via
@@ -102,7 +98,7 @@ pyrsistent==0.17.3
     # via
     #   -r requirements/base.txt
     #   jsonschema
-python-dotenv==0.15.0
+python-dotenv==0.16.0
     # via
     #   -r requirements/base.txt
     #   docker-compose

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -18,10 +18,6 @@ bcrypt==3.2.0
     #   paramiko
 bleach==3.3.0
     # via readme-renderer
-cached-property==1.5.2
-    # via
-    #   -r requirements/base.txt
-    #   docker-compose
 certifi==2020.12.5
     # via
     #   -r requirements/base.txt
@@ -37,7 +33,7 @@ chardet==4.0.0
     #   -r requirements/base.txt
     #   doc8
     #   requests
-cryptography==3.4.6
+cryptography==3.4.7
     # via
     #   -r requirements/base.txt
     #   paramiko
@@ -47,7 +43,7 @@ distro==1.5.0
     #   docker-compose
 doc8==0.8.1
     # via -r requirements/doc.in
-docker-compose==1.28.5
+docker-compose==1.28.6
     # via -r requirements/base.txt
 docker[ssh]==4.4.4
     # via
@@ -67,7 +63,7 @@ docutils==0.16
     #   readme-renderer
     #   restructuredtext-lint
     #   sphinx
-edx-sphinx-theme==2.0.0
+edx-sphinx-theme==2.1.0
     # via -r requirements/doc.in
 idna==2.10
     # via
@@ -112,7 +108,7 @@ pyrsistent==0.17.3
     # via
     #   -r requirements/base.txt
     #   jsonschema
-python-dotenv==0.15.0
+python-dotenv==0.16.0
     # via
     #   -r requirements/base.txt
     #   docker-compose


### PR DESCRIPTION
Currently, viewers of documentation would need to know alot about a page
to know where they need to go to fix outdated docs. "Edit on Github"
button should decrease the barrier in entry for improving docs.

TODO: upgrade edx_theme