### PR TITLE
Visually emphasize Docker configuration requirements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,8 +91,9 @@ boot2docker) are *not* supported.
 
 Since a Docker-based devstack runs many containers,
 you should configure Docker with a sufficient
-amount of resources. We find that `configuring Docker for Mac`_ with
-a minimum of 2 CPUs, 8GB of memory, and a disk image size of 96GB does work.
+amount of resources. We find that `configuring Docker for Mac`_
+with a minimum of **2 CPUs, 8GB of memory, and a disk image size of 96GB**
+does work.
 
 `Docker for Windows`_ may work but has not been tested and is *not* supported.
 


### PR DESCRIPTION
Bolds required docker sizing.

The idea is help people who have already installed docker see the required sizing information instead of just reading that docker is required and skipping ahead. Sadly there is no blink tag available in RST.

----

I've completed each of the following or determined they are not applicable:

- [ N/A ] Made a plan to communicate any major developer interface changes (or N/A)
