### PR TITLE
chore: upgrade elasticsearch version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -219,7 +219,7 @@ services:
     container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.discovery"
     hostname: discovery.devstack.edx
     depends_on:
-      - elasticsearch7
+      - elasticsearch710
       - frontend-app-publisher
       - memcached
       - mysql57
@@ -230,7 +230,7 @@ services:
       # This next DB_MIGRATION_HOST line can be removed once edx/configuration has been updated with this value for
       # a while and most people have had a chance to do a "make pull" to get the latest images.
       DB_MIGRATION_HOST: edx.devstack.mysql57
-      TEST_ELASTICSEARCH_URL: "edx.devstack.elasticsearch7"
+      TEST_ELASTICSEARCH_URL: "edx.devstack.elasticsearch710"
       ENABLE_DJANGO_TOOLBAR: 1
       DJANGO_WATCHMAN_TIMEOUT: 30
     image: edxops/discovery:${OPENEDX_RELEASE:-latest}


### PR DESCRIPTION
- update elasticsearch version from 7.8.1 to 7.10.1 for discovery service.

**Steps to test locally**
- update elasticsearch version in devstack for discovery service 
- restart discovery container 
- create some records in `course-discovery` app using `frontend-app-publisher` if there is no record in DB
- create indexes by using django command for elasticsearch indexing.
https://github.com/edx/course-discovery/#using-elasticsearch-locally
- test API's `course_discovery/apps/api/v1`
- run unit tests 
- test django commands

VAN-642
