### PR TITLE
fix: Remove more error suppression: IDA user, credentials

### DIFF
--- a/provision-credentials.sh
+++ b/provision-credentials.sh
@@ -18,19 +18,11 @@ docker-compose exec -T ${name}  bash -e -c 'source /edx/app/credentials/credenti
 echo -e "${GREEN}Running migrations for ${name}...${NC}"
 docker-compose exec -T ${name}  bash -e -c 'source /edx/app/credentials/credentials_env && cd /edx/app/credentials/credentials && make migrate' -- "$name"
 
-set +e
-# FIXME[bash-e]: Bash scripts should use -e -- but this script fails
-# with missing manage.py (need another "credentials" in that cd path?)
 echo -e "${GREEN}Creating super-user for ${name}...${NC}"
 docker-compose exec -T ${name}  bash -e -c 'source /edx/app/credentials/credentials_env && cd /edx/app/credentials/credentials && echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser(\"edx\", \"edx@example.com\", \"edx\") if not User.objects.filter(username=\"edx\").exists() else None" | python /edx/app/$1/$1/manage.py shell' -- "$name"
-set -e
 
-set +e
-# FIXME[bash-e]: Bash scripts should use -e -- but this script fails
-# with missing manage.py (need another "credentials" in that cd path?)
 echo -e "${GREEN}Configuring site for ${name}...${NC}"
-docker-compose exec -T ${name} bash -e -c 'source /edx/app/credentials/credentials_env && cd /edx/app/credentials/ && ./manage.py create_or_update_site --site-id=1 --site-domain=localhost:18150 --site-name="Open edX" --platform-name="Open edX" --company-name="Open edX" --lms-url-root=http://localhost:18000 --catalog-api-url=http://edx.devstack.discovery:18381/api/v1/ --tos-url=http://localhost:18000/tos --privacy-policy-url=http://localhost:18000/privacy --homepage-url=http://localhost:18000 --certificate-help-url=http://localhost:18000/faq --records-help-url=http://localhost:18000/faq --theme-name=openedx'
-set -e
+docker-compose exec -T ${name} bash -e -c 'source /edx/app/credentials/credentials_env && cd /edx/app/credentials/credentials && ./manage.py create_or_update_site --site-id=1 --site-domain=localhost:18150 --site-name="Open edX" --platform-name="Open edX" --company-name="Open edX" --lms-url-root=http://localhost:18000 --catalog-api-url=http://edx.devstack.discovery:18381/api/v1/ --tos-url=http://localhost:18000/tos --privacy-policy-url=http://localhost:18000/privacy --homepage-url=http://localhost:18000 --certificate-help-url=http://localhost:18000/faq --records-help-url=http://localhost:18000/faq --theme-name=openedx'
 
 ./provision-ida-user.sh ${name} ${name} ${port}
 

--- a/provision-ida-user.sh
+++ b/provision-ida-user.sh
@@ -2,12 +2,6 @@
 set -eu -o pipefail
 set -x
 
-# FIXME[bash-e]: Bash scripts should use -e -- but this script fails
-# with the following errors for ecommerce & edx_notes_api:
-# - RuntimeError: Model class openedx.core.djangoapps.content_libraries.models.ContentLibrary doesn't declare an explicit app_label and isn't in an application in INSTALLED_APPS.
-# - django.db.utils.ProgrammingError: (1146, "Table 'edxapp.auth_user' doesn't exist")
-set +e
-
 #This script depends on the LMS being up!
 
 . scripts/colors.sh
@@ -24,10 +18,3 @@ docker-compose exec -T lms  bash -e -c 'source /edx/app/edxapp/edxapp_env && pyt
 # Create the DOT applications - one for single sign-on and one for backend service IDA-to-IDA authentication.
 docker-compose exec -T lms  bash -e -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker create_dot_application --grant-type authorization-code --skip-authorization --redirect-uris "http://localhost:$3/complete/edx-oauth2/" --client-id "$1-sso-key" --client-secret "$1-sso-secret" --scopes "user_id" $1-sso $1_worker' -- "$app_name" "$client_name" "$client_port"
 docker-compose exec -T lms  bash -e -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker create_dot_application --grant-type client-credentials --client-id "$1-backend-service-key" --client-secret "$1-backend-service-secret" $1-backend-service $1_worker' -- "$app_name" "$client_name" "$client_port"
-
-
-# FIXME[bash-e]: Suppress last error so that calling script can set -e
-# for itself. Remove this once *this* script is run entirely with `-e`
-# in effect (or at least the last command is no longer erroring for
-# any services).
-true


### PR DESCRIPTION
- The errors in provision-ida-user.sh were solved by commit 7b029fe in
  PR #772 -- these services needed the LMS to be provisioned as well.
- One of these credentials error suppression comments may have been
  spurious, or at least copy-pasted but not adjusted properly.
- The other does seem to have been fixed by adding another `credentials`
  path element.

----

I've completed each of the following, or confirmed they do not apply to this PR:

- [x] Made a plan to communicate any major developer interface changes