### PR TITLE
feat: add target to install XBlocks into LMS+Studio

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -633,7 +633,7 @@ build-courses: ## Build course and provision studio, and ecommerce with it.
 
 XBLOCKS_HOME=$(abspath $(DEVSTACK_WORKSPACE)/edx-platform/src)
 XBLOCKS_NAMES=$(addprefix src/,$(notdir $(wildcard $(XBLOCKS_HOME)/*)))
-dev.xblocks.install: dev.up.without-deps.lms dev.up.without-deps.studio  ## Install XBlocks into LMS+Studio
+dev.xblocks.install: dev.up.lms dev.up.studio  ## Install XBlocks into LMS+Studio
 ifeq ($(XBLOCKS_NAMES),)
 	@printf '\n\n\n\n'
 	@echo "This is setup to automatically install any XBlocks found in $(XBLOCKS_HOME)"

--- a/Makefile
+++ b/Makefile
@@ -642,6 +642,7 @@ ifneq ($(XBLOCKS_NAMES),)
 	docker-compose exec studio env /edx/app/edxapp/devstack.sh exec \
 	    pip install -e $(XBLOCKS_NAMES) \
 	;
+	$(MAKE) lms-restart studio-restart
 	@printf '\n\n\n\n'
 	@printf "Here are the currently installed XBlocks "
 	@echo "(installed packages with 'xblock' in the name):"

--- a/Makefile
+++ b/Makefile
@@ -633,17 +633,18 @@ build-courses: ## Build course and provision studio, and ecommerce with it.
 
 XBLOCKS_HOME=$(abspath $(DEVSTACK_WORKSPACE)/edx-platform/src)
 XBLOCKS_NAMES=$(addprefix src/,$(notdir $(wildcard $(XBLOCKS_HOME)/*)))
-dev.xblocks.install: dev.up.lms dev.up.studio  ## Install XBlocks into LMS+Studio
-ifeq ($(XBLOCKS_NAMES),)
+dev.xblocks.install:  ## Install XBlocks into LMS+Studio
 	@printf '\n\n\n\n'
 	@echo "This is setup to automatically install any XBlocks found in $(XBLOCKS_HOME)"
 	@echo "You'll need to check-out any XBlock repositories there, like:"
 	@echo
 	@echo "    git clone git@github.com:edx/xblock-image-modal.git $(XBLOCKS_HOME)/xblock-image-modal"
 	@echo
+ifeq ($(XBLOCKS_NAMES),)
 	@echo "then try this command again."
-	exit 1
+	@exit 1
 else
+	make dev.up.lms dev.up.studio
 	docker-compose exec lms env /edx/app/edxapp/devstack.sh exec \
 		pip install -e $(XBLOCKS_NAMES) \
 	;

--- a/Makefile
+++ b/Makefile
@@ -634,17 +634,8 @@ build-courses: ## Build course and provision studio, and ecommerce with it.
 XBLOCKS_HOME=$(abspath $(DEVSTACK_WORKSPACE)/edx-platform/src)
 XBLOCKS_NAMES=$(addprefix src/,$(notdir $(wildcard $(XBLOCKS_HOME)/*)))
 dev.xblocks.install:  ## Install XBlocks into LMS+Studio
-	@printf '\n\n\n\n'
-	@echo "This is setup to automatically install any XBlocks found in $(XBLOCKS_HOME)"
-	@echo "You'll need to check-out any XBlock repositories there, like:"
-	@echo
-	@echo "    git clone git@github.com:edx/xblock-image-modal.git $(XBLOCKS_HOME)/xblock-image-modal"
-	@echo
-ifeq ($(XBLOCKS_NAMES),)
-	@echo "then try this command again."
-	@exit 1
-else
-	make dev.up.lms dev.up.studio
+ifneq ($(XBLOCKS_NAMES),)
+	make dev.up.without-deps.lms dev.up.without-deps.studio
 	docker-compose exec lms env /edx/app/edxapp/devstack.sh exec \
 		pip install -e $(XBLOCKS_NAMES) \
 	;
@@ -660,3 +651,10 @@ else
 		| sed 's/.*egg=//; s/\&.*//' \
 	;
 endif
+	@printf '\n\n'
+	@echo "This is setup to automatically install any XBlocks found in $(XBLOCKS_HOME)"
+	@echo "You'll need to check-out any XBlock repositories there, like:"
+	@echo
+	@echo "    git clone git@github.com:edx/xblock-image-modal.git $(XBLOCKS_HOME)/xblock-image-modal"
+	@echo
+	@echo "then try this command again."


### PR DESCRIPTION
Story
=====
As an XBlock developer,
I want to easily install my XBlock in LMS+Studio,
so I can easily run my XBlock in LMS+Studio.

Testing
=======
- Run `make dev.xblocks.install` once.
  - See the error/instruction message.
  - Follow directions and clone an XBlock to `edx-platform/src`.
- Run `make dev.xblocks.install` again.
  - Confirm your XBlock listed in the output.
- In Studio, enable your XBlock [1].
  - Confirm you can now add your XBlock to a Unit.

References
==========
- [1] https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/exercises_tools/enable_exercises_tools.html#enable-additional-exercises-and-tools

----

I've completed each of the following, or confirmed they do not apply to this PR:

- [ ] Tested on both Mac and Linux (if changed Makefile or shell scripts)
    - [X] Already tested on: Linux
- [ ] Made a plan to communicate any major developer interface changes
