### PR TITLE
feat: Send devstack metrics to Segment (if locally enabled)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
     env:
       DEVSTACK_WORKSPACE: /tmp
       SHALLOW_CLONE: 1
+      # Don't report metrics as real usage
+      DEVSTACK_METRICS_TESTING: ci
     strategy:
       matrix:
         os: [ ubuntu-latest ]
@@ -50,7 +52,9 @@ jobs:
       # the TCL `expect` CLI tool in your OS. Non-zero exit code is a
       # test failure.
       - name: CLI tests
-        run: ./tests/warn_default.exp
+        run: |
+          ./tests/warn_default.exp
+          ./tests/metrics.exp
 
       - name: pull
         run:  make dev.pull.${{matrix.services}}

--- a/scripts/send-metrics.py
+++ b/scripts/send-metrics.py
@@ -1,43 +1,175 @@
 #!/usr/bin/env python3
 """
 Python script to collect metrics on devstack make targets.
-The script calls the specified make target and records:
-- target start time
-- target end time
-- target name
 
-This data is collected to determine the performance of devstack's make targets.
+If the devstack user has consented to metrics collected, this script
+calls the specified make target and records metrics about the target,
+execution time, and other attributes that can be used to monitor the
+usability of devstack. For more information:
+
+https://openedx.atlassian.net/wiki/spaces/AC/pages/2720432206/Devstack+Metrics
+
+If environment variable ``DEVSTACK_METRICS_TESTING`` is present and non-empty, then
+metrics will be annotated to indicate that the event occurred in the
+course of running tests so that it does not pollute our main data. (TODO)
+(Extra debugging information will also be printed, including the sent
+event data.)
 """
+
+import base64
+import json
+import os
 import subprocess
 import sys
-import datetime
+import traceback
+import urllib.request as req
+import uuid
+from datetime import datetime, timezone
+from http.client import RemoteDisconnected
 from os import path
+from urllib.error import URLError
 
-def send_metrics(make_target):
+
+test_mode = os.environ.get('DEVSTACK_METRICS_TESTING')
+
+
+def base64str(s):
+    """Encode a string in Base64, returning a string."""
+    return base64.b64encode(s.encode()).decode()
+
+
+def prep_for_send():
+    """
+    Prepare for sending to Segment, returning config object.
+
+    If successful, indicates that the user has opted in to metrics collection
+    and the returned config object will contain:
+
+    - anonymous_user_id
+    - segment_write_key
+
+    Failure may take the form of an exception or returning None.
+    """
+    config_path = path.expanduser("~/.config/devstack/metrics.json")
+    with open(config_path, 'r') as f:
+        config = json.loads(f.read())
+
+    # Currently serving in place of a consent check -- gate on
+    # presence of this manually configured setting so that people
+    # developing this script can test it.
+    if 'segment_write_key' not in config:
+        return None
+
+    # Set user ID on first run
+    if 'anonymous_user_id' not in config:
+        config['anonymous_user_id'] = str(uuid.uuid4())
+        with open(config_path, 'w') as f:
+            f.write(json.dumps(config))
+
+    return config
+
+
+def send_metrics_to_segment(event_properties, config):
+    """
+    Send collected metrics to Segment.
+
+    May throw.
+    """
+    event_properties = dict(**event_properties)
+    event = {
+        'event': 'devstack.command.run',
+        'userId': config['anonymous_user_id'],
+        'properties': event_properties,
+        'sentAt': datetime.now(timezone.utc).isoformat(),
+    }
+
+    if test_mode:
+        event_properties['is_test'] = test_mode
+        print(f"Send metrics info: {json.dumps(event)}", file=sys.stderr)
+
+    # https://segment.com/docs/connections/sources/catalog/libraries/server/http-api/
+    headers = {
+        'Authorization': 'Basic ' + base64str(config['segment_write_key'] + ':'),
+        'Content-Type': 'application/json',
+        'User-Agent': 'edx-devstack-send-metrics',
+    }
+    request = req.Request(
+        url = 'https://api.segment.io/v1/track',
+        method = 'POST',
+        headers = headers,
+        data = json.dumps(event).encode(),
+    )
+
+    try:
+        with req.urlopen(request, timeout=8) as resp:
+            status_code = resp.getcode()
+            if status_code != 200 and test_mode:
+                print("Segment metrics send returned an unexpected status code ${status_code}", file=sys.stderr)
+    # Might just be a Segment outage; user probably doesn't care.
+    # Other errors can bubble up to a layer that might report them.
+    except (RemoteDisconnected, URLError) as e:
+        if test_mode:
+            traceback.print_exc()
+
+
+def run_wrapped(make_target, config):
     """
     Runs specified make shell target and collects performance data.
     """
-    t0 = datetime.datetime.now()
+    start_time = datetime.now(timezone.utc)
+
     completed_process = run_target(make_target)
-    t1 = datetime.datetime.now()
-    exit_code = completed_process.returncode
-    time_diff = t1.timestamp() - t0.timestamp()
-    output = {"target":make_target, "t0":t0, "time_diff":time_diff, "exit_code": exit_code}
-    print(f"send metrics info: {output}", file=sys.stderr)
+
+    # Do as much as possible inside try blocks
+    try:
+        end_time = datetime.now(timezone.utc)
+        exit_code = completed_process.returncode
+        time_diff_millis = (end_time - start_time).microseconds // 1000
+        # Must be compatible with our Segment schema
+        event_properties = {
+            'command_type': 'make',
+            'command': make_target[:50],  # limit in case of mis-pastes at terminal
+            'start_time': start_time.isoformat(),
+            'duration': time_diff_millis,
+            'exit_status': exit_code,
+            'is_test': 'false',
+        }
+        send_metrics_to_segment(event_properties, config)
+    except Exception as e:
+        # We don't want to warn about transient Segment outages or
+        # similar, but there might be a coding error in the
+        # send-metrics script.
+        traceback.print_exc()
+        print("Failed to send devstack metrics to Segment. "
+              "If this keeps happening, please let the Architecture team know. "
+              "(This should not have affected the outcome of your make command.)",
+              file=sys.stderr)
+
 
 def run_target(make_target):
+    """Just run make on the given target."""
     return subprocess.run(["make", f"impl-{make_target}"])
 
-def main(make_target):
-    # Collect data only if user has consented to data collection by creating a file named: ~/.config/devstack/metrics.json
-    if path.exists(path.expanduser("~/.config/devstack/metrics.json")):
-        send_metrics(make_target)
+
+def main(args):
+    if len(args) != 1:
+        print("Usage: send-metrics.py <make-target>", file=sys.stderr)
+        exit(1)
+    make_target = args[0]
+
+    # Collect and report data only if user has consented to data collection
+    try:
+        consented_config = prep_for_send()
+    except Exception as e:  # don't let errors interrupt dev's work
+        if test_mode:
+            print(f"Metrics disabled due to startup error: {e!r}")
+        consented_config = None
+
+    if consented_config:
+        run_wrapped(make_target, consented_config)
     else:
         run_target(make_target)
 
+
 if __name__ == "__main__":
-    # if no make target is specified, print error and exit.
-    if len(sys.argv)>1:
-        main(sys.argv[1])
-    else:
-        print("No make target specified")
+    main(sys.argv[1:])

--- a/tests/metrics.exp
+++ b/tests/metrics.exp
@@ -1,0 +1,49 @@
+#!/usr/bin/expect -f
+# Test that dev.up.% is instrumented for metrics collection.
+
+# You'll need a DEVSTACK_METRICS_TESTING=debug if running these locally.
+# This environment variable enables printing of metrics.
+if {![info exists env(DEVSTACK_METRICS_TESTING)] || $env(DEVSTACK_METRICS_TESTING) eq ""} {
+    puts "Environment variable DEVSTACK_METRICS_TESTING must be set"
+    exit 2
+}
+
+set homedir $env(HOME) ;# can't rely on tilde expansion when exec'ing
+set config_dir $homedir/.config/devstack
+set config_path $config_dir/metrics.json
+
+if {[file exist $config_path]} {
+    puts "You already have a config file; failing now to avoid overwriting it."
+    exit 2
+}
+
+# Set up a fake Segment write key so that CI tests are "opted in" and
+# will collect metrics.
+file mkdir $config_dir
+set cnf_id [open $config_path "w"]
+puts $cnf_id "{\"segment_write_key\":\"fake\"}"
+close $cnf_id
+
+# Clean up before exiting
+proc clean_exit {ecode} {
+    # For debugging
+    exec cat $::config_path >&@stdout
+    puts "\n^ Metrics config file in effect"
+
+    file delete $::config_path
+    exit $ecode
+}
+
+# OK, the actual test...
+
+set timeout 60
+
+spawn make dev.up.redis
+
+expect {
+    "Send metrics info:*dev.up.redis" {}
+    timeout { puts timeout; clean_exit 1 }
+    eof { puts EOF; clean_exit 1 }
+}
+
+clean_exit 0


### PR DESCRIPTION
- Gating changes from "does config file exist" to "does config file contain a Segment write key"
- try-blocks wrapped around everything that isn't running the user's intended command
- Most of our attributes are in place; still need anonymous user ID and an attribute for marking events resulting from automated tests

ARCHBOM-1761

----

I've completed each of the following, or confirmed they do not apply to this PR:

- [x] Tested on both Mac and Linux (if changed Makefile or shell scripts)
    - Already tested on: Linux
    - Testing instructions:
        - Make sure the config file `~/.config/devstack/metrics.json` is *missing*
        - Run `DEVSTACK_METRICS_TESTING=debug make dev.up.redis` and confirm that it works as it would normally
            - You should also notice an error message about config failure; this should not appear if that env var is not set
        - Set up the config file with `{"segment_write_key":"MUy..."}` (get write key from team)
        - Run `DEVSTACK_METRICS_TESTING=debug make dev.up.redis` and confirm some metrics are printed out this time
        - Confirm that an anonymous user ID has appeared in the config file
        - Run `make dev.up.something_unique` and confirm that you see the event in New Relic (`select * from DevstackMetrics since 2 days ago`)
- [x] Made a plan to communicate any major developer interface changes
    - None needed yet, still not enabled
