### PR TITLE
fix gradebook src entry in docker-sync.yml

### DIFF
--- a/docker-sync.yml
+++ b/docker-sync.yml
@@ -37,7 +37,7 @@ syncs:
 
   gradebook-sync:
     host_disk_mount_mode: 'cached'
-    src: '../gradebook/'
+    src: '../frontend-app-gradebook/'
     sync_excludes: [ '.git', '.idea' ]
 
   program-console-sync:


### PR DESCRIPTION
Repository `edx/gradebook` redirects to `edx/frontend-app-gradebook`, so we need to update the src value to "../frontend-app-gradebook"

----

I've completed each of the following, or confirmed they do not apply to this PR:

- [X] Tested on both Mac and Linux (if changed Makefile or shell scripts)
    - Already tested on: MacOS BigSur
    - Testing instructions: execute `make dev.sync.provision` and the problem (directory not found) has gone away
