### PR TITLE
fix: Make `make` quieter when printing container IDs (unbreak provisioning)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,18 +253,18 @@ dev.provision.%: ## Provision specified services.
 	@scripts/send-metrics.py wrap "dev.provision.$*"
 
 dev.backup: dev.up.mysql+mysql57+mongo+elasticsearch+elasticsearch7 ## Write all data volumes to the host.
-	docker run --rm --volumes-from $$(make -s dev.print-container.mysql) -v $$(pwd)/.dev/backups:/backup debian:jessie tar zcvf /backup/mysql.tar.gz /var/lib/mysql
-	docker run --rm --volumes-from $$(make -s dev.print-container.mysql57) -v $$(pwd)/.dev/backups:/backup debian:jessie tar zcvf /backup/mysql57.tar.gz /var/lib/mysql
-	docker run --rm --volumes-from $$(make -s dev.print-container.mongo) -v $$(pwd)/.dev/backups:/backup debian:jessie tar zcvf /backup/mongo.tar.gz /data/db
-	docker run --rm --volumes-from $$(make -s dev.print-container.elasticsearch) -v $$(pwd)/.dev/backups:/backup debian:jessie tar zcvf /backup/elasticsearch.tar.gz /usr/share/elasticsearch/data
-	docker run --rm --volumes-from $$(make -s dev.print-container.elasticsearch7) -v $$(pwd)/.dev/backups:/backup debian:jessie tar zcvf /backup/elasticsearch7.tar.gz /usr/share/elasticsearch/data
+	docker run --rm --volumes-from $$(make --silent --no-print-directory dev.print-container.mysql) -v $$(pwd)/.dev/backups:/backup debian:jessie tar zcvf /backup/mysql.tar.gz /var/lib/mysql
+	docker run --rm --volumes-from $$(make --silent --no-print-directory dev.print-container.mysql57) -v $$(pwd)/.dev/backups:/backup debian:jessie tar zcvf /backup/mysql57.tar.gz /var/lib/mysql
+	docker run --rm --volumes-from $$(make --silent --no-print-directory dev.print-container.mongo) -v $$(pwd)/.dev/backups:/backup debian:jessie tar zcvf /backup/mongo.tar.gz /data/db
+	docker run --rm --volumes-from $$(make --silent --no-print-directory dev.print-container.elasticsearch) -v $$(pwd)/.dev/backups:/backup debian:jessie tar zcvf /backup/elasticsearch.tar.gz /usr/share/elasticsearch/data
+	docker run --rm --volumes-from $$(make --silent --no-print-directory dev.print-container.elasticsearch7) -v $$(pwd)/.dev/backups:/backup debian:jessie tar zcvf /backup/elasticsearch7.tar.gz /usr/share/elasticsearch/data
 
 dev.restore: dev.up.mysql+mysql57+mongo+elasticsearch+elasticsearch7 ## Restore all data volumes from the host. WILL OVERWRITE ALL EXISTING DATA!
-	docker run --rm --volumes-from $$(make -s dev.print-container.mysql) -v $$(pwd)/.dev/backups:/backup debian:jessie tar zxvf /backup/mysql.tar.gz
-	docker run --rm --volumes-from $$(make -s dev.print-container.mysql57) -v $$(pwd)/.dev/backups:/backup debian:jessie tar zxvf /backup/mysql57.tar.gz
-	docker run --rm --volumes-from $$(make -s dev.print-container.mongo) -v $$(pwd)/.dev/backups:/backup debian:jessie tar zxvf /backup/mongo.tar.gz
-	docker run --rm --volumes-from $$(make -s dev.print-container.elasticsearch) -v $$(pwd)/.dev/backups:/backup debian:jessie tar zxvf /backup/elasticsearch.tar.gz
-	docker run --rm --volumes-from $$(make -s dev.print-container.elasticsearch7) -v $$(pwd)/.dev/backups:/backup debian:jessie tar zxvf /backup/elasticsearch7.tar.gz
+	docker run --rm --volumes-from $$(make --silent --no-print-directory dev.print-container.mysql) -v $$(pwd)/.dev/backups:/backup debian:jessie tar zxvf /backup/mysql.tar.gz
+	docker run --rm --volumes-from $$(make --silent --no-print-directory dev.print-container.mysql57) -v $$(pwd)/.dev/backups:/backup debian:jessie tar zxvf /backup/mysql57.tar.gz
+	docker run --rm --volumes-from $$(make --silent --no-print-directory dev.print-container.mongo) -v $$(pwd)/.dev/backups:/backup debian:jessie tar zxvf /backup/mongo.tar.gz
+	docker run --rm --volumes-from $$(make --silent --no-print-directory dev.print-container.elasticsearch) -v $$(pwd)/.dev/backups:/backup debian:jessie tar zxvf /backup/elasticsearch.tar.gz
+	docker run --rm --volumes-from $$(make --silent --no-print-directory dev.print-container.elasticsearch7) -v $$(pwd)/.dev/backups:/backup debian:jessie tar zxvf /backup/elasticsearch7.tar.gz
 
 # List of Makefile targets to run database migrations, in the form dev.migrate.$(service)
 # Services will only have their migrations added here
@@ -354,7 +354,7 @@ dev.ps: ## View list of created services and their statuses.
 	docker-compose ps
 
 dev.print-container.%: ## Get the ID of the running container for a given service.
-	@# Can be run as ``make --silent dev.print-container.$service`` for just ID.
+	@# Can be run as ``make --silent --no-print-directory dev.print-container.$service`` for just ID.
 	@echo $$(docker-compose ps --quiet $*)
 
 dev.restart-container: ## Restart all service containers.
@@ -432,7 +432,7 @@ dev.logs.%: ## View the logs of the specified service container.
 dev.attach: _expects-service.dev.attach
 
 dev.attach.%: ## Attach to the specified service container process for debugging & seeing logs.
-	docker attach "$$(make --silent dev.print-container.$*)"
+	docker attach "$$(make --silent --no-print-directory dev.print-container.$*)"
 
 dev.shell: _expects-service.dev.shell
 

--- a/Makefile.edx
+++ b/Makefile.edx
@@ -24,7 +24,7 @@ dev.provision.whitelabel:
 # AND the test must be setup using the 'dev.provision.whitelabel' target.
 whitelabel-tests:
 	docker run -d --name=devstack.whitelabel --network=${COMPOSE_PROJECT_NAME:-devstack}_default -v ${DEVSTACK_WORKSPACE}/edx-e2e-tests:/edx-e2e-tests -v ${DEVSTACK_WORKSPACE}/edx-platform:/edx-e2e-tests/lib/edx-platform --env-file ${DEVSTACK_WORKSPACE}/edx-e2e-tests/devstack_env edxops/e2e
-	docker cp ${DEVSTACK_WORKSPACE}/edx-themes/edx-platform/run_whitelabel_tests.sh $(make --silent dev.print-container.devstack.whitelabel)":/tmp/run_whitelabel_tests.sh
+	docker cp ${DEVSTACK_WORKSPACE}/edx-themes/edx-platform/run_whitelabel_tests.sh $(make --silent --no-print-directory dev.print-container.devstack.whitelabel)":/tmp/run_whitelabel_tests.sh
 	docker exec -t devstack.whitelabel env TEST_ENV=devstack TERM=$(TERM) bash /tmp/run_whitelabel_tests.sh
 
 whitelabel-cleanup:

--- a/in
+++ b/in
@@ -17,10 +17,10 @@ set -u
 service="$1"
 shift
 
-container_id=$(make --silent dev.print-container."$service")
+container_id=$(make --silent --no-print-directory dev.print-container."$service")
 if [[ -z "$container_id" ]]; then
-	make --silent dev.up."$service"
-	container_id=$(make --silent dev.print-container."$service")
+	make --silent --no-print-directory dev.up."$service"
+	container_id=$(make --silent --no-print-directory dev.print-container."$service")
 fi
 
 docker exec -it "$container_id" bash -c "$*"

--- a/load-db.sh
+++ b/load-db.sh
@@ -17,6 +17,6 @@ then
 fi
 
 echo "Loading the $1 database..."
-mysql_container=$(make -s dev.print-container.mysql57)
+mysql_container=$(make --silent --no-print-directory dev.print-container.mysql57)
 docker exec -i "$mysql_container" mysql -uroot $1 < $1.sql
 echo "Finished loading the $1 database!"

--- a/provision-e2e.sh
+++ b/provision-e2e.sh
@@ -10,7 +10,7 @@ elif [ ! -d "$DEVSTACK_WORKSPACE" ]; then
 fi
 
 # Copy the test course tarball into the studio container
-docker cp ${DEVSTACK_WORKSPACE}/edx-e2e-tests/upload_files/course.tar.gz "$(make --silent dev.print-container.studio)":/tmp/
+docker cp ${DEVSTACK_WORKSPACE}/edx-e2e-tests/upload_files/course.tar.gz "$(make --silent --no-print-directory dev.print-container.studio)":/tmp/
 
 # Extract the test course tarball
 docker-compose exec -T studio bash -c 'cd /tmp && tar xzf course.tar.gz'

--- a/update-dbs-init-sql-scripts.sh
+++ b/update-dbs-init-sql-scripts.sh
@@ -24,7 +24,7 @@ make dev.clone.ssh
 make dev.provision.services.lms+ecommerce
 
 # dump schema and data from mysql databases in the mysql docker container and copy them to current directory in docker host
-MYSQL_DOCKER_CONTAINER="$(make --silent dev.print-container.mysql57)"
+MYSQL_DOCKER_CONTAINER="$(make --silent --no-print-directory dev.print-container.mysql57)"
 for DB_NAME in "${DBS[@]}"; do
     DB_CREATION_SQL_SCRIPT="${DB_NAME}.sql"
     if [[ " ${EDXAPP_DBS[@]} " =~ " ${DB_NAME} " ]]; then

--- a/upgrade_mongo_4_0.sh
+++ b/upgrade_mongo_4_0.sh
@@ -11,7 +11,7 @@ export MONGO_VERSION=3.4.24
 current_mongo_version="3.4"
 echo -e "${GREEN}Sarting Mongo ${MONGO_VERSION}${NC}"
 make dev.up.mongo
-mongo_container="$(make -s dev.print-container.mongo)"
+mongo_container="$(make --silent --no-print-directory dev.print-container.mongo)"
 
 echo -e "${GREEN}Waiting for MongoDB...${NC}"
 until docker exec "$mongo_container" mongo --eval 'db.serverStatus()' &> /dev/null
@@ -49,7 +49,7 @@ export MONGO_VERSION=3.6.17
 echo
 echo -e "${GREEN}Restarting Mongo on version ${MONGO_VERSION}${NC}"
 make dev.up.mongo
-mongo_container="$(make -s dev.print-container.mongo)"
+mongo_container="$(make --silent --no-print-directory dev.print-container.mongo)"
 
 echo -e "${GREEN}Waiting for MongoDB...${NC}"
 until docker exec "$mongo_container" mongo --eval 'db.serverStatus()' &> /dev/null
@@ -78,7 +78,7 @@ export MONGO_VERSION=4.0.22
 echo
 echo -e "${GREEN}Restarting Mongo on version ${MONGO_VERSION}${NC}"
 make dev.up.mongo
-mongo_container="$(make -s dev.print-container.mongo)"
+mongo_container="$(make --silent --no-print-directory dev.print-container.mongo)"
 
 echo -e "${GREEN}Waiting for MongoDB...${NC}"
 until docker exec "$mongo_container" mongo --eval 'db.serverStatus()' &> /dev/null


### PR DESCRIPTION
Provisioning was broken by commit d1edbe7573a/PR #758 because it introduced
a second layer of make, which caused the now-inner make call to target
`dev.print-container.%` to print debugging info that looked like
`make[2]: Entering directory '/home/timmc/edx-repos/devstack'`.

Calls to `dev.print-container.%` already used the `--silent` flag, which is
correct to use here but is insufficient because it doesn't suppress
printing of the current directory when a recursive make call is made.

This commit adds `--no-print-directory` to all calls to that target as well
as to the documented way to call the target.

This was not caught by automated tests because they fail to set `-e`
in bash; this will be addressed in a separate PR.

----

I've completed each of the following, or confirmed they do not apply to this PR:

- [x] Tested on both Mac and Linux (if changed Makefile or shell scripts)
    - Already tested on: Linux
    - Testing instructions: `make dev.destroy && make dev.provision.registrar+lms`
- [x] Made a plan to communicate any major developer interface changes
