### PR TITLE
test: Fix corner case in warn-default test around early exit of process

### DIFF
--- a/tests/warn_default.exp
+++ b/tests/warn_default.exp
@@ -8,12 +8,14 @@ spawn make dev.pull
 expect {
     "Are you sure you want to run this command" {}
     timeout { exit 1 }
+    eof { exit 1 }
 }
 send "\n"
 
 expect {
     "Pulling lms" {}
     timeout { exit 1 }
+    eof { exit 1 }
 }
 
 # Send ^C, don't wait for it to finish


### PR DESCRIPTION
Previously this test would only fail if the spawned make command timed
out, but wouldn't fail if it exited without providing the expected text.
This covers that case by using the `eof` keyword.

----

I've completed each of the following, or confirmed they do not apply to this PR:

- [ ] Tested on both Mac and Linux (if changed Makefile or shell scripts)
    - Already tested on: Linux
    - Testing instructions:
        - Have `expect` installed
        - Run `./tests/warn_default.exp; echo $?` and confirm the last output is `0` (success)
        - Change the script's spawn line to `spawn ls`
        - Re-run and confirm the last output is `1` (error)
- [x] Made a plan to communicate any major developer interface changes
