### PR TITLE
docs: correct the step numbers and link to getting started

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -118,7 +118,6 @@ the ones installed globally on your system.
 Directions to setup devstack
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-
 The default devstack services can be run by following the steps below.
 
 **Note:** This will set up a large number of services, more than you are likely to need to work with, but that's only necessary for first-time provisioning. See `Service List`_ and the `most common development workflow`_ for how to run and update devstack with just the services you need, rather than the ``large-and-slow`` default set.
@@ -162,13 +161,13 @@ The default devstack services can be run by following the steps below.
 
 .. _document on developing on named releases: https://edx.readthedocs.io/projects/open-edx-devstack/en/latest/developing_on_named_release_branches.html
 
-3. Optional: You have an option to use NFS on MacOS which may improve the performance significantly. To set it up ONLY ON MAC, do
+4. Optional: You have an option to use NFS on MacOS which may improve the performance significantly. To set it up ONLY ON MAC, do:
+
     .. code:: sh
 
         make dev.nfs.setup
 
-
-4. Run the provision command, if you haven't already, to configure the various
+5. Run the provision command, if you haven't already, to configure the various
    services with superusers (for development without the auth service) and
    tenants (for multi-tenancy).
 
@@ -201,7 +200,7 @@ The default devstack services can be run by following the steps below.
 
    **NOTE:** This command will bring up both MySQL 5.6 and 5.7 databases until all services are upgraded to 5.7.
 
-5. Start the desired services. This command will mount the repositories under the
+6. Start the desired services. This command will mount the repositories under the
    ``DEVSTACK_WORKSPACE`` directory.
 
    **NOTE:** it may take up to 60 seconds for the LMS to start, even after the ``dev.up.*`` command outputs ``done``.

--- a/docs/developing_on_named_release_branches.rst
+++ b/docs/developing_on_named_release_branches.rst
@@ -3,7 +3,7 @@ Developing on Open edX named release branches
 
 .. contents:: Table of Contents
 
-By default, the startup steps in `README.rst`_ will install the devstack using the master branch of all repos. If you want to install a named release instead, follow these steps before pulling the docker images in step 3 of the Getting Started guide:
+By default, the startup steps in `README.rst`_ will install the devstack using the master branch of all repos. If you want to install a named release instead, follow these steps before pulling the docker images in step 3 of the `Getting Started`_ guide:
 
 #. Set the ``OPENEDX_RELEASE`` environment variable to the appropriate image
    tag; "hawthorn.master", "zebrawood.rc1", etc.  Note that unlike a server
@@ -11,7 +11,7 @@ By default, the startup steps in `README.rst`_ will install the devstack using t
 #. Check out the appropriate branch in devstack, e.g. ``git checkout open-release/ironwood.master``
 #. Use ``make dev.checkout`` to check out the correct branch in the local
    checkout of each service repository
-#. Continue with step 3 in the `getting started` guide to pull the correct docker images.
+#. Continue with step 3 in the `getting started`_ guide to pull the correct docker images.
 
 All ``make`` target and ``docker-compose`` calls should now use the correct
 images until you change or unset ``OPENEDX_RELEASE`` again.  To work on the


### PR DESCRIPTION
The Getting Started steps had two #3, and one of them was mis-formatted.
The links to Getting Started in the named-release page weren't links.
Now they are, though they go to the GitHub page rather than the
readthedocs page. We should fix that in the future.

----

I've completed each of the following or determined they are not applicable:

- [ ] Made a plan to communicate any major developer interface changes (or N/A)
