### PR TITLE
feat: Allow metrics logging of make runs interrupted by Ctrl-C

### DIFF
--- a/tests/README.rst
+++ b/tests/README.rst
@@ -1,0 +1,8 @@
+Devstack CLI tests
+==================
+
+These tests rely heavily on the pexpect library (inspired by TCL
+Expect); if you're editing or creating tests it is highly recommended
+you read up on the gotchas in here:
+
+https://pexpect.readthedocs.io/en/stable/overview.html


### PR DESCRIPTION
This traps SIGINT in the metrics wrapper just before launching the
subprocess and untraps it right after (including if a signal is caught.)

This also moves the collection setup into a try/except block so that errors
during setup don't prevent the wrapped command from running.

----

I've completed each of the following, or confirmed they do not apply to this PR:

- [x] Tested on both Mac and Linux (if changed Makefile or shell scripts)
    - Already tested on: Linux
    - Testing instructions: Try Ctrl-C during `make dev.pull`
- [x] Made a plan to communicate any major developer interface changes
