### PR TITLE
fix!: Fix duration metric and rename

### DIFF
--- a/scripts/send_metrics.py
+++ b/scripts/send_metrics.py
@@ -34,7 +34,7 @@ import sys
 import traceback
 import urllib.request as req
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from http.client import RemoteDisconnected
 from os import path
 from signal import SIG_DFL, SIGINT, signal
@@ -231,7 +231,7 @@ def run_wrapped(make_target, config):
 
         signal(SIGINT, SIG_DFL)  # stop trapping SIGINT (if haven't already)
         end_time = datetime.now(timezone.utc)
-        time_diff_millis = (end_time - start_time).microseconds // 1000
+        time_diff_millis = (end_time - start_time) // timedelta(milliseconds=1)
         # Must be compatible with our Segment schema, and must not be
         # expanded to include additional attributes without an
         # additional consent check.
@@ -239,7 +239,7 @@ def run_wrapped(make_target, config):
             'command_type': 'make',
             'command': make_target[:50],  # limit in case of mis-pastes at terminal
             'start_time': start_time.isoformat(),
-            'duration': time_diff_millis,
+            'duration_ms': time_diff_millis,
             # If the subprocess was interrupted by a signal, the exit
             # code will be negative signal value (e.g. -2 for SIGINT,
             # rather than the 130 it returns from the shell):

--- a/tests/metrics.py
+++ b/tests/metrics.py
@@ -288,7 +288,7 @@ def test_metrics():
         assert sorted(data.keys()) == ['event', 'properties', 'sentAt', 'userId'], \
             "Unrecognized key in envelope -- confirm that this addition is authorized."
         assert sorted(data['properties'].keys()) == [
-            'command', 'command_type', 'duration', 'exit_status',
+            'command', 'command_type', 'duration_ms', 'exit_status',
             'git_checked_out_master', 'git_commit_time',
             'is_test', 'start_time',
         ], "Unrecognized attribute -- confirm that this addition is authorized."


### PR DESCRIPTION
- `duration` changes name to `duration_ms` (more explicit)
- duration is now correct, as opposed to being milliseconds modulo seconds

The old usage metrics calculation for command duration used the
microseconds property of a timedelta, which only gets the microseconds
*component* of the difference -- not the difference *in* microseconds.
(It was then divided by 1000 to get milliseconds.)

The new calculation takes the difference and then divides it by
milliseconds. (This continues to compute the floor, using integer
division.)

Since the previous data was unusable, the name change doesn't interfere
with any analysis we were doing.

----

I've completed each of the following or determined they are not applicable:

- [x] Made a plan to communicate any major developer interface changes (or N/A)
- [x] Update metrics page on Confluence
- [x] Update dashboard in New Relic
