### PR TITLE
feat!: Change metrics is_test default from 'false' to 'no'

### DIFF
--- a/scripts/send-metrics.py
+++ b/scripts/send-metrics.py
@@ -91,7 +91,11 @@ def send_metrics_to_segment(event_properties, config):
 
     May throw.
     """
-    event_properties = dict(is_test=test_mode or 'no', **event_properties)
+    # Get a shallow copy of the input and annotate it as a non-test
+    # event unless overridden by environment variable.
+    event_properties = event_properties.copy()
+    event_properties['is_test'] = test_mode or 'no'
+
     event = {
         'event': 'devstack.command.run',
         'userId': config['anonymous_user_id'],

--- a/scripts/send-metrics.py
+++ b/scripts/send-metrics.py
@@ -91,7 +91,7 @@ def send_metrics_to_segment(event_properties, config):
 
     May throw.
     """
-    event_properties = dict(**event_properties)
+    event_properties = dict(is_test=test_mode or 'no', **event_properties)
     event = {
         'event': 'devstack.command.run',
         'userId': config['anonymous_user_id'],
@@ -100,7 +100,6 @@ def send_metrics_to_segment(event_properties, config):
     }
 
     if test_mode:
-        event_properties['is_test'] = test_mode
         print(f"Send metrics info: {json.dumps(event)}", file=sys.stderr)
 
     # https://segment.com/docs/connections/sources/catalog/libraries/server/http-api/
@@ -148,7 +147,6 @@ def run_wrapped(make_target, config):
             'start_time': start_time.isoformat(),
             'duration': time_diff_millis,
             'exit_status': exit_code,
-            'is_test': 'no',
         }
         send_metrics_to_segment(event_properties, config)
     except Exception as e:

--- a/scripts/send-metrics.py
+++ b/scripts/send-metrics.py
@@ -148,7 +148,7 @@ def run_wrapped(make_target, config):
             'start_time': start_time.isoformat(),
             'duration': time_diff_millis,
             'exit_status': exit_code,
-            'is_test': 'false',
+            'is_test': 'no',
         }
         send_metrics_to_segment(event_properties, config)
     except Exception as e:

--- a/tests/metrics.py
+++ b/tests/metrics.py
@@ -82,4 +82,25 @@ def test_metrics():
     with environment_as({'collection_enabled': True}):
         p = pexpect.spawn('make dev.up.redis', timeout=60)
         p.expect(r'Send metrics info:')
-        p.expect(r'dev\.up\.redis')
+        p.expect(pexpect.EOF)
+        metrics_json = p.before.decode()
+
+        data = json.loads(metrics_json)
+        # These keys are defined by a central document; do not send
+        # additional metrics without specifying them there first:
+        #
+        # https://openedx.atlassian.net/wiki/spaces/AC/pages/2720432206/Devstack+Metrics
+        #
+        # Additional metrics require approval.
+        assert sorted(data.keys()) == ['event', 'properties', 'sentAt', 'userId'], \
+            "Unrecognized key in envelope -- confirm that this addition is authorized."
+        assert sorted(data['properties'].keys()) == [
+            'command', 'command_type', 'duration',
+            'exit_status', 'is_test', 'start_time'
+        ], "Unrecognized attribute -- confirm that this addition is authorized."
+
+        assert data['event'] == 'devstack.command.run'
+        assert data['properties']['command'] == 'dev.up.redis'
+        is_test = data['properties']['is_test']
+        assert type(is_test) == str
+        assert is_test != 'no'

--- a/tests/metrics.py
+++ b/tests/metrics.py
@@ -101,6 +101,5 @@ def test_metrics():
 
         assert data['event'] == 'devstack.command.run'
         assert data['properties']['command'] == 'dev.up.redis'
-        is_test = data['properties']['is_test']
-        assert type(is_test) == str
-        assert is_test != 'no'
+        # Any string but 'no', really (will match env var in practice)
+        assert data['properties']['is_test'] in ['ci', 'debug']


### PR DESCRIPTION
This is to work around a bug in New Relic dashboards where an attempt to
filter on the string false turns into a filter on a boolean false. It might
also be clearer to read.

Also adds a more detailed test of metrics data, both expected values and
a total allowed set of keys. (Includes test of `is_test` attribute.)

----

I've completed each of the following, or confirmed they do not apply to this PR:

- [x] Tested on both Mac and Linux (if changed Makefile or shell scripts)
    - Already tested on: Linux
    - Testing instructions: Confirmed that test failed with env var `DEVSTACK_METRICS_TESTING=no`
- [x] Made a plan to communicate any major developer interface changes
