### PR TITLE
feat: Warn developers about accidentally using default-services commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,10 @@ dev.clone.ssh: ## Clone service repos using SSH method to the parent directory.
 # Developer interface: Docker image management.
 ########################################################################################
 
-dev.pull: dev.pull.$(DEFAULT_SERVICES) ## Pull latest Docker images required by default services.
+dev.pull: ## Deprecated: Use dev.pull.default or a set of service names, e.g. dev.pull.lms+studio
+	@scripts/make_warn_generic.sh "$@"
+
+dev.pull.default: dev.pull.$(DEFAULT_SERVICES) ## Pull latest Docker images required by default services.
 
 dev.pull.%: ## Pull latest Docker images for services and their dependencies.
 	docker-compose pull --include-deps $$(echo $* | tr + " ")
@@ -212,7 +215,10 @@ dev.pull.without-deps.%: ## Pull latest Docker images for specific services.
 # Developer interface: Database management.
 ########################################################################################
 
-dev.provision: dev.check-memory ## Provision dev environment with default services, and then stop them.
+dev.provision: ## Deprecated: Use dev.provision.default or a set of service names, e.g. dev.provision.lms+studio
+	@scripts/make_warn_generic.sh "$@"
+
+dev.provision.default: dev.check-memory ## Provision dev environment with default services, and then stop them.
 	# We provision all default services as well as 'e2e' (end-to-end tests).
 	# e2e is not part of `DEFAULT_SERVICES` because it isn't a service;
 	# it's just a way to tell ./provision.sh that the fake data for end-to-end
@@ -268,7 +274,10 @@ dev.drop-db.%: ## Irreversably drop the contents of a MySQL database in each mys
 # Developer interface: Container management.
 ########################################################################################
 
-dev.up: dev.up.$(DEFAULT_SERVICES) ## Bring up default services.
+dev.up: ## Deprecated: Use dev.up.default or a set of service names, e.g. dev.up.lms+studio
+	@scripts/make_warn_generic.sh "$@"
+
+dev.up.default: dev.up.$(DEFAULT_SERVICES) ## Bring up default services.
 
 dev.up.%: dev.check-memory ## Bring up services and their dependencies.
 	docker-compose up -d $$(echo $* | tr + " ")
@@ -356,7 +365,10 @@ dev.check-memory: ## Check if enough memory has been allocated to Docker.
 dev.stats: ## Get per-container CPU and memory utilization data.
 	docker stats --format "table {{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}"
 
-dev.check: dev.check.$(DEFAULT_SERVICES) ## Run checks for the default service set.
+dev.check: ## Deprecated: Use dev.check.default or a set of service names, e.g. dev.check.lms+studio
+	@scripts/make_warn_generic.sh "$@"
+
+dev.check.default: dev.check.$(DEFAULT_SERVICES) ## Run checks for the default service set.
 
 dev.check.%:  # Run checks for a given service or set of services.
 	$(WINPTY) bash ./check.sh $*

--- a/Makefile
+++ b/Makefile
@@ -197,10 +197,11 @@ dev.clone.ssh: ## Clone service repos using SSH method to the parent directory.
 # Developer interface: Docker image management.
 ########################################################################################
 
-dev.pull: ## Deprecated: Use dev.pull.default or a set of service names, e.g. dev.pull.lms+studio
-	@scripts/make_warn_generic.sh "$@"
+dev.pull:
+	@scripts/make_warn_default_large.sh "$@"
 
-dev.pull.default: dev.pull.$(DEFAULT_SERVICES) ## Pull latest Docker images required by default services.
+dev.pull.large-and-slow: dev.pull.$(DEFAULT_SERVICES) ## Pull latest Docker images required by default services.
+	@echo # at least one statement so that dev.pull.% doesn't run too
 
 dev.pull.%: ## Pull latest Docker images for services and their dependencies.
 	docker-compose pull --include-deps $$(echo $* | tr + " ")
@@ -215,10 +216,7 @@ dev.pull.without-deps.%: ## Pull latest Docker images for specific services.
 # Developer interface: Database management.
 ########################################################################################
 
-dev.provision: ## Deprecated: Use dev.provision.default or a set of service names, e.g. dev.provision.lms+studio
-	@scripts/make_warn_generic.sh "$@"
-
-dev.provision.default: dev.check-memory ## Provision dev environment with default services, and then stop them.
+dev.provision: dev.check-memory ## Provision dev environment with default services, and then stop them.
 	# We provision all default services as well as 'e2e' (end-to-end tests).
 	# e2e is not part of `DEFAULT_SERVICES` because it isn't a service;
 	# it's just a way to tell ./provision.sh that the fake data for end-to-end
@@ -274,10 +272,11 @@ dev.drop-db.%: ## Irreversably drop the contents of a MySQL database in each mys
 # Developer interface: Container management.
 ########################################################################################
 
-dev.up: ## Deprecated: Use dev.up.default or a set of service names, e.g. dev.up.lms+studio
-	@scripts/make_warn_generic.sh "$@"
+dev.up:
+	@scripts/make_warn_default_large.sh "$@"
 
-dev.up.default: dev.up.$(DEFAULT_SERVICES) ## Bring up default services.
+dev.up.large-and-slow: dev.up.$(DEFAULT_SERVICES) ## Bring up default services.
+	@echo # at least one statement so that dev.up.% doesn't run too
 
 dev.up.%: dev.check-memory ## Bring up services and their dependencies.
 	docker-compose up -d $$(echo $* | tr + " ")
@@ -365,10 +364,7 @@ dev.check-memory: ## Check if enough memory has been allocated to Docker.
 dev.stats: ## Get per-container CPU and memory utilization data.
 	docker stats --format "table {{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}"
 
-dev.check: ## Deprecated: Use dev.check.default or a set of service names, e.g. dev.check.lms+studio
-	@scripts/make_warn_generic.sh "$@"
-
-dev.check.default: dev.check.$(DEFAULT_SERVICES) ## Run checks for the default service set.
+dev.check: dev.check.$(DEFAULT_SERVICES) ## Run checks for the default service set.
 
 dev.check.%:  # Run checks for a given service or set of services.
 	$(WINPTY) bash ./check.sh $*
@@ -474,7 +470,8 @@ dev.static.%: ## Rebuild static assets for the specified service's container.
 # Developer interface: Commands that do a combination of things.
 ########################################################################################
 
-dev.reset: dev.down dev.reset-repos dev.pull dev.up dev.static dev.migrate ## Attempt to reset the local devstack to the master working state without destroying data.
+
+dev.reset: dev.down dev.reset-repos dev.pull.large-and-slow dev.up.large-and-slow dev.static dev.migrate ## Attempt to reset the local devstack to the master working state without destroying data.
 
 dev.destroy: ## Irreversibly remove all devstack-related containers, networks, and volumes.
 	$(WINPTY) bash ./destroy.sh

--- a/README.rst
+++ b/README.rst
@@ -121,7 +121,7 @@ Directions to setup devstack
 
 The default devstack services can be run by following the steps below.
 
-**Note:** This will set up a large number of services, more than you are likely to need to work with, but that's only necessary for first-time provisioning. See `Service List`_ and `Workflow`_ for how to run and update devstack with just the services you need, rather than the ``large-and-slow`` default set.
+**Note:** This will set up a large number of services, more than you are likely to need to work with, but that's only necessary for first-time provisioning. See `Service List`_ and the `most common development workflow`_ for how to run and update devstack with just the services you need, rather than the ``large-and-slow`` default set.
 
 1. Install the requirements inside of a `Python virtualenv`_.
 

--- a/README.rst
+++ b/README.rst
@@ -151,7 +151,7 @@ The default devstack services can be run by following the steps below.
 
    .. code:: sh
 
-       make dev.pull
+       make dev.pull.default
 
 .. Update rst to point to readthedocs once published.
 
@@ -181,7 +181,7 @@ The default devstack services can be run by following the steps below.
 
    .. code:: sh
 
-       make dev.provision
+       make dev.provision.default
 
    Provision using `docker-sync`_:
 
@@ -199,16 +199,16 @@ The default devstack services can be run by following the steps below.
 
    **NOTE:** This command will bring up both MySQL 5.6 and 5.7 databases until all services are upgraded to 5.7.
 
-5. Start the services. This command will mount the repositories under the
+5. Start the desired services. This command will mount the repositories under the
    ``DEVSTACK_WORKSPACE`` directory.
 
-   **NOTE:** it may take up to 60 seconds for the LMS to start, even after the ``make dev.up`` command outputs ``done``.
+   **NOTE:** it may take up to 60 seconds for the LMS to start, even after the ``dev.up.*`` command outputs ``done``.
 
    Default:
 
    .. code:: sh
 
-       make dev.up
+       make dev.up.default
 
    Start using `docker-sync`_:
 
@@ -302,10 +302,10 @@ The table below provides links to the homepage, API root, or API docs of each se
 as well as links to the repository where each service's code lives.
 
 The services marked as ``Default`` are provisioned/pulled/run whenever you run
-``make dev.provision`` / ``make dev.pull`` / ``make dev.up``, respectively.
+``make dev.provision.default`` / ``make dev.pull.default`` / ``make dev.up.default``, respectively.
 
-The extra services are provisioned/pulled/run when specifically requested (e.g.,
-``make dev.provision.xqueue`` / ``make dev.pull.xqueue`` / ``make dev.up.xqueue``).
+The other services are provisioned/pulled/run when specifically requested (e.g.,
+``make dev.provision.lms+xqueue`` / ``make dev.pull.lms+xqueue`` / ``make dev.up.lms+xqueue``).
 Alternatively, you can run these by modifying the ``DEFAULT_SERVICES`` option as described in the `Advanced Configuration Options`_ section.
 
 +------------------------------------+-------------------------------------+----------------+--------------+

--- a/README.rst
+++ b/README.rst
@@ -121,6 +121,8 @@ Directions to setup devstack
 
 The default devstack services can be run by following the steps below.
 
+**Note:** This will set up a large number of services, more than you are likely to need to work with, but that's only necessary for first-time provisioning. See `Service List`_ and `Workflow`_ for how to run and update devstack with just the services you need, rather than the ``large-and-slow`` default set.
+
 1. Install the requirements inside of a `Python virtualenv`_.
 
    .. code:: sh
@@ -151,7 +153,7 @@ The default devstack services can be run by following the steps below.
 
    .. code:: sh
 
-       make dev.pull.default
+       make dev.pull.large-and-slow
 
 .. Update rst to point to readthedocs once published.
 
@@ -181,7 +183,7 @@ The default devstack services can be run by following the steps below.
 
    .. code:: sh
 
-       make dev.provision.default
+       make dev.provision
 
    Provision using `docker-sync`_:
 
@@ -208,7 +210,7 @@ The default devstack services can be run by following the steps below.
 
    .. code:: sh
 
-       make dev.up.default
+       make dev.up.large-and-slow
 
    Start using `docker-sync`_:
 
@@ -301,12 +303,9 @@ Each service is accessible at ``localhost`` on a specific port.
 The table below provides links to the homepage, API root, or API docs of each service,
 as well as links to the repository where each service's code lives.
 
-The services marked as ``Default`` are provisioned/pulled/run whenever you run
-``make dev.provision.default`` / ``make dev.pull.default`` / ``make dev.up.default``, respectively.
+Most developers will be best served by working with specific combinations of these services, for example ``make dev.pull.studio`` or ``make dev.up.ecommerce``. These will pull in dependencies as needed—starting ecommerce will also start lms, and lms will pull in forums, discovery, and others. If you need multiple, they can be listed like ``make dev.up.studio+ecommerce``. After the service table below there is a list of some common combinations.
 
-The other services are provisioned/pulled/run when specifically requested (e.g.,
-``make dev.provision.lms+xqueue`` / ``make dev.pull.lms+xqueue`` / ``make dev.up.lms+xqueue``).
-Alternatively, you can run these by modifying the ``DEFAULT_SERVICES`` option as described in the `Advanced Configuration Options`_ section.
+Instead of a service name or list, you can also run commands like ``make dev.provision`` / ``make dev.pull.large-and-slow`` / ``make dev.up.large-and-slow``. This is a larger list than most people will need for most of their work, and includes all of the services marked "Default" in the below table. (Some of these targets use ``large-and-slow`` in their name as a warning; others may be changed to use this over time.) However, you can change this list by modifying the ``DEFAULT_SERVICES`` option as described in the `Advanced Configuration Options`_ section.
 
 +------------------------------------+-------------------------------------+----------------+--------------+
 | Service                            | URL                                 | Type           | Role         |
@@ -343,6 +342,12 @@ Alternatively, you can run these by modifying the ``DEFAULT_SERVICES`` option as
 +------------------------------------+-------------------------------------+----------------+--------------+
 | `xqueue`_                          | http://localhost:18040/api/v1/      | Python/Django  | Extra        |
 +------------------------------------+-------------------------------------+----------------+--------------+
+
+Some common service combinations include:
+
+* ``lms``: Just the LMS, along with dependencies like ``forum``, ``discovery``, and some databases
+* ``ecommerce``: Most services will bring in LMS as a dependency (for auth)
+* ``studio+credentials``: Services can be combined to bring both up at once
 
 .. _credentials: https://github.com/edx/credentials
 .. _discovery: https://github.com/edx/course-discovery

--- a/README.rst
+++ b/README.rst
@@ -345,9 +345,9 @@ Instead of a service name or list, you can also run commands like ``make dev.pro
 
 Some common service combinations include:
 
-* ``lms``: Just the LMS, along with dependencies like ``forum``, ``discovery``, and some databases
-* ``ecommerce``: Most services will bring in LMS as a dependency (for auth)
-* ``studio+credentials``: Services can be combined to bring both up at once
+* ``lms``: LMS, along with dependencies ``forum``, ``discovery``, and some databases
+* ``ecommerce``: Ecommerce, but also LMS as a dependency (for auth)
+* ``studio+credentials``: Services can be combined to affect both at once
 
 .. _credentials: https://github.com/edx/credentials
 .. _discovery: https://github.com/edx/course-discovery

--- a/docs/decisions/0001-avoid-default-service-set.rst
+++ b/docs/decisions/0001-avoid-default-service-set.rst
@@ -1,0 +1,42 @@
+1. Avoid default service set
+============================
+
+Status
+------
+
+Approved
+
+Context
+-------
+
+Commands like ``make dev.pull`` and ``make dev.up`` operate by default on a large subset of the services that devstack supports (via overridable variable ``DEFAULT_SERVICES``). There are also variants such as ``make dev.up.studio+credentials`` which will operate on a more constrained subset. However, many developers are not aware of these variants or are not in the habit of using them. By not constraining the command to selected services, developers pull down Docker images that they do not need for their current workflow, or find that devstack is using more memory and CPU than needed due to running unnecessary services. These issues have been repeatedly observed in supporting fellow edX devs in internal communications, and are likely an issue in the community as well. We also see people run into bugs in unrelated services, distracting them from their main task.
+
+Several people and teams have made efforts to improve the documentation and offer these better-scoped commands, but we still see complaints about memory, CPU, and network usage that can be solved by avoiding the default set.
+
+The term "default" is also too prescriptive, since it usually connotes a desirable path and we actually don't want people to use this default. The contents of ``DEFAULT_SERVICES`` is also incoherent, as it does not reflect any one workflow, but rather is simply a "large set" that covers something like 80% of cases (but too much for any one of them).
+
+Decision
+--------
+
+We introduce an explicit alias for the default service set, ``large-and-slow``, and introduce targets like ``dev.pull.large-and-slow``. Creating a name for the large set with a built-in warning may help warn people away from it.
+
+Next, any direct usage of the bare target ``dev.pull`` triggers a warning in the terminal and an opportunity to cancel and use a more tightly scoped command. Using ``dev.pull.large-and-slow`` directly bypasses this warning; this set may still be needed for some use-cases, such as initial provisioning. This allows us to educate a broader range of developers (not just the ones who come and ask for help) and tighten the feedback loop to seconds rather than hours (warning in terminal vs. discussion in chat.)
+
+Finally, documentation is to be updated to better explain this distinction, and any mention of ``dev.pull`` updated to either ``dev.pull.large-and-slow`` or ``dev.pull.<service>`` so that readers will be steered in the correct direction from the outset.
+
+The first pass only changes the ``pull`` and ``up`` families of make targets, since we believe they are the most commonly used and the most common to cause developer pain. ``provision``, ``check``, ``migrate``, and ``reset`` are good candidates for after this is proved out.
+
+Use of ``DEFAULT_SERVICES`` and the make targets which rely on it is not deprecated, but should always be an intentional act.
+
+Consequences
+------------
+
+People will be steered away from bare targets like ``dev.pull`` and ``DEFAULT_SERVICES`` may be reduced in importance.
+
+Developers first setting up devstack will still use the large set, since some parts of provisioning (specifically, the loading of test data) have non-trivial dependencies between services.
+
+Rejected Alternatives
+---------------------
+
+- Shrinking ``DEFAULT_SERVICES``: Likely to break any number of workflows, or at least confuse people who rely on it.
+- Just document it better: We don't think people read the docs enough to discover docs on this issue. People probably mostly go looking through the docs when they have a specific error or a task they want to learn how to accomplish, but they may not even identify overly large service sets as a problem to solve.

--- a/docs/devpi.rst
+++ b/docs/devpi.rst
@@ -16,7 +16,7 @@ requirements of all Devstack applications.
 In general the operation of devpi should be transparent. You may notice
 some significant speedup in tox testing and ``paver update_prereqs``
 operations after the first run. Container storage should persist through
-``make dev.down`` and ``make dev.up`` operations.
+``make dev.down`` and ``make dev.up.<service>`` operations.
 
 The devpi web interface can be browsed from the host at:
 http://localhost:3141/

--- a/docs/devstack_faq.rst
+++ b/docs/devstack_faq.rst
@@ -185,11 +185,11 @@ To run migrations for all services at once, run:
 
 .. code:: sh
 
-   make dev.up
+   make dev.up.large-and-slow
    make dev.migrate
 
 Alternatively, you can discard and rebuild the entire database for all
-devstack services by re-running ``make dev.provision`` or
+devstack services by re-running ``make dev.provision.<service>`` or
 ``make dev.sync.provision`` as appropriate for your configuration.  Note that
 if your branch has fallen significantly behind master, it may not include all
 of the migrations included in the database dump used by provisioning.  In these
@@ -261,7 +261,7 @@ database migrations and package updates.
 When switching to a branch which differs greatly from the one you've been
 working on (especially if the new branch is more recent), you may wish to
 halt and remove the existing containers via ``make down``, pull the latest Docker
-images via ``make dev.pull.<service>``, and then re-run ``make dev.provision`` or
+images via ``make dev.pull.<service>``, and then re-run ``make dev.provision.<service>`` or
 ``make dev.sync.provision`` in order to recreate up-to-date databases,
 static assets, etc.
 

--- a/docs/devstack_interface.rst
+++ b/docs/devstack_interface.rst
@@ -18,7 +18,7 @@ Examples:
     make dev.logs.gradebook
     make gradebook-logs
 
-The user interface for devstack often also gives you both big hammers(``make dev.pull``) and small hammers(``make dev.pull.<service>``) to do things. It is recommend you opt for the small hammer commands, because they often tend to be alot faster.
+The user interface for devstack often also gives you both big hammers(``make dev.pull.large-and-slow``) and small hammers(``make dev.pull.<service>``) to do things. It is recommend you opt for the small hammer commands, because they often tend to be alot faster.
 
 Useful Commands and Summary
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -35,7 +35,7 @@ Useful Commands and Summary
 
   Variations:
 
-  + ``make dev.pull`` or ``make pull`` will pull all images in the default devstack.
+  + ``make dev.pull.large-and-slow``, ``make dev.pull``, or ``make pull`` will pull all images in the default devstack.
 
     When to use: Probably only when you are first setting up devstack. Do not use this often. This will take a lot of time.
 
@@ -55,7 +55,7 @@ Useful Commands and Summary
 
   Variations:
 
-  + ``make dev.up`` or ``make up`` will bring up containers for *everything* in default devstack
+  + ``make dev.up.large-and-slow``, ``make dev.up``, or ``make up`` will bring up containers for *everything* in default devstack
 
     When to use: Probably never, unless you are doing a full devstack level testing
 

--- a/docs/troubleshoot_general_tips.rst
+++ b/docs/troubleshoot_general_tips.rst
@@ -48,7 +48,7 @@ No space left on device
 If you see the error ``no space left on device``, Docker has run
 out of space in its Docker.qcow2 file.
 
-Here is an example error while running ``make dev.pull``:
+Here is an example error while running ``make dev.pull.<service>``:
 
 .. code:: sh
 
@@ -69,7 +69,7 @@ If you are still seeing issues, you can try cleaning up dangling volumes.
 
 .. code:: sh
 
-   make dev.up
+   make dev.up.large-and-slow
 
 2. Remove all unused volumes. **Warning:** this will remove all Docker data on your system that is *not currently in use by a container*, which is why it's important to run the previous step. Otherwise, this will wipe out your Devstack data.
 
@@ -96,7 +96,7 @@ up the provisioning process on Mac), so you can try the following:
 
    # repeat the following until you get past the error.
    make stop
-   make dev.provision
+   make dev.provision.<service>
 
 Once you get past the issue, you should be able to continue to use sync versions
 of the make targets.

--- a/scripts/extract_snapshot_linux.sh
+++ b/scripts/extract_snapshot_linux.sh
@@ -26,4 +26,4 @@ cd devstack
 make down
 
 # Start all the containers again with correctly populated volumes.
-make dev.up
+make dev.up.large-and-slow

--- a/scripts/extract_snapshot_mac.sh
+++ b/scripts/extract_snapshot_mac.sh
@@ -22,4 +22,4 @@ cd devstack
 make down
 
 # Start all the containers again with correctly populated volumes.
-make dev.up
+make dev.up.large-and-slow

--- a/scripts/make_warn_default_large.sh
+++ b/scripts/make_warn_default_large.sh
@@ -41,6 +41,6 @@ the command "make $target.large-and-slow".)
 
 EOF
 
-read -r -p $'(You can cancel the command now or press ENTER to continue.)\n'
+read -r -p $'(You can cancel the command now with Ctrl-C or press ENTER to continue.)\n'
 
 make --no-print-directory "$target.large-and-slow"

--- a/scripts/make_warn_default_large.sh
+++ b/scripts/make_warn_default_large.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
-# Warn the developer that they've run a make command that uses a broad
-# service set and that often is not the best tool for the job.
+# Warn the developer that they've run a make command that uses a very
+# large set of services and that often is not the best tool for the
+# job.
 #
 # This script is used in the Makefile for commands that should be run
-# as `make $target.default` instead.
+# as `make $target.large-and-slow` instead if that's what's intended.
 
 target="$1"
 
@@ -25,7 +26,7 @@ The command "make $target" will operate on a large default set of
 services and their dependencies. This can make your task take longer
 than necessary.
 
-You may prefer to use something like "make $target.lms+studio" to
+You may prefer to use something like "make $target.lms" to
 target a smaller set of services.  Learn more about the commands you
 can run at:
 
@@ -35,11 +36,11 @@ Without an explicit list of services, many devstack Make targets pull
 down Docker images you don't need or take up extra memory and CPU. You
 might even run into bugs in unrelated services.
 
-(If you *really* want the default set of services, you can use the
-command "make $target.default".)
+(If you *really* want the large default set of services, you can use
+the command "make $target.large-and-slow".)
 
 EOF
 
 read -r -p $'(You can cancel the command now or press ENTER to continue.)\n'
 
-make "$target.default"
+make --no-print-directory "$target.large-and-slow"

--- a/scripts/make_warn_generic.sh
+++ b/scripts/make_warn_generic.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Warn the developer that they've run a make command that uses a broad
+# service set and that often is not the best tool for the job.
+#
+# This script is used in the Makefile for commands that should be run
+# as `make $target.default` instead.
+
+target="$1"
+
+cat <<"EOCOW" >&2
+ _________________________________________________________________________
+/                                                                         \
+| Are you sure you want to run this command for *all* Open edX services?  |
+\_________________________________________________________________________/
+        \   ^__^
+         \  (oo)\_______
+            (__)\       )\/\
+                ||----w |
+                ||     ||
+
+EOCOW
+
+cat <<EOF >&2
+The command "make $target" will operate on a large default set of
+services and their dependencies. This can make your task take longer
+than necessary.
+
+You may prefer to use something like "make $target.lms+studio" to
+target a smaller set of services.  Learn more about the commands you
+can run at:
+
+  https://github.com/edx/devstack/blob/master/docs/devstack_interface.rst
+
+Without an explicit list of services, many devstack Make targets pull
+down Docker images you don't need or take up extra memory and CPU. You
+might even run into bugs in unrelated services.
+
+(If you *really* want the default set of services, you can use the
+command "make $target.default".)
+
+EOF
+
+read -r -p $'(You can cancel the command now or press ENTER to continue.)\n'
+
+make "$target.default"

--- a/scripts/restore.py
+++ b/scripts/restore.py
@@ -37,7 +37,7 @@ def start_devstack():
     """
     cwd = os.getcwd()
     os.chdir(DEVSTACK_REPO_DIR)
-    check_call(['make', 'dev.up'])
+    check_call(['make', 'dev.up.large-and-slow'])
     os.chdir(cwd)
 
 


### PR DESCRIPTION
- Pause and warn when `dev.pull` or `dev.up` are run without a service specified
- Introduce a `*.large-and-slow` variation for when using the default set is intentional
- Improve documentation around when to use the large set or a specific service; update some doc locations to use one or the other more explicitly

We've seen that a lot of developers use `dev.pull` and `dev.up` and then experience the resulting pain around bandwidth and memory. This is an experiment in education -- rather than responding in chat when someone asks where all the RAM has gone, can we guide people away from these commands in a tighter loop?

(Implementation note: Keeping the main text out of the cowsay allows us to have variable length text (interpolate the make target) without messing up the speech bubble borders or having to install the cowsay package.)

The first commit is cherry-picked from PR #708 (commit 80ed748) which was reverted for a bugfix; if you previously reviewed that PR, see the second commit's message for a description of what has changed since then.

----

I've completed each of the following, or confirmed they do not apply to this PR:

- [x] Tested on both Mac and Linux (if changed Makefile or shell scripts)
    - Already tested on: Linux
    - Testing instructions:
        - Run `make dev.pull.lms` and confirm it does not warn and does pull the right things
        - Run `make dev.pull` and `make pull` and confirm they give the warning (can cancel out of it)
        - Run `make dev.pull` and allow it to continue, and confirm that it does not give an error after running to completion
        - Run `make dev.pull.large-and-slow` and confirm that it does *not* warn
        - Run `make dev.reset` (or any other all/most-services workflow depending on up/pull) and confirm you are not warned
        - If you're feeling lucky, also test `make dev.up`
- [x] Made a plan to communicate any major developer interface changes
    - Will _inform_ the parties listed in "All Open edX developers" on How We Announce and ask for feedback
    - Will also ask for contributions to the "common combinations" list (MFEs? other services usually run together?)