### PR TITLE
test: More generous timeout on test; print hints on failure

### DIFF
--- a/tests/warn_default.exp
+++ b/tests/warn_default.exp
@@ -1,21 +1,21 @@
 #!/usr/bin/expect -f
 # Test that dev.pull (bare) prompts before continuing
 
-set timeout 3
+set timeout 15
 
 spawn make dev.pull
 
 expect {
     "Are you sure you want to run this command" {}
-    timeout { exit 1 }
-    eof { exit 1 }
+    timeout { puts timeout; exit 1 }
+    eof { puts EOF; exit 1 }
 }
 send "\n"
 
 expect {
     "Pulling lms" {}
-    timeout { exit 1 }
-    eof { exit 1 }
+    timeout { puts timeout; exit 1 }
+    eof { puts EOF; exit 1 }
 }
 
 # Send ^C, don't wait for it to finish


### PR DESCRIPTION
----

I've completed each of the following, or confirmed they do not apply to this PR:

- [ ] Tested on both Mac and Linux (if changed Makefile or shell scripts)
    - Already tested on: Linux
    - Testing instructions: Probably not needed, but if you install `expect` you can run `./tests/warn_default.exp; echo $?` before and after editing the test to do something broken (e.g. change `spawn make dev.pull` to `spawn make xxxxxx` or `spawn cat`). When it returns exit code 1, it should also indicate timeout or EOF.
- [x] Made a plan to communicate any major developer interface changes
    - N/A