### PR TITLE
fix: Update text of metrics opt-in.

### DIFF
--- a/scripts/send-metrics.py
+++ b/scripts/send-metrics.py
@@ -284,16 +284,17 @@ def do_opt_in():
         )
         return
 
+    # NOTE: This is required for informed consent on the part of the users opting-in.
+    # The types of data collected cannot be expanded or changed without legal review.
     print(
         "Allow devstack to report anonymized usage metrics?\n"
         "\n"
         "This will report usage information to a team at edX so that "
-        "devstack improvements can be planned and evaluated. The exact metrics "
-        "may change over time, but will include information such as the make "
-        "target, a timestamp, duration of command run, the version of devstack, "
-        "and an anonymous user ID. See "
-        "https://openedx.atlassian.net/wiki/spaces/AC/pages/2720432206/Devstack+Metrics "
-        "for more information. You can opt out again at any time.\n"
+        "devstack improvements can be planned and evaluated. The metrics included are: "
+        "the make target, a timestamp, duration of command run, the git hash of the version of devstack, "
+        "whether or not this command was run on the master branch, the exit status of the command, "
+        "and an anonymous user ID."
+        "You can opt out again at any time.\n"
         "\n"
         "Type 'yes' or 'y' to opt in, or anything else to cancel."
     )

--- a/tests/metrics.py
+++ b/tests/metrics.py
@@ -84,7 +84,6 @@ def test_initial_opt_in_accept():
     with environment_as({'collection_enabled': True}):
         p = pexpect.spawn('make metrics-opt-in', timeout=10)
         p.expect_exact("Allow devstack to report anonymized usage metrics?")
-        p.expect("https://")  # gives a URL for more info
         p.expect("Type 'yes' or 'y'")
         p.sendline("yes")
         p.expect("metrics-opt-out")  # prints instructions for opt-out
@@ -100,7 +99,7 @@ def test_initial_opt_in_accept():
         # https://openedx.atlassian.net/wiki/spaces/AC/pages/2720432206/Devstack+Metrics
         #
         # Additional metrics require approval (as do changes to
-        # existing ones).
+        # existing ones). Update the list of metrics displayed during opt-in in send-metrics.py
         assert sorted(data.keys()) == ['event', 'properties', 'sentAt', 'userId'], \
             "Unrecognized key in envelope -- confirm that this addition is authorized."
         assert sorted(data['properties'].keys()) == [

--- a/tests/metrics.py
+++ b/tests/metrics.py
@@ -99,7 +99,8 @@ def test_initial_opt_in_accept():
         # https://openedx.atlassian.net/wiki/spaces/AC/pages/2720432206/Devstack+Metrics
         #
         # Additional metrics require approval (as do changes to
-        # existing ones). Update the list of metrics displayed during opt-in in send-metrics.py
+        # existing ones). Changes to metrics also require an update to the
+        # list of metrics displayed during opt-in.
         assert sorted(data.keys()) == ['event', 'properties', 'sentAt', 'userId'], \
             "Unrecognized key in envelope -- confirm that this addition is authorized."
         assert sorted(data['properties'].keys()) == [


### PR DESCRIPTION
We want to be more explicit about the data collected
for devstack metrics. Opt-in now lists all data collected.

https://openedx.atlassian.net/browse/ARCHBOM-1800

----

I've completed each of the following, or confirmed they do not apply to this PR:

- [ ] Tested on both Mac and Linux (if changed Makefile or shell scripts)
    - Already tested on: Mac
    - Testing instructions: run `make metrics-opt-in` and read through the updated opt-in text.
