### PR TITLE
doc: Abandon attempt at expanding testing on Mac

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,5 @@
 ----
 
-I've completed each of the following, or confirmed they do not apply to this PR:
+I've completed each of the following or determined they are not applicable:
 
-- [ ] Tested on both Mac and Linux (if changed Makefile or shell scripts)
-    - Already tested on: *[my OS here]*
-    - Testing instructions: *[commands and expected behavior]*
-- [ ] Made a plan to communicate any major developer interface changes
+- [ ] Made a plan to communicate any major developer interface changes (or N/A)

--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -61,6 +61,9 @@ jobs:
       # TODO: Stop using boot2docker, which is contradindicated in the
       # README. (Not sure how to install Docker for Desktop here,
       # though.)
+      #
+      # This also only seems to work for the CLI tests, not the
+      # provisioning tests, even with apparently identical scripts.
       - name: Docker installation - Mac
         if: ${{ matrix.os.name == 'mac' }}
         run: |


### PR DESCRIPTION
There are problems getting Docker installed on MacOS in Github Actions and
failures due to Mac/Linux differences are rare enough that we can just test
on Linux and address issues as they come up.

If we're not doing automated testing for Mac, no sense in manual testing
either -- it was only meant to be a stop-gap solution.

----

I've completed each of the following or determined they are not applicable:

- [x] Made a plan to communicate any major developer interface changes (or N/A)
