### PR TITLE
feat: Implement consent check for metrics reporting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -594,6 +594,17 @@ _expects-database.%:
 
 
 ########################################################################################
+# Convenient ways to opt in or out of devstack usage metrics reporting
+########################################################################################
+
+metrics-opt-in:
+	@./scripts/send-metrics.py opt-in
+
+metrics-opt-out:
+	@./scripts/send-metrics.py opt-out
+
+
+########################################################################################
 # Miscellaneous targets.
 # These are useful, but don't fit nicely to the greater Devstack interface.
 ########################################################################################

--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ dev.pull.without-deps.%: ## Pull latest Docker images for specific services.
 	docker-compose pull $$(echo $* | tr + " ")
 
 dev.pull:
-	@scripts/send-metrics.py "$@"
+	@scripts/send-metrics.py wrap "$@"
 
 impl-dev.pull: ##
 	@scripts/make_warn_default_large.sh "dev.pull"
@@ -322,7 +322,7 @@ endif
 
 # Wildcards must be below anything they could match
 dev.up.%:
-	@scripts/send-metrics.py "dev.up.$*"
+	@scripts/send-metrics.py wrap "dev.up.$*"
 
 dev.ps: ## View list of created services and their statuses.
 	docker-compose ps

--- a/scripts/send-metrics.py
+++ b/scripts/send-metrics.py
@@ -228,13 +228,11 @@ def run_target(make_target):
     return subprocess.run(["make", f"impl-{make_target}"])
 
 
-def main(args):
-    if len(args) != 1:
-        print("Usage: send-metrics.py <make-target>", file=sys.stderr)
-        exit(1)
-    make_target = args[0]
-
-    # Collect and report data only if user has consented to data collection
+def do_wrap(make_target):
+    """
+    Run the given make target, and collect and report data if and only if
+    the user has consented to data collection.
+    """
     try:
         consented_config = prep_for_send()
     except Exception as e:  # don't let errors interrupt dev's work
@@ -246,6 +244,28 @@ def main(args):
         run_wrapped(make_target, consented_config)
     else:
         run_target(make_target)
+
+
+def main(args):
+    if len(args) == 0:
+        print(
+            "Usage:\n"
+            "  send-metrics.py wrap <make-target>",
+            file=sys.stderr
+        )
+        exit(1)
+    action = args[0]
+    action_args = args[1:]
+
+    # Dispatch
+    if action == 'wrap':
+        if len(action_args) != 1:
+            print("send-metrics wrap takes one argument", file=sys.stderr)
+            exit(1)
+        do_wrap(action_args[0])
+    else:
+        print(f"Unrecognized action: {action}", file=sys.stderr)
+        exit(1)
 
 
 if __name__ == "__main__":

--- a/tests/metrics.py
+++ b/tests/metrics.py
@@ -2,9 +2,15 @@ import json
 import os
 import pexpect
 import pytest
+import re
 from contextlib import contextmanager
 from pexpect import EOF
 
+
+#### Utilities
+
+config_dir = os.path.expanduser('~/.config/devstack')
+config_path = os.path.join(config_dir, 'metrics.json')
 
 @contextmanager
 def environment_as(config_data):
@@ -20,9 +26,6 @@ def environment_as(config_data):
         "locally since this environment variable both enables printing of " \
         "metrics and also marks sent metric events as test data."
         
-    config_dir = os.path.expanduser('~/.config/devstack')
-    config_path = os.path.join(config_dir, 'metrics.json')
-
     assert not os.path.isfile(config_path), \
         "You already have a config file; failing now to avoid overwriting it."
 
@@ -46,13 +49,144 @@ def environment_as(config_data):
             pass
 
 
+def do_opt_in():
+    """Opt in (without assertions)."""
+    p = pexpect.spawn('make metrics-opt-in', timeout=10)
+    p.expect("Type 'yes' or 'y'")
+    p.sendline('yes')
+    p.expect(EOF)
+
+
+def assert_consent(status=True):
+    """
+    Assert consent status in config file. status=True will check for consent
+    with timestamp, False will check for a decline with timestamp, and None
+    will check that the consent dict is missing.
+    """
+    with open(config_path, 'r') as f:
+        config = json.loads(f.read())
+        if status == None:
+            assert 'consent' not in config
+        else:
+            assert type(status) is bool
+            consent = config['consent']
+            assert consent.get('decision') == status
+            # Timestamp should be a date at least (likely also has a time)
+            assert re.match(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}', consent.get('timestamp'))
+
+
+#### Opting in and out
+
+def test_initial_opt_in_accept():
+    """
+    Test that a consent check is provided, and what happens on accept.
+    """
+    with environment_as({'collection_enabled': True}):
+        p = pexpect.spawn('make metrics-opt-in', timeout=10)
+        p.expect_exact("Allow devstack to report anonymized usage metrics?")
+        p.expect("https://")  # gives a URL for more info
+        p.expect("Type 'yes' or 'y'")
+        p.sendline("yes")
+        p.expect("metrics-opt-out")  # prints instructions for opt-out
+        # Check that a metric is sent for opt-in
+        p.expect("Send metrics info:")
+        p.expect(EOF)
+        metrics_json = p.before.decode()
+
+        data = json.loads(metrics_json)
+        # These keys are defined by a central document; do not send
+        # additional metrics without specifying them there first:
+        #
+        # https://openedx.atlassian.net/wiki/spaces/AC/pages/2720432206/Devstack+Metrics
+        #
+        # Additional metrics require approval (as do changes to
+        # existing ones).
+        assert sorted(data.keys()) == ['event', 'properties', 'sentAt', 'userId'], \
+            "Unrecognized key in envelope -- confirm that this addition is authorized."
+        assert sorted(data['properties'].keys()) == [
+            'choice', 'command', 'command_type',
+            'git_checked_out_master', 'git_commit_time',
+            'is_test', 'start_time',
+        ], "Unrecognized attribute -- confirm that this addition is authorized."
+
+        assert data['event'] == 'devstack.command.run'
+        assert data['properties']['command_type'] == 'make'
+        assert data['properties']['command'] == 'metrics-opt-in'
+        assert data['properties']['choice'] == 'accept'
+
+        assert_consent(True)
+
+
+def test_initial_opt_in_decline():
+    """
+    Test that a consent check is provided, and what happens on decline.
+    """
+    with environment_as({'collection_enabled': True}):
+        p = pexpect.spawn('make metrics-opt-in', timeout=10)
+        p.sendline("")  # empty response
+        # No metrics event sent
+        with pytest.raises(EOF):
+            p.expect(r'Send metrics info:')
+        # No consent info stored on decline
+        assert_consent(None)
+
+
+def test_initial_opt_out():
+    """
+    Test that opt-out always marks consent=False (even without collection=enabled).
+    """
+    with environment_as(None):
+        p = pexpect.spawn('make metrics-opt-out', timeout=10)
+        p.expect('metrics-opt-in')  # indicates how to undo
+        # No metrics event sent
+        with pytest.raises(EOF):
+            p.expect(r'Send metrics info:')
+        assert_consent(False)
+
+
+def test_later_opt_out():
+    """
+    Test that opt-out after previously opting in sends an event.
+    """
+    with environment_as({'collection_enabled': True}):
+        do_opt_in()
+        p = pexpect.spawn('make metrics-opt-out', timeout=10)
+        p.expect('metrics-opt-in')
+        p.expect(r'Send metrics info:')
+        p.expect(EOF)
+        metrics_json = p.before.decode()
+
+        data = json.loads(metrics_json)
+        # These keys are defined by a central document; do not send
+        # additional metrics without specifying them there first:
+        #
+        # https://openedx.atlassian.net/wiki/spaces/AC/pages/2720432206/Devstack+Metrics
+        #
+        # Additional metrics require approval (as do changes to
+        # existing ones).
+        assert sorted(data.keys()) == ['event', 'properties', 'sentAt', 'userId'], \
+            "Unrecognized key in envelope -- confirm that this addition is authorized."
+        assert sorted(data['properties'].keys()) == [
+            'command', 'command_type', 'is_test', 'previous_consent', 'start_time',
+        ], "Unrecognized attribute -- confirm that this addition is authorized."
+
+        assert data['event'] == 'devstack.command.run'
+        assert data['properties']['command_type'] == 'make'
+        assert data['properties']['command'] == 'metrics-opt-out'
+        assert data['properties']['previous_consent'] == 'yes'
+
+        assert_consent(False)
+
+
+#### Collection, or not, for an instrumented make target
+
 def test_feature_flag_missing():
     """
     Test that metrics collection does not happen with feature flag missing.
     """
     with environment_as(None):
         p = pexpect.spawn('make dev.up.redis', timeout=60)
-        with pytest.raises(pexpect.EOF):
+        with pytest.raises(EOF):
             p.expect(r'Send metrics info:')
 
 
@@ -62,7 +196,18 @@ def test_feature_flag_false():
     """
     with environment_as({'collection_enabled': False}):
         p = pexpect.spawn('make dev.up.redis', timeout=60)
-        with pytest.raises(pexpect.EOF):
+        with pytest.raises(EOF):
+            p.expect(r'Send metrics info:')
+
+
+def test_enabled_but_no_consent():
+    """
+    Test that consent still required even with feature flag enabled.
+    """
+    with environment_as({'collection_enabled': True}):
+        # no opt-in first
+        p = pexpect.spawn('make dev.up.redis', timeout=60)
+        with pytest.raises(EOF):
             p.expect(r'Send metrics info:')
 
 
@@ -71,8 +216,9 @@ def test_no_arbitrary_target_instrumented():
     Test that arbitrary make targets are not instrumented.
     """
     with environment_as({'collection_enabled': True}):
+        do_opt_in()
         p = pexpect.spawn('make xxxxx', timeout=60)
-        with pytest.raises(pexpect.EOF):
+        with pytest.raises(EOF):
             p.expect(r'Send metrics info:')
 
 
@@ -81,9 +227,10 @@ def test_metrics():
     Test that dev.up.% is instrumented for metrics collection.
     """
     with environment_as({'collection_enabled': True}):
+        do_opt_in()
         p = pexpect.spawn('make dev.up.redis', timeout=60)
         p.expect(r'Send metrics info:')
-        p.expect(pexpect.EOF)
+        p.expect(EOF)
         metrics_json = p.before.decode()
 
         data = json.loads(metrics_json)
@@ -92,7 +239,8 @@ def test_metrics():
         #
         # https://openedx.atlassian.net/wiki/spaces/AC/pages/2720432206/Devstack+Metrics
         #
-        # Additional metrics require approval.
+        # Additional metrics require approval (as do changes to
+        # existing ones).
         assert sorted(data.keys()) == ['event', 'properties', 'sentAt', 'userId'], \
             "Unrecognized key in envelope -- confirm that this addition is authorized."
         assert sorted(data['properties'].keys()) == [
@@ -106,11 +254,13 @@ def test_metrics():
         # Any string but 'no', really (will match env var in practice)
         assert data['properties']['is_test'] in ['ci', 'debug']
 
+
 def test_handle_ctrl_c():
     """
     Test that wrapper can survive and report on a Ctrl-C.
     """
     with environment_as({'collection_enabled': True}):
+        do_opt_in()
         p = pexpect.spawn('make dev.pull', timeout=60)
         # Make sure wrapped command has started before we interrupt,
         # otherwise signal handler won't even have been registered


### PR DESCRIPTION
This adds a proper consent check. The whole thing is still gated on the feature flag for now, since we haven't yet user-tested the consent flow or gotten final approval. This does not yet advertise the new make targets.

Feature changes:

- Require new `"consent"` key in config to gate collecting and reporting
- Send event for opt-in (but not for opt-out, of course)
- New make targets `metrics-opt-in` and `metrics-opt-out`

Supporting changes:

- Lift config path to global variable (in script and tests)
- Extract config keys to constants
- Generalize to allow multiple Segment event types

ref ARCHBOM-1786

----

I've completed each of the following, or confirmed they do not apply to this PR:

- [x] Tested on both Mac and Linux (if changed Makefile or shell scripts)
    - Already tested on: Linux
    - Testing instructions: With the feature flag in place and `DEVSTACK_METRICS_TESTING=debug` exported in your shell, try opting in and out several times in a row to see what happens. (e.g. in, in, out, out, in). Confirm that metrics are only sent on a positive opt-in or for instrumented commands (e.g. `make dev.up.redis`) while opted in.
- [x] Made a plan to communicate any major developer interface changes
