### PR TITLE
fix: fix Credentials IDA provisioning in devstack

### DIFF
--- a/provision-credentials.sh
+++ b/provision-credentials.sh
@@ -9,7 +9,7 @@ port=18150
 docker-compose up -d $name
 
 echo -e "${GREEN}Installing requirements for ${name}...${NC}"
-docker-compose exec -T ${name}  bash -c 'source /edx/app/credentials/credentials_env && cd /edx/app/credentials/credentials && make requirements && make production-requirements' -- "$name"
+docker-compose exec -T ${name}  bash -c 'source /edx/app/credentials/credentials_env && cd /edx/app/credentials/credentials && make requirements' -- "$name"
 
 echo -e "${GREEN}Running migrations for ${name}...${NC}"
 docker-compose exec -T ${name}  bash -c 'source /edx/app/credentials/credentials_env && cd /edx/app/credentials/credentials && make migrate' -- "$name"


### PR DESCRIPTION
[MICROBA-1189]
- Call new make target in credentials that ensures all the required packages will be installed

See https://github.com/edx/credentials/pull/1118 for more details

----

I've completed each of the following, or confirmed they do not apply to this PR:

- [ ] Tested on both Mac and Linux (if changed Makefile or shell scripts)
    - Already tested on: *[my OS here]*
    - Testing instructions: *[commands and expected behavior]*
- [ ] Made a plan to communicate any major developer interface changes


[MICROBA-1189]: https://openedx.atlassian.net/browse/MICROBA-1189