### PR TITLE
feat: print out untracked files

### DIFF
--- a/repo.sh
+++ b/repo.sh
@@ -183,7 +183,7 @@ reset ()
             # Try to switch branch and pull, but fail if there are uncommitted changes.
             if (cd "$name"; git checkout -q master && git pull -q --ff-only);
             then
-                # Echo untracked files to simplify debugging and make it easier to see tha reseting does not remove everything
+                # Echo untracked files to simplify debugging and make it easier to see that resetting does not remove everything
                 untracked_files="$(cd ${name} && git ls-files --others --exclude-standard)"
                 if [[ $untracked_files ]];
                 then

--- a/repo.sh
+++ b/repo.sh
@@ -181,11 +181,21 @@ reset ()
 
         if [ -d "$name" ]; then
             # Try to switch branch and pull, but fail if there are uncommitted changes.
-            (cd "$name"; git checkout -q master && git pull -q --ff-only) || {
+            if (cd "$name"; git checkout -q master && git pull -q --ff-only);
+            then
+                # Echo untracked files to simplify debugging and make it easier to see tha reseting does not remove everything
+                untracked_files="$(cd ${name} && git ls-files --others --exclude-standard)"
+                if [[ $untracked_files ]];
+                then
+                    echo "The following untracked files are in ${name} repository:"
+                    echo "$untracked_files"
+                fi
+            else
                 echo >&2 "Failed to reset $name repo. Exiting."
                 echo >&2 "Please go to the repo and clean up any issues that are keeping 'git checkout master' and 'git pull' from working."
                 exit 1
-            }
+
+            fi
         else
             printf "The [%s] repo is not cloned. Skipping.\n" "$name"
         fi

--- a/repo.sh
+++ b/repo.sh
@@ -194,7 +194,6 @@ reset ()
                 echo >&2 "Failed to reset $name repo. Exiting."
                 echo >&2 "Please go to the repo and clean up any issues that are keeping 'git checkout master' and 'git pull' from working."
                 exit 1
-
             fi
         else
             printf "The [%s] repo is not cloned. Skipping.\n" "$name"


### PR DESCRIPTION
Print out untracked files when running "./repo.sh reset". Reset only
modifies repositories in a way that allows changes to be recovered. As
such, reset does to automatically delete untracked files.
Without this new echo, it was easy to not know that one of the
repositories is in a modified state.

----

I've completed each of the following or determined they are not applicable:

- [x] Made a plan to communicate any major developer interface changes (or N/A)
