### PR TITLE
doc: Remove reference to Vagrant Devstack.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,8 +8,7 @@ Documentation is on `Read the Docs`_.  Code repository is on `GitHub`_.
 .. _Read the Docs: https://edx.readthedocs.io/projects/open-edx-devstack/en/latest/
 .. _GitHub: https://github.com/edx/devstack
 
-This project replaces the older Vagrant-based devstack with a
-multi-container approach driven by `Docker Compose`_.
+The Devstack runs as multiple containers with `Docker Compose`_ at its core.
 
 A Devstack installation includes the following Open edX components by default:
 


### PR DESCRIPTION
A call back to the vagrant devstack is no longer relevant.

----

I've completed each of the following, or confirmed they do not apply to this PR:

- [ ] Tested on both Mac and Linux (if changed Makefile or shell scripts)
    - Already tested on: *[my OS here]*
    - Testing instructions: *[commands and expected behavior]*
- [ ] Made a plan to communicate any major developer interface changes
