### PR TITLE
feat!: Don't bring up chrome and firefox containers by default.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -638,10 +638,10 @@ metrics-opt-out:
 docs: ## generate Sphinx HTML documentation, including API docs
 	tox -e docs
 
-e2e-tests: dev.up.lms+studio ## Run the end-to-end tests against the service containers.
+e2e-tests: dev.up.lms+studio+firefox+chrome ## Run the end-to-end tests against the service containers.
 	docker run -t --network=$(COMPOSE_PROJECT_NAME)_default -v $(DEVSTACK_WORKSPACE)/edx-e2e-tests:/edx-e2e-tests --env-file $(DEVSTACK_WORKSPACE)/edx-e2e-tests/devstack_env edxops/e2e env TERM=$(TERM) bash -c 'paver e2e_test'
 
-e2e-tests.with-shell: dev.up.lms+studio ## Start the end-to-end tests container with a shell.
+e2e-tests.with-shell: dev.up.lms+studio+firefox+chrome ## Start the end-to-end tests container with a shell.
 	docker run -it --network=$(COMPOSE_PROJECT_NAME)_default -v $(DEVSTACK_WORKSPACE)/edx-e2e-tests:/edx-e2e-tests --env-file $(DEVSTACK_WORKSPACE)/edx-e2e-tests/devstack_env edxops/e2e env TERM=$(TERM) bash
 
 validate-lms-volume: ## Validate that changes to the local workspace are reflected in the LMS container.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -322,8 +322,6 @@ services:
       - mongo
       - discovery
       - forum
-      - firefox
-      - chrome
       - elasticsearch7
     # Allows attachment to the LMS service using 'docker attach <containerID>'.
     stdin_open: true
@@ -432,8 +430,6 @@ services:
       - elasticsearch7
       - memcached
       - mongo
-      - firefox
-      - chrome
       - lms
     # Allows attachment to the Studio service using 'docker attach <containerID>'.
     stdin_open: true


### PR DESCRIPTION
These containers are only used for e2e, and a11y tests.  Most users
don't need to run these so bringing these containers up as a part of
the default set seems wasteful.

BREAKING CHANGE: Previously these two containers came up by default as
dependencies of the `lms` and `studio` containers.  Now they would have
to be explicitly added as a part of the up command.

eg. `make dev.up.lms+chrome+firefox`

----

I've completed each of the following or determined they are not applicable:

- [ ] Made a plan to communicate any major developer interface changes (or N/A)
