### PR TITLE
test: Test a few CLI interactions, starting with large-set warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
           sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu focal test"
           sudo apt update
-          sudo apt install docker-ce
+          sudo apt install docker-ce expect
           docker version
           docker-compose --version
 
@@ -44,6 +44,12 @@ jobs:
 
       - name: clone
         run:  make dev.clone.https
+
+      # These can be run in your virtualenv as scripts if you install
+      # the TCL `expect` CLI tool in your OS. Non-zero exit code is a
+      # test failure.
+      - name: CLI tests
+        run: ./tests/warn_default.exp
 
       - name: pull
         run:  make dev.pull.${{matrix.services}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
         os: [ ubuntu-latest ]
         python-version: [ '3.8' ]
         services: [ discovery+lms+forum ,registrar+lms, ecommerce, edx_notes_api, credentials, xqueue]
+      fail-fast: false # some services can be flaky; let others run to completion even if one fails
 
     steps:
       - uses: actions/checkout@v2

--- a/docs/decisions/0002-expect-cli-testing.rst
+++ b/docs/decisions/0002-expect-cli-testing.rst
@@ -1,0 +1,35 @@
+2. Use ``expect`` for CLI testing
+=================================
+
+Status
+------
+
+Approved
+
+Context
+-------
+
+Devstack has a CLI that a large number of developers depend upon, and when it breaks it can cause disruption across multiple teams. However, there is limited automated testing that would prevent such breakage. The CI script is currently set up to run through some common commands for a static set of services, from cloning repositories all the way through provisioning. These can catch some basic problems but only exercise a few core Makefile targets.
+
+Recently the CLI was changed to warn the developer when "bare" commands such as ``make dev.pull`` are run. The new ``make_warn_default_large.sh`` prints a warning and then waits for acknowledgement before proceeding. It was not obvious how to add automated tests for this. Using pytest and Python's ``subprocess`` module turned out to be overly difficult—this type of explicit process management requires a lot of low-level work such as designating the spawned process as a process group leader, killing the group at the end or on error, reading into buffers before the command is finished, matching stderr and stdout against regexes, managing timeouts, etc. The Expect utility handles this using a domain-specific language, and while it is not installed by default on Mac or Linux, it is designed for exactly this sort of task.
+
+It is possible that there's an expect-like wrapper of subprocess that would work from pytest, but we couldn't find one in the time we'd allotted for the task.
+
+Decision
+--------
+
+A ``tests`` directory is added with a single Expect script which tests the warn-on-large-set path for one make command. More scripts can be added as other CLI changes are made.
+
+The Github CI configuration installs ``expect`` and runs the Expect script by name.
+
+Consequences
+------------
+
+Developers wishing to run the automated tests locally will have to have Expect installed. This should be available on both Mac and Linux.
+
+There is no provision made here for setting up different environments in which to run the tests (e.g. with/without an ``options.local.mk`` overrides file). If this is needed, it can be arranged from a wrapper script.
+
+Rejected Alternatives
+---------------------
+
+Manual invocation of ``subprocess``, as described above.

--- a/tests/warn_default.exp
+++ b/tests/warn_default.exp
@@ -1,0 +1,20 @@
+#!/usr/bin/expect -f
+# Test that dev.pull (bare) prompts before continuing
+
+set timeout 3
+
+spawn make dev.pull
+
+expect {
+    "Are you sure you want to run this command" {}
+    timeout { exit 1 }
+}
+send "\n"
+
+expect {
+    "Pulling lms" {}
+    timeout { exit 1 }
+}
+
+# Send ^C, don't wait for it to finish
+send \x03


### PR DESCRIPTION
This adds basic CI testing for the large-set warning introduced in
https://github.com/edx/devstack/pull/718 (ARCHBOM-1672).

Tests can be run locally if `expect` is installed.

Also turn off fail-fast in Github Actions; it's not uncommon for one
test to be flaky, and this allows us to get results from the other tests
even if one fails early.

ref ARCHBOM-1752

----

I've completed each of the following, or confirmed they do not apply to this PR:

- [ ] Tested on both Mac and Linux (if changed Makefile or shell scripts)
    - Already tested on: Linux
    - Testing instructions: Install `expect`, run new test files as scripts (as in CI file)
- [x] Made a plan to communicate any major developer interface changes
