### PR TITLE
chore: upgrade devstack edx-platform es to 7.10

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -321,7 +321,7 @@ services:
     depends_on:
       - devpi
       - discovery
-      - elasticsearch7
+      - elasticsearch710
       - forum
       - frontend-app-gradebook
       - frontend-app-learning
@@ -432,7 +432,7 @@ services:
     hostname: studio.devstack.edx
     depends_on:
       - devpi
-      - elasticsearch7
+      - elasticsearch710
       - frontend-app-course-authoring
       - frontend-app-library-authoring
       - frontend-app-publisher


### PR DESCRIPTION
chore: upgrade devstack edx-platform es to 7.10

As part of larger elasticsearch upgrade work, we must move edx-platform to use the 7.10 container.

This will ensure future compatibility and maybe make performance improvements to es calls.

Presently, edx-platofrm uses elasticsearch for searching within the content-library. Searching through the [changelogs](https://www.elastic.co/guide/en/elasticsearch/reference/current/migrating-7.10.html#breaking-changes-7.10), no functionality should change in the present formation, as edx-platform es usage is relatively rudimentary.

Testing involved running unit, e2e, and hand testing of the creation and indexing of course content. Attention was paid to its usage in the teams api as well, as that is a notable edge usage.

Part of [TNL-8484](ES 7.10 - Upgrade and Test edx-platform Devstack on Elasticsearch 7.10) and the larger ES upgrade efforts:

https://openedx.atlassian.net/wiki/spaces/AC/pages/2923561087/Elasticsearch+7.10

Config changes: https://github.com/edx/configuration/pull/6496