### PR TITLE
feat: Print invitation to opt-in to metrics

### DIFF
--- a/tests/warn_default.py
+++ b/tests/warn_default.py
@@ -1,5 +1,8 @@
+"""
+Tests for make_warn_default_large.sh
+"""
+
 import pexpect
-import pytest
 
 
 def test_warn_default():


### PR DESCRIPTION
Invitation is only printed for people who have the feature toggle enabled (for now) and who have neither consented nor declined.

Major supporting changes:

- Change `prep_for_send` into `check_for_consent`, since there is now an in-between state (feature toggled enabled, but decision not made) where we want the wrapper to behave differently. There are three possible return states now, factored across two booleans.

Minor changes:

- Move documentation of config file format to module docstring
- Tightens values for `collection_enabled` -- has to be True, not just truthy
- Treat falsey user ID (e.g. empty string) as missing
- Bugfix: Check for missing user ID in opt-in as well (to match the other check)

Also includes some preliminary improvements to tests as a foundational commit.

----

I've completed each of the following, or confirmed they do not apply to this PR:

- [x] Tested on both Mac and Linux (if changed Makefile or shell scripts)
- [x] Made a plan to communicate any major developer interface changes