### PR TITLE
test: Use Ubuntu focal in provisioning tests

### DIFF
--- a/.github/workflows/provisioning-tests.yml
+++ b/.github/workflows/provisioning-tests.yml
@@ -20,7 +20,8 @@ jobs:
       DEVSTACK_METRICS_TESTING: ci
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os:
+          - ubuntu-20.04 # Ubuntu 20.04 "Focal Fossa"
         python-version: [ '3.8' ]
         services: [ discovery+lms+forum ,registrar+lms, ecommerce+lms, edx_notes_api+lms, credentials+lms, xqueue]
       fail-fast: false # some services can be flaky; let others run to completion even if one fails


### PR DESCRIPTION
Ubuntu Focal is the version of Linux that Open edX currently targets, so
don't just use the latest version.

----

I've completed each of the following or determined they are not applicable:

- [x] Made a plan to communicate any major developer interface changes (or N/A)
