### PR TITLE
revert: feat!: invert dependencies so that backends now depend on frontends

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,22 +13,27 @@ The Devstack runs as multiple containers with `Docker Compose`_ at its core.
 
 A Devstack installation includes the following Open edX components by default:
 
-* The Learning Management System (LMS).
-* LMS micro-frontends, including Gradebook and Learning (a.k.a. the "new courseware experience").
+* The Learning Management System (LMS)
+* The Learning micro-frontend (A.K.A the new Courseware experience)
 * Open Response Assessments (ORA2), among other LMS plug-ins.
-* Discussion Forums.
-* Open edX Studio, including the Library- and Course-Authoring micro-frontends.
-* E-Commerce, including the Payment micro-frontend.
-* Course Discovery, including the Publisher micro-frontend.
-* Credentials.
-* Notes.
-* Open edX Search.
-* A demonstration Open edX course.
+* Open edX Studio
+* Discussion Forums
+* E-Commerce
+* Credentials
+* Notes
+* Course Discovery
+* Open edX Search
+* A demonstration Open edX course
+* The Publisher and Gradebook micro-frontends
 
 It also includes the following extra components:
 
-* XQueue and an example XQueue consumer.
-* Registrar, including the Program Console micro-frontend.
+* XQueue
+* The Program Console micro-frontend
+* The Library Authoring micro-frontend
+* edX Registrar service.
+* The course-authoring micro-frontend
+
 
 .. contents:: **Table of Contents:**
 
@@ -297,13 +302,13 @@ Instead of a service name or list, you can also run commands like ``make dev.pro
 +------------------------------------+-------------------------------------+----------------+--------------+
 | `frontend-app-gradebook`_          | http://localhost:1994/              | MFE (React.js) | Default      |
 +------------------------------------+-------------------------------------+----------------+--------------+
-| `frontend-app-library-authoring`_  | http://localhost:3001/              | MFE (React.js) | Default      |
-+------------------------------------+-------------------------------------+----------------+--------------+
-| `frontend-app-course-authoring`_   | http://localhost:2001/              | MFE (React.js) | Default      |
+| `registrar`_                       | http://localhost:18734/api-docs/    | Python/Django  | Extra        |
 +------------------------------------+-------------------------------------+----------------+--------------+
 | `frontend-app-program-console`_    | http://localhost:1976/              | MFE (React.js) | Extra        |
 +------------------------------------+-------------------------------------+----------------+--------------+
-| `registrar`_                       | http://localhost:18734/api-docs/    | Python/Django  | Extra        |
+| `frontend-app-library-authoring`_  | http://localhost:3001/              | MFE (React.js) | Extra        |
++------------------------------------+-------------------------------------+----------------+--------------+
+| `frontend-app-course-authoring`_   | http://localhost:2001/              | MFE (React.js) | Extra        |
 +------------------------------------+-------------------------------------+----------------+--------------+
 | `xqueue`_                          | http://localhost:18040/api/v1/      | Python/Django  | Extra        |
 +------------------------------------+-------------------------------------+----------------+--------------+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -220,7 +220,6 @@ services:
     hostname: discovery.devstack.edx
     depends_on:
       - elasticsearch710
-      - frontend-app-publisher
       - memcached
       - mysql57
     # Allows attachment to the discovery service using 'docker attach <containerID>'.
@@ -249,7 +248,6 @@ services:
     hostname: ecommerce.devstack.edx
     depends_on:
       - discovery
-      - frontend-app-payment
       - lms
       - memcached
       - mysql57
@@ -323,8 +321,6 @@ services:
       - discovery
       - elasticsearch710
       - forum
-      - frontend-app-gradebook
-      - frontend-app-learning
       - memcached
       - mongo
       - mysql57
@@ -358,7 +354,6 @@ services:
     hostname: registrar.devstack.edx
     depends_on:
       - discovery
-      - frontend-app-program-console
       - lms
       - mysql57
       - memcached
@@ -433,9 +428,6 @@ services:
     depends_on:
       - devpi
       - elasticsearch710
-      - frontend-app-course-authoring
-      - frontend-app-library-authoring
-      - frontend-app-publisher
       - lms
       - memcached
       - mongo
@@ -512,6 +504,8 @@ services:
           - edx.devstack.frontend-app-course-authoring
     ports:
       - "2001:2001"
+    depends_on:
+      - studio
 
   frontend-app-gradebook:
     extends:
@@ -525,6 +519,8 @@ services:
           - edx.devstack.frontend-app-gradebook
     ports:
       - "1994:1994"
+    depends_on:
+      - lms
 
   frontend-app-learning:
     extends:
@@ -538,6 +534,8 @@ services:
           - edx.devstack.frontend-app-learning
     ports:
       - "2000:2000"
+    depends_on:
+      - lms
 
   frontend-app-library-authoring:
     extends:
@@ -551,6 +549,9 @@ services:
           - edx.devstack.frontend-app-library-authoring
     ports:
       - "3001:3001"
+    depends_on:
+      - lms
+      - studio
 
   frontend-app-payment:
     extends:
@@ -564,6 +565,8 @@ services:
           - edx.devstack.frontend-app-payment
     ports:
       - "1998:1998"
+    depends_on:
+      - ecommerce
 
   frontend-app-program-console:
     extends:
@@ -577,6 +580,9 @@ services:
           - edx.devstack.frontend-app-program-console
     ports:
       - "1976:1976"
+    depends_on:
+      - lms
+      - registrar
 
   frontend-app-publisher:
     extends:
@@ -590,6 +596,8 @@ services:
           - edx.devstack.frontend-app-publisher
     ports:
       - "18400:18400"
+    depends_on:
+      - lms
 
 volumes:
   discovery_assets:

--- a/docs/decisions/0004-backends-depend-on-frontends.rst
+++ b/docs/decisions/0004-backends-depend-on-frontends.rst
@@ -4,8 +4,15 @@
 Status
 ======
 
-Approved
+**Reverted** due to resource depletion concerns.
 
+A consequence of implementing this decision was that an increased number of containers (specifically, frontend containers) were started by common commands like ``make dev.provision`` and ``make dev.up.lms``. Unfortunately, the increased system resource consumption was leading to blocking workflow disruptions such as Docker network timeouts.
+
+In absence of an immediately obvious way of reducing the additional resource burden that this decision's implementation requires, we have decided to revert it. Future work could include:
+
+* Revisit the *Rejected Alternatives* listed at the bottom of this decision record. Both of those alternatives allow smaller groups of containers to be started for different situtations.
+* Investigate how the memory and CPU footprints of the micro-frontend Docker containers could be reduced.
+* Investigate running all micro-frontends from a singular Docker container.
 
 Context
 =======

--- a/options.mk
+++ b/options.mk
@@ -58,8 +58,6 @@ FS_SYNC_STRATEGY ?= local-mounts
 # Services that are to be pulled, provisioned, run, and checked by default
 # when no services are specified manually.
 # Should be a subset of $(EDX_SERVICES).
-# frontend-apps are not included here, but several of them are dependencies of default
-# services.
 # Separated by plus signs. Listed in alphabetical order for clarity.
 # WARNING: You may remove services from this list in order to make Devstack lighter,
 #          but beware that some services have implicit, undocumented dependencies on
@@ -70,7 +68,7 @@ FS_SYNC_STRATEGY ?= local-mounts
 #       The current value was chosen such that it would not change the existing
 #       Devstack behavior.
 DEFAULT_SERVICES ?= \
-credentials+discovery+ecommerce+edx_notes_api+forum+lms+studio
+credentials+discovery+ecommerce+edx_notes_api+forum+frontend-app-gradebook+frontend-app-payment+frontend-app-publisher+frontend-app-learning+lms+studio
 
 # All edX services, whether or not they are run by default.
 # Separated by plus signs.


### PR DESCRIPTION
## Description

```
The original commit made it so frontend services were started
as dependencies whenever LMS (or other services) were started.
The increased number of Docker containers is causing resource
depletion for at least one developer.
As a short-term fix, we will revert this commit.

This reverts most of commit 54fb57ffd94d1d723de0920b49922e0100abdae7,
although it leaves in place the changes to docs/workflow.rst, as they
are still relevant.
It also keeps ADR #4, but amends it.
```

## Other information

This reverts part of (but not all of) https://github.com/edx/devstack/pull/783. Specifically, it puts the old dependency relationships back in place, but keeps the changes to frontend app names and frontend package mounting.

I will follow up this merge with a new email to the org.