### PR TITLE
feat: update notes to elasticsearch 7.10 (PSRE-871)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,8 +89,8 @@ services:
         aliases:
           - edx.devstack.elasticsearch710
     ports:
-      - "9200:9200"
-      - "9300:9300"
+      - "9201:9200"
+      - "9301:9300"
     volumes:
       - elasticsearch710_data:/usr/share/elasticsearch/data
     environment:
@@ -272,7 +272,7 @@ services:
     hostname: edx_notes_api.devstack.edx
     depends_on:
       - devpi
-      - elasticsearch7
+      - elasticsearch710
       - lms
       - mysql57
     image: edxops/notes:${OPENEDX_RELEASE:-latest}
@@ -291,7 +291,8 @@ services:
       DB_USER: "notes001"
       DJANGO_WATCHMAN_TIMEOUT: 30
       ENABLE_DJANGO_TOOLBAR: 1
-      ELASTICSEARCH_URL: "http://edx.devstack.elasticsearch7:9200"
+      ELASTICSEARCH_URL: "http://edx.devstack.elasticsearch710:9200"
+      ELASTICSEARCH_DSL: "http://edx.devstack.elasticsearch710:9200"
 
   forum:
     command: bash -c 'source /edx/app/forum/ruby_env && source /edx/app/forum/devstack_forum_env && cd /edx/app/forum/cs_comments_service && bundle install && while true; do ruby app.rb -o 0.0.0.0 ; sleep 2; done'


### PR DESCRIPTION
----
This PR will switch the edx notes api in devstack to Elasticsearch 7.10. I will inform via email and slack to run the following commands to switch notes api to ES 7.10 in devstack after this PR is merged.
```
git checkout master && git pull
make dev.down dev.reset-repos dev.pull dev.up dev.static
make dev.migrate
docker-compose exec edx_notes_api bash -c 'source /edx/app/edx_notes_api/edx_notes_api_env && /edx/app/edx_notes_api/venvs/edx_notes_api/bin/python /edx/app/edx_notes_api/edx_notes_api/manage.py search_index --rebuild -f
```

**Testing**

- [Enable Notes](https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/exercises_tools/notes.html) for a course and add few notes.
- Check notes index on ES 7.8
    - curl -X GET "localhost:9200/_cat/indices/notes_index" 
         - It will give this output. See the doc count. `green open notes_index cyIa0wGbSUu5GJBw4z3TgQ 1 0 10 0 64.1kb 64.1kb`
- Run `make dev.down dev.up` to bring up notes with ES 7.10
- Rebuild notes_index on ES 7.10
    - `docker-compose exec edx_notes_api bash -c 'source /edx/app/edx_notes_api/edx_notes_api_env && /edx/app/edx_notes_api/venvs/edx_notes_api/bin/python /edx/app/edx_notes_api/edx_notes_api/manage.py search_index --rebuild -f`
- Verify notes index on ES 7.10 
    - curl -X GET "localhost:9201/_cat/indices/notes_index" 
         - See the doc count make sure it is the same as it was in ES 7.8 request above. `green open notes_index usKUXEjsTTK24gfsebERlA 1 0 10 0 11.5kb 11.5kb` 
     - Go to the course where you have added notes and search for something you have put in for your notes.