### PR TITLE
Caution MacOS users against blind NFS use

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -163,6 +163,8 @@ The default devstack services can be run by following the steps below.
 
 4. Optional: You have an option to use NFS on MacOS which may improve the performance significantly. To set it up ONLY ON MAC, do:
 
+    Note -
+    Using NFS leads to increased complexity and might cause errors. Improvements to Docker's default FS have made performance improvements negligiable.
     .. code:: sh
 
         make dev.nfs.setup

--- a/README.rst
+++ b/README.rst
@@ -163,8 +163,11 @@ The default devstack services can be run by following the steps below.
 
 4. Optional: You have an option to use NFS on MacOS which may improve the performance significantly. To set it up ONLY ON MAC, do:
 
-    Note -
-    Using NFS leads to increased complexity and might cause errors. Improvements to Docker's default FS have made performance improvements negligible.
+    **Note**
+    Using NFS leads to increased complexity and might cause errors. Improvements to Docker's default FS have made performance improvements negligible.  `Deprecation`_ of NFS is forthcoming. 
+
+    .. _Deprecation: https://openedx.atlassian.net/browse/DEPR-161
+
     .. code:: sh
 
         make dev.nfs.setup

--- a/README.rst
+++ b/README.rst
@@ -164,7 +164,7 @@ The default devstack services can be run by following the steps below.
 4. Optional: You have an option to use NFS on MacOS which may improve the performance significantly. To set it up ONLY ON MAC, do:
 
     **Note**
-    Using NFS leads to increased complexity and might cause errors. Improvements to Docker's default FS have made performance improvements negligible.  `Deprecation`_ of NFS is forthcoming. 
+    Using NFS leads to increased complexity and might cause errors. Improvements to Docker's default FS have made performance improvements negligible. `Deprecation`_ of NFS is forthcoming.
 
     .. _Deprecation: https://openedx.atlassian.net/browse/DEPR-161
 

--- a/README.rst
+++ b/README.rst
@@ -165,7 +165,6 @@ The default devstack services can be run by following the steps below.
 
     Note -
     Using NFS leads to increased complexity and might cause errors. Improvements to Docker's default FS have made performance improvements negligible.
-    
     .. code:: sh
 
         make dev.nfs.setup

--- a/README.rst
+++ b/README.rst
@@ -164,7 +164,8 @@ The default devstack services can be run by following the steps below.
 4. Optional: You have an option to use NFS on MacOS which may improve the performance significantly. To set it up ONLY ON MAC, do:
 
     Note -
-    Using NFS leads to increased complexity and might cause errors. Improvements to Docker's default FS have made performance improvements negligiable.
+    Using NFS leads to increased complexity and might cause errors. Improvements to Docker's default FS have made performance improvements negligible.
+    
     .. code:: sh
 
         make dev.nfs.setup


### PR DESCRIPTION
Added a note to README.rst which describes potential issues with using nfs.

The current docs lead MacOS users to choose NFS.  Per [Previous Discussion ](https://github.com/edx/devstack/pull/465) The original osxfs Docker back end was replaced by gRPC-FUSE in Docker Desktop Community 2.4.0.0 (released on 2021-09-30), which largely eliminates the need for NFS mounts or other previous file synchronization hacks. People have issues with devstack from time-to-time that seem to go away when they stop using NFS.

A note in the README would not remove functionality, but inform new users of Devstack NFS might not always be the best option.


