### PR TITLE
 test: Fix a flaky metrics test due to signal/exit race

### DIFF
--- a/scripts/send-metrics.py
+++ b/scripts/send-metrics.py
@@ -211,6 +211,12 @@ def run_wrapped(make_target, config):
         # when the developer uses Ctrl-C to kill the make command
         # (which would normally kill this process as well).  This
         # handler just ignores the signal and then unregisters itself.
+        #
+        # There is no guarantee of whether this signal will be caught
+        # first or the child process will exit first. This could
+        # theoretically result in unregistering the signal handler
+        # before the signal has occurred, resulting in failure to
+        # report the event, but there's no way to prevent this.
         signal(SIGINT, lambda _signum, _frame: signal(SIGINT, SIG_DFL))
     except:
         do_collect = False

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -6,3 +6,10 @@ Expect); if you're editing or creating tests it is highly recommended
 you read up on the gotchas in here:
 
 https://pexpect.readthedocs.io/en/stable/overview.html
+
+Debugging tips
+--------------
+
+If an expectation fails (or an unexpected timeout or EOF occurs) then pexpect will throw an exception which contains a printout of the internal state of the pexpect instance. This includes the ``buffer``, ``before``, and ``after`` buffers, which are essential for seeing what the child process's output was.
+
+However, pexpect truncates two of these to 100 characters by default. To see more, set the undocumented ``str_last_chars`` attribute on the pexpect object to something larger, or to 0 for the full output.

--- a/tests/metrics.py
+++ b/tests/metrics.py
@@ -323,11 +323,16 @@ def test_signal_conversion():
         p.sendintr()  # send Ctrl-C to process group
         # Confirm that the process is actually catching the signal, as
         # proven by it printing some things before ending.
-        p.expect(r'Send metrics info:.*"exit_status": ?-2')
+        p.expect(r'Send metrics info:')
         p.expect(EOF)
 
         # This time we're calling the script directly, so we see the
         # script exiting with code 130 (128 + SIGINT).
+        #
+        # ...or, depending on timing and/or operating system, the make
+        # process may die *first* with its generic exit code 2 and the
+        # wrapper would exit before it even receives the signal. So, we
+        # expect either scenario.
         p.close()
-        assert p.exitstatus == 130
+        assert p.exitstatus in [130, 2]
         assert p.signalstatus is None

--- a/tests/metrics.py
+++ b/tests/metrics.py
@@ -285,7 +285,7 @@ def test_handle_ctrl_c():
         # otherwise signal handler won't even have been registered
         # yet.
         p.expect(r'Are you sure you want to run this command')
-        p.send(b'\x03')  # send Ctrl-C to process group
+        p.sendintr()  # send Ctrl-C to process group
         p.expect(EOF)
         output = p.before.decode()
 
@@ -320,7 +320,7 @@ def test_signal_conversion():
         # otherwise signal handler won't even have been registered
         # yet.
         p.expect(r'Are you sure you want to run this command')
-        p.send(b'\x03')  # send Ctrl-C to process group
+        p.sendintr()  # send Ctrl-C to process group
         # Confirm that the process is actually catching the signal, as
         # proven by it printing some things before ending.
         p.expect(r'Send metrics info:.*"exit_status": ?-2')

--- a/tests/warn_default.py
+++ b/tests/warn_default.py
@@ -17,4 +17,4 @@ def test_warn_default():
     p.expect(r'Pulling lms')
 
     # Send ^C, don't wait for it to finish
-    p.send(b'\x03')
+    p.sendintr()


### PR DESCRIPTION
Also add some comments based on what I learned while fixing this.

----

I've completed each of the following, or confirmed they do not apply to this PR:

- [x] Tested on both Mac and Linux (if changed Makefile or shell scripts)
- [x] Made a plan to communicate any major developer interface changes
