### PR TITLE
feat: mount local frontend libs into frontend containers

### DIFF
--- a/docker-compose-host-nfs.yml
+++ b/docker-compose-host-nfs.yml
@@ -46,30 +46,51 @@ services:
     volumes:
       - ${DEVSTACK_WORKSPACE}/registrar:/edx/app/registrar/registrar
   frontend-app-course-authoring:
+    extends:
+      file: microfrontend.yml
+      service: microfrontend-with-nfs-libs
     volumes:
       - ${DEVSTACK_WORKSPACE}/frontend-app-course-authoring:/edx/app/frontend-app-course-authoring:cached
       - frontend_app_course_authoring_node_modules:/edx/app/frontend-app-course-authoring/node_modules
   frontend-app-gradebook:
+    extends:
+      file: microfrontend.yml
+      service: microfrontend-with-nfs-libs
     volumes:
       - ${DEVSTACK_WORKSPACE}/frontend-app-gradebook:/edx/app/frontend-app-gradebook:cached
       - frontend_app_gradebook_node_modules:/edx/app/frontend-app-gradebook/node_modules
   frontend-app-learning:
+    extends:
+      file: microfrontend.yml
+      service: microfrontend-with-nfs-libs
     volumes:
       - ${DEVSTACK_WORKSPACE}/frontend-app-learning:/edx/app/frontend-app-learning:cached
       - frontend_app_learning_node_modules:/edx/app/frontend-app-learning/node_modules
   frontend-app-library-authoring:
+    extends:
+      file: microfrontend.yml
+      service: microfrontend-with-nfs-libs
     volumes:
       - ${DEVSTACK_WORKSPACE}/frontend-app-library-authoring:/edx/app/frontend-app-library-authoring:cached
       - frontend_app_library_authoring_node_modules:/edx/app/frontend-app-library-authoring/node_modules
   frontend-app-payment:
+    extends:
+      file: microfrontend.yml
+      service: microfrontend-with-nfs-libs
     volumes:
       - ${DEVSTACK_WORKSPACE}/frontend-app-payment:/edx/app/frontend-app-payment:cached
       - frontend_app_payment_node_modules:/edx/app/frontend-app-payment/node_modules
   frontend-app-program-console:
+    extends:
+      file: microfrontend.yml
+      service: microfrontend-with-nfs-libs
     volumes:
       - ${DEVSTACK_WORKSPACE}/frontend-app-program-console:/edx/app/frontend-app-program-console:cached
       - frontend_app_program_console_node_modules:/edx/app/frontend-app-program-console/node_modules
   frontend-app-publisher:
+    extends:
+      file: microfrontend.yml
+      service: microfrontend-with-nfs-libs
     volumes:
       - ${DEVSTACK_WORKSPACE}/frontend-app-publisher:/edx/app/frontend-app-publisher:cached
       - frontend_app_publisher_node_modules:/edx/app/frontend-app-publisher/node_modules

--- a/docker-compose-host.yml
+++ b/docker-compose-host.yml
@@ -51,30 +51,51 @@ services:
       - edxapp_uploads:/edx/var/edxapp/uploads
       - ${DEVSTACK_WORKSPACE}/src:/edx/src:cached
   frontend-app-course-authoring:
+    extends:
+      file: microfrontend.yml
+      service: microfrontend-with-host-mounted-libs
     volumes:
       - ${DEVSTACK_WORKSPACE}/frontend-app-course-authoring:/edx/app/frontend-app-course-authoring:cached
       - frontend_app_course_authoring_node_modules:/edx/app/frontend-app-course-authoring/node_modules
   frontend-app-gradebook:
+    extends:
+      file: microfrontend.yml
+      service: microfrontend-with-host-mounted-libs
     volumes:
       - ${DEVSTACK_WORKSPACE}/frontend-app-gradebook:/edx/app/frontend-app-gradebook:cached
       - frontend_app_gradebook_node_modules:/edx/app/frontend-app-gradebook/node_modules
   frontend-app-learning:
+    extends:
+      file: microfrontend.yml
+      service: microfrontend-with-host-mounted-libs
     volumes:
       - ${DEVSTACK_WORKSPACE}/frontend-app-learning:/edx/app/frontend-app-learning:cached
       - frontend_app_learning_node_modules:/edx/app/frontend-app-learning/node_modules
   frontend-app-library-authoring:
+    extends:
+      file: microfrontend.yml
+      service: microfrontend-with-host-mounted-libs
     volumes:
       - ${DEVSTACK_WORKSPACE}/frontend-app-library-authoring:/edx/app/frontend-app-library-authoring:cached
       - frontend_app_library_authoring_node_modules:/edx/app/frontend-app-library-authoring/node_modules
   frontend-app-payment:
+    extends:
+      file: microfrontend.yml
+      service: microfrontend-with-host-mounted-libs
     volumes:
       - ${DEVSTACK_WORKSPACE}/frontend-app-payment:/edx/app/frontend-app-payment:cached
       - frontend_app_payment_node_modules:/edx/app/frontend-app-payment/node_modules
   frontend-app-program-console:
+    extends:
+      file: microfrontend.yml
+      service: microfrontend-with-host-mounted-libs
     volumes:
       - ${DEVSTACK_WORKSPACE}/frontend-app-program-console:/edx/app/frontend-app-program-console:cached
       - frontend_app_program_console_node_modules:/edx/app/frontend-app-program-console/node_modules
   frontend-app-publisher:
+    extends:
+      file: microfrontend.yml
+      service: microfrontend-with-host-mounted-libs
     volumes:
       - ${DEVSTACK_WORKSPACE}/frontend-app-publisher:/edx/app/frontend-app-publisher:cached
       - frontend_app_publisher_node_modules:/edx/app/frontend-app-publisher/node_modules

--- a/microfrontend.yml
+++ b/microfrontend.yml
@@ -1,8 +1,39 @@
-# This file contains configuration common too all microfrontends
+# This file contains configuration common to all microfrontends.
 
 version: "2.1"
 
 services:
+
+  # Micro-frontend service template that mounts a list of frontend libraries
+  # from the host, if they exist.
+  microfrontend-with-host-mounted-libs:
+    extends:
+      file: microfrontend.yml
+      service: microfrontend
+    # This list should be kept synced with `microfrontend-with-nfs-libs`.
+    volumes:
+      - ${DEVSTACK_WORKSPACE}/brand-edx.org:/edx/app/brand-edx.org:cached
+      - ${DEVSTACK_WORKSPACE}/brand-openedx:/edx/app/brand-openedx:cached
+      - ${DEVSTACK_WORKSPACE}/frontend-platform:/edx/app/frontend-platform:cached
+      - ${DEVSTACK_WORKSPACE}/paragon:/edx/app/paragon:cached
+
+  # Micro-frontend service template that uses NFS to mount frontend libraries,
+  # if they exist.
+  microfrontend-with-nfs-libs:
+    extends:
+      file: microfrontend.yml
+      service: microfrontend
+    # This list should be kept synced with `microfrontend-with-host-mounted-libs`.
+    # The NFS volumes here need to be defined in the `volumes` section of the file.
+    volumes:
+      - brand-edxorg-nfs:/edx/app/brand-edx.org:cached
+      - brand-openedx-nfs:/edx/app/brand-openedx:cached
+      - frontend-platform-nfs:/edx/app/frontend-platform:cached
+      - paragon-nfs:/edx/app/paragon:cached
+
+  # Base micro-frontend service template.
+  # Defines the underlying image and command to install+run frontend.
+  # Does not mount any host folders.
   microfrontend:
     command: bash -c 'npm install; while true; do npm start; sleep 2; done'
     stdin_open: true
@@ -10,3 +41,31 @@ services:
     image: node:12
     environment:
       - NODE_ENV=development
+
+# NFS volumes to mount micro-frontend libraries.
+# These have no effect for devstack users not using NFS.
+volumes:
+  brand-edxorg-nfs:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
+      device: :${DEVSTACK_WORKSPACE}/brand-edx.org
+  brand-openedx-nfs:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
+      device: :${DEVSTACK_WORKSPACE}/brand-openedx
+  frontend-platform-nfs:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
+      device: :${DEVSTACK_WORKSPACE}/frontend-platform
+  paragon-nfs:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
+      device: :${DEVSTACK_WORKSPACE}/paragon


### PR DESCRIPTION
Should allow installation of local versions of NPM
packages via module.config.js, allowing frontend devs
to test out frontend library changes within devstack.
____________________________

## State

* This does successfully mount the folders into each frontend using the default local-mounts strategy.
* I haven't tested this using the NFS strategy; I think I'll need someone with a Mac to try that.
* I get an error when I actually try to load a frontend using the local JS packages.

____________________________

This is a PR into another PR: https://github.com/edx/devstack/pull/783