### PR TITLE
feat: Adding performance data collection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -283,6 +283,7 @@ dev.up.large-and-slow: dev.up.$(DEFAULT_SERVICES) ## Bring up default services.
 
 dev.up.%:
 	@scripts/send-metrics.py "dev.up.$*"
+
 impl-dev.up.%: dev.check-memory ## Bring up services and their dependencies.
 	docker-compose up -d $$(echo $* | tr + " ")
 ifeq ($(ALWAYS_CACHE_PROGRAMS),true)

--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,7 @@
         dev.sync.requirements dev.sync.up dev.up dev.up.attach dev.up.shell \
         dev.up.without-deps dev.up.without-deps.shell dev.up.with-programs \
         dev.up.with-watchers dev.validate docs e2e-tests e2e-tests.with-shell \
-		impl-dev.pull \
-        help requirements selfcheck upgrade upgrade \
+        help requirements impl-dev.pull selfcheck upgrade upgrade \
         validate-lms-volume vnc-passwords
 
 # Load up options (configurable through options.local.mk).

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@
         dev.sync.requirements dev.sync.up dev.up dev.up.attach dev.up.shell \
         dev.up.without-deps dev.up.without-deps.shell dev.up.with-programs \
         dev.up.with-watchers dev.validate docs e2e-tests e2e-tests.with-shell \
+		impl-dev.pull \
         help requirements selfcheck upgrade upgrade \
         validate-lms-volume vnc-passwords
 
@@ -198,7 +199,10 @@ dev.clone.ssh: ## Clone service repos using SSH method to the parent directory.
 ########################################################################################
 
 dev.pull:
-	@scripts/make_warn_default_large.sh "$@"
+	@scripts/send-metrics.py "$@"
+
+impl-dev.pull: ##
+	@scripts/make_warn_default_large.sh "dev.pull"
 
 dev.pull.large-and-slow: dev.pull.$(DEFAULT_SERVICES) ## Pull latest Docker images required by default services.
 	@echo # at least one statement so that dev.pull.% doesn't run too
@@ -278,7 +282,9 @@ dev.up:
 dev.up.large-and-slow: dev.up.$(DEFAULT_SERVICES) ## Bring up default services.
 	@echo # at least one statement so that dev.up.% doesn't run too
 
-dev.up.%: dev.check-memory ## Bring up services and their dependencies.
+dev.up.%:
+	@scripts/send-metrics.py "dev.up.$*"
+impl-dev.up.%: dev.check-memory ## Bring up services and their dependencies.
 	docker-compose up -d $$(echo $* | tr + " ")
 ifeq ($(ALWAYS_CACHE_PROGRAMS),true)
 	make dev.cache-programs

--- a/scripts/send-metrics.py
+++ b/scripts/send-metrics.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""
+Python script to collect metrics on devstack make targets.
+The script calls the specified make target and records:
+- target start time
+- target end time
+- target name
+
+This data is collected to determine the performance of devstack's make targets.
+"""
+import subprocess
+import sys
+import datetime
+from os import path
+
+def send_metrics(make_target):
+    """
+    Runs specified make shell target and collects performance data.
+    """
+    t0 = datetime.datetime.now()
+    completed_process = run_target(make_target)
+    t1 = datetime.datetime.now()
+    exit_code = completed_process.returncode
+    time_diff = t1.timestamp() - t0.timestamp()
+    output = {"target":make_target, "t0":t0, "time_diff":time_diff, "exit_code": exit_code}
+    print(f"send metrics info: {output}", file=sys.stderr)
+
+def run_target(make_target):
+    return subprocess.run(["make", f"impl-{make_target}"])
+    # return subprocess.run(["ls"])
+
+def main(make_target):
+    # Collect data only if user has concented to data collection by creating a file named: ~/.config/devstack/metrics.json
+    if path.exists(path.expanduser("~/.config/devstack/metrics.json")):
+        send_metrics(make_target)
+    else:
+        run_target(make_target)
+
+if __name__ == "__main__":
+    # if no target is specified, print error and exit.
+    if len(sys.argv)>1:
+        main(sys.argv[1])
+    else:
+        print("No make target specified")

--- a/scripts/send-metrics.py
+++ b/scripts/send-metrics.py
@@ -27,7 +27,6 @@ def send_metrics(make_target):
 
 def run_target(make_target):
     return subprocess.run(["make", f"impl-{make_target}"])
-    # return subprocess.run(["ls"])
 
 def main(make_target):
     # Collect data only if user has concented to data collection by creating a file named: ~/.config/devstack/metrics.json
@@ -37,7 +36,7 @@ def main(make_target):
         run_target(make_target)
 
 if __name__ == "__main__":
-    # if no target is specified, print error and exit.
+    # if no make target is specified, print error and exit.
     if len(sys.argv)>1:
         main(sys.argv[1])
     else:

--- a/scripts/send-metrics.py
+++ b/scripts/send-metrics.py
@@ -29,7 +29,7 @@ def run_target(make_target):
     return subprocess.run(["make", f"impl-{make_target}"])
 
 def main(make_target):
-    # Collect data only if user has concented to data collection by creating a file named: ~/.config/devstack/metrics.json
+    # Collect data only if user has consented to data collection by creating a file named: ~/.config/devstack/metrics.json
     if path.exists(path.expanduser("~/.config/devstack/metrics.json")):
         send_metrics(make_target)
     else:


### PR DESCRIPTION
Collecting data on thes make targets: dev.pull and dev.up.%
The data collected:
- the time make target is called
- how long it took for target to finish
- the name of the target

Currently, the data is only collected, but not saved. For now, it is
just printed out to stderr. We plan to eventually send it to segment as
part of follow up work.

[ARCHBOM-1766](https://openedx.atlassian.net/browse/ARCHBOM-1766)

----

I've completed each of the following, or confirmed they do not apply to this PR:

- [x] Tested on both Mac and Linux (if changed Makefile or shell scripts)
    - Already tested on: mac by jinder
    - Testing instructions: *[commands and expected behavior]*
- [x] Made a plan to communicate any major developer interface changes
