### PR TITLE
 feat: Include Segment metrics write key; gate on new feature switch instead

### DIFF
--- a/tests/metrics.py
+++ b/tests/metrics.py
@@ -22,11 +22,10 @@ def test_metrics():
     assert not os.path.isfile(config_path), \
         "You already have a config file; failing now to avoid overwriting it."
 
-    # Set up a fake Segment write key so that CI tests are "opted in" and
-    # will collect metrics.
+    # Enable feature switch for CI tests
     os.makedirs(config_dir, exist_ok=True)
     with open(config_path, 'w') as f:
-        f.write(json.dumps({"segment_write_key": "fake"}))
+        f.write(json.dumps({'collection_enabled': True}))
 
     # OK, the actual test:
 


### PR DESCRIPTION
- Include Segment write key in source code (provisioned for this purpose)
- Stop reading write key from config file
- Use a more explicit feature flag in the config file for gating all of  the data collection and consent checking. This flag is intended to be  temporary.
- Add negative metrics tests

There should be no observable behavior change for people who have not manually created this config file.

ref ARCHBOM-1785

(commits best reviewed individually)

----

I've completed each of the following, or confirmed they do not apply to this PR:

- [x] Tested on both Mac and Linux (if changed Makefile or shell scripts)
    - Already tested on: Linux
    - Testing instructions: Run tests
- [x] Made a plan to communicate any major developer interface changes
