### PR TITLE
feat: adding metrics collections to more targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,8 +292,11 @@ dev.drop-db.%: ## Irreversably drop the contents of a MySQL database in each mys
 
 dev.up.attach: _expects-service.dev.up.attach
 
-dev.up.attach.%: ## Bring up a service and its dependencies + and attach to it.
+impl-dev.up.attach.%: ## Bring up a service and its dependencies + and attach to it.
 	docker-compose up $*
+
+dev.up.attach.%: ## Bring up a service and its dependencies + and attach to it.
+	@scripts/send-metrics.py wrap "dev.up.attach.$*"
 
 dev.up.shell: _expects-service.dev.up.shell
 
@@ -313,8 +316,11 @@ dev.up.with-watchers.%: ## Bring up services and their dependencies + asset watc
 
 dev.up.without-deps: _expects-service-list.dev.up.without-deps
 
-dev.up.without-deps.%: dev.check-memory ## Bring up services by themselves.
+impl-dev.up.without-deps.%: dev.check-memory ## Bring up services by themselves.
 	docker-compose up --d --no-deps $$(echo $* | tr + " ")
+
+dev.up.without-deps.%: ## Bring up services by themselves.
+	@scripts/send-metrics.py wrap "dev.up.without-deps.$*"
 
 dev.up.without-deps.shell: _expects-service.dev.up.without-deps.shell
 

--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,8 @@
         dev.up.without-deps dev.up.without-deps.shell dev.up.with-programs \
         dev.up.with-watchers dev.validate docs e2e-tests e2e-tests.with-shell \
         help requirements impl-dev.clone.https impl-dev.clone.ssh impl-dev.provision \
-		impl-dev.pull impl-dev.pull.without-deps impl-dev.up impl-dev.up.attach \
-		impl-dev.up.without-deps selfcheck upgrade upgrade \
+        impl-dev.pull impl-dev.pull.without-deps impl-dev.up impl-dev.up.attach \
+        impl-dev.up.without-deps selfcheck upgrade upgrade \
         validate-lms-volume vnc-passwords
 
 # Load up options (configurable through options.local.mk).

--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ dev.clone.https: ## Clone service repos using HTTPS method to the parent directo
 impl-dev.clone.ssh: ## Clone service repos using SSH method to the parent directory.
 	./repo.sh clone_ssh
 
-dev.clone.ssh:
+dev.clone.ssh: ## Clone service repos using SSH method to the parent directory.
 	@scripts/send-metrics.py wrap "$@"
 
 ########################################################################################
@@ -205,7 +205,7 @@ dev.clone.ssh:
 
 dev.pull.without-deps: _expects-service-list.dev.pull.without-deps
 
-dev.pull.without-deps.%:
+dev.pull.without-deps.%: ## Pull latest Docker images for specific services.
 	@scripts/send-metrics.py wrap "dev.pull.without-deps.$*"
 
 impl-dev.pull.without-deps.%: ## Pull latest Docker images for specific services.
@@ -214,7 +214,7 @@ impl-dev.pull.without-deps.%: ## Pull latest Docker images for specific services
 dev.pull:
 	@scripts/send-metrics.py wrap "$@"
 
-impl-dev.pull: ##
+impl-dev.pull:
 	@scripts/make_warn_default_large.sh "dev.pull"
 
 dev.pull.large-and-slow: dev.pull.$(DEFAULT_SERVICES) ## Pull latest Docker images required by default services.
@@ -222,21 +222,25 @@ dev.pull.large-and-slow: dev.pull.$(DEFAULT_SERVICES) ## Pull latest Docker imag
 
 # Wildcards must be below anything they could match
 dev.pull.%: ## Pull latest Docker images for services and their dependencies.
+	@scripts/send-metrics.py wrap "dev.pull.$*"
+
+impl-dev.pull.%: ## Pull latest Docker images for services and their dependencies.
 	docker-compose pull --include-deps $$(echo $* | tr + " ")
 
 ########################################################################################
 # Developer interface: Database management.
 ########################################################################################
 
-impl-dev.provision: dev.check-memory ## Provision dev environment with default services, and then stop them.
+impl-dev.provision: ## Provision dev environment with default services, and then stop them.
 	# We provision all default services as well as 'e2e' (end-to-end tests).
 	# e2e is not part of `DEFAULT_SERVICES` because it isn't a service;
 	# it's just a way to tell ./provision.sh that the fake data for end-to-end
 	# tests should be prepared.
+	make dev.check-memory
 	$(WINPTY) bash ./provision.sh $(DEFAULT_SERVICES)+e2e
 	make dev.stop
 
-dev.provision:
+dev.provision: ## Provision dev environment with default services, and then stop them.
 	@scripts/send-metrics.py wrap "$@"
 
 impl-dev.provision.%: dev.check-memory ## Provision specified services.

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,9 @@
         dev.sync.requirements dev.sync.up dev.up dev.up.attach dev.up.shell \
         dev.up.without-deps dev.up.without-deps.shell dev.up.with-programs \
         dev.up.with-watchers dev.validate docs e2e-tests e2e-tests.with-shell \
-        help requirements impl-dev.pull selfcheck upgrade upgrade \
+        help requirements impl-dev.clone.https impl-dev.clone.ssh impl-dev.provision \
+		impl-dev.pull impl-dev.pull.without-deps impl-dev.up impl-dev.up.attach \
+		impl-dev.up.without-deps selfcheck upgrade upgrade \
         validate-lms-volume vnc-passwords
 
 # Load up options (configurable through options.local.mk).


### PR DESCRIPTION
particularly:
dev.clone...
dev.provision...
dev.pull...
- [ ] dev.up still needs to be done
This extends the work from https://github.com/edx/devstack/pull/732. 

[inform] We do not plan to continue using this method of metrics collect beyond these few essential make targets. Since the future of devstack is uncertain(i.e. potential replacement of devstack with tutor), it did not make sense to invest in finding a different method of metric collection.

----

I've completed each of the following, or confirmed they do not apply to this PR:

- [x] Tested on both Mac and Linux (if changed Makefile or shell scripts)
    - Already tested on: jinder1s
    - Testing instructions: Run the modified targets and make sure they start correctly. We don't need to check if they end correctly cause making sure send_metrics scripts work correctly is done elsewhere.
- [ ] Made a plan to communicate any major developer interface changes
