### PR TITLE
fix: Remove suggestion to delete config; spacing; grammar in opt-in message

### DIFF
--- a/scripts/send-metrics.py
+++ b/scripts/send-metrics.py
@@ -324,15 +324,16 @@ def do_opt_in():
         "\n"
         "This will report usage information to a team at edX so that "
         "devstack improvements can be planned and evaluated. The metrics included are: "
-        "the make target, a timestamp, duration of command run, the git hash of the version of devstack, "
+        "The make target, a timestamp, duration of command run, the git hash of the version of devstack, "
         "whether or not this command was run on the master branch, the exit status of the command, "
-        "and an anonymous user ID."
+        "and an anonymous user ID. "
         "You can opt out again at any time in order to "
         "stop sending metrics.\n"
         "\n"
         "Type 'yes' or 'y' to opt in, or anything else to cancel."
     )
     answer = input()
+    print()
 
     if answer.lower() in ['yes', 'y']:
         config['consent'] = {
@@ -349,8 +350,8 @@ def do_opt_in():
 
         print(
             "Thank you for contributing to devstack development! "
-            "You can opt out again at any time with `make metrics-opt-out` "
-            "or by deleting the file at {config_path}."
+            "Your opt-in has been stored in {config_path} and "
+            "you can opt out again at any time with `make metrics-opt-out`."
             .format(config_path=config_path)
         )
         # Send record of opt-in so we can tell whether people are


### PR DESCRIPTION
Continue to print the file path, just with different phrasing that will
make it more likely that people use the proper opt-out method.

The suggestion to delete the config file as an opt-out method would be
empowering in a situation where the opt-out target fails, but we would
then not receive the Segment event for their opt-out. The opt-out is
fairly simple code, so this isn't even a likely scenario, and if it does
happen... well, the users here are developers, so it should be pretty
clear to them that deleting the file would do what they want.

There is also an incidental benefit here of the message change in that
copy-and-paste is no longer likely to pick up the trailing period by
accident.

----

I've completed each of the following, or confirmed they do not apply to this PR:

- [x] Tested on both Mac and Linux (if changed Makefile or shell scripts)
- [x] Made a plan to communicate any major developer interface changes
