### PR TITLE
feat: Add metrics for git commit timestamp and , whether on master

### DIFF
--- a/scripts/send-metrics.py
+++ b/scripts/send-metrics.py
@@ -140,13 +140,14 @@ def read_git_state():
     # timestamp; the latter could be older when commits have been
     # rewritten, and the former is more likely to be of interest when
     # looking at repo checkout age.
-    p = subprocess.run(
+    process = subprocess.run(
         ['git', 'show', '--no-patch', '--pretty=format:%cI|%D'],
         capture_output=True, check=True, timeout=5
     )
-    timestamp, reflist = p.stdout.decode().split('|', 2)
-    # Returns true if master is currently checked out. Does not return
-    # true in the following similar situations:
+    timestamp, reflist = process.stdout.decode().split('|', 2)
+    # Returns true if master is currently checked out. Returns false
+    # otherwise, which includes the following situations that are similar
+    # to, but different from a master checkout:
     #
     # - Detached-head state which happens to be on same commit as master
     # - Another branch is checked out but points to the same commit as

--- a/tests/metrics.py
+++ b/tests/metrics.py
@@ -95,8 +95,9 @@ def test_metrics():
         assert sorted(data.keys()) == ['event', 'properties', 'sentAt', 'userId'], \
             "Unrecognized key in envelope -- confirm that this addition is authorized."
         assert sorted(data['properties'].keys()) == [
-            'command', 'command_type', 'duration',
-            'exit_status', 'is_test', 'start_time'
+            'command', 'command_type', 'duration', 'exit_status',
+            'git_checked_out_master', 'git_commit_time',
+            'is_test', 'start_time',
         ], "Unrecognized attribute -- confirm that this addition is authorized."
 
         assert data['event'] == 'devstack.command.run'


### PR DESCRIPTION
`git_commit_time`:

This discovers the timestamp of the currently checked out commit and
includes it in the metrics so that we know how old a version of devstack
the developer is using. This has use both in correlating behavior changes
to devstack version and in seeing whether people use old versions of
devstack.

`git_checked_out_master`:

This allows us to filter out events made on other branches, since we’re
not sure how much time people spend on branches. While it is derivable
from `git_commit_time` plus a copy of the repo’s public reflog, collecting
it this way is useful because New Relic can’t integrate that public data
readily.

----

I've completed each of the following, or confirmed they do not apply to this PR:

- [x] Tested on both Mac and Linux (if changed Makefile or shell scripts)
    - Already tested on: Linux
    - Testing instructions: With collection enabled, run `DEVSTACK_METRICS_TESTING=debug make dev.up.redis` and confirm that output of git attrs looks correct.
- [x] Made a plan to communicate any major developer interface changes
