### PR TITLE
feat: Use new openedx Credentials image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -438,7 +438,7 @@ dev.attach.%: ## Attach to the specified service container process for debugging
 dev.shell: _expects-service.dev.shell
 
 dev.shell.credentials:
-	docker-compose exec credentials env TERM=$(TERM) bash -c 'source /edx/app/credentials/credentials_env && cd /edx/app/credentials/credentials && /bin/bash'
+	docker-compose exec credentials env TERM=$(TERM) bash -c 'cd /edx/app/credentials/credentials && /bin/bash'
 
 dev.shell.discovery:
 	docker-compose exec discovery env TERM=$(TERM) /edx/app/discovery/devstack.sh open

--- a/credentials/generate_program_certificate.sh
+++ b/credentials/generate_program_certificate.sh
@@ -9,11 +9,11 @@ docker-compose exec -T discovery bash -c 'rm -rf /edx/app/discovery/discovery/pr
 
 echo 'Updating credentials...'
 echo 'setting catalog and lms base urls'
-docker-compose exec -T credentials bash -c 'source /edx/app/credentials/credentials_env && python /edx/app/credentials/credentials/manage.py create_or_update_site --site-domain example.com --site-name example.com --platform-name edX --tos-url https://www.edx.org/edx-terms-service --privacy-policy-url https://www.edx.org/edx-privacy-policy --homepage-url https://www.edx.org --company-name "edX Inc." --certificate-help-url https://edx.readthedocs.org/projects/edx-guide-for-students/en/latest/SFD_certificates.html#web-certificates --lms-url-root http://edx.devstack.lms:18000/ --catalog-api-url http://edx.devstack.discovery:18381/api/v1/ --theme-name edx.org'
+docker-compose exec -T credentials bash -c 'python /edx/app/credentials/credentials/manage.py create_or_update_site --site-domain example.com --site-name example.com --platform-name edX --tos-url https://www.edx.org/edx-terms-service --privacy-policy-url https://www.edx.org/edx-privacy-policy --homepage-url https://www.edx.org --company-name "edX Inc." --certificate-help-url https://edx.readthedocs.org/projects/edx-guide-for-students/en/latest/SFD_certificates.html#web-certificates --lms-url-root http://edx.devstack.lms:18000/ --catalog-api-url http://edx.devstack.discovery:18381/api/v1/ --theme-name edx.org'
 echo 'copying discovery catalog'
-docker-compose exec -T credentials bash -c 'source /edx/app/credentials/credentials_env && python /edx/app/credentials/credentials/manage.py copy_catalog'
+docker-compose exec -T credentials bash -c 'python /edx/app/credentials/credentials/manage.py copy_catalog'
 echo 'creating a program certificate configuration'
-docker-compose exec -T credentials bash -c 'source /edx/app/credentials/credentials_env && python /edx/app/credentials/credentials/manage.py create_program_certificate_configuration'
+docker-compose exec -T credentials bash -c 'python /edx/app/credentials/credentials/manage.py create_program_certificate_configuration'
 
 echo 'Updating LMS...'
 echo 'creating a credentials API connection'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -190,7 +190,7 @@ services:
   # ================================================
 
   credentials:
-    command: bash -c 'source /edx/app/credentials/credentials_env && while true; do python /edx/app/credentials/credentials/manage.py runserver 0.0.0.0:18150; sleep 2; done'
+    command: bash -c 'while true; do python /edx/app/credentials/credentials/manage.py runserver 0.0.0.0:18150; sleep 2; done'
     container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.credentials"
     hostname: credentials.devstack.edx
     depends_on:
@@ -206,7 +206,8 @@ services:
       SOCIAL_AUTH_EDX_OIDC_URL_ROOT: http://edx.devstack.lms:18000/oauth2
       ENABLE_DJANGO_TOOLBAR: 1
       DJANGO_WATCHMAN_TIMEOUT: 30
-    image: edxops/credentials:${OPENEDX_RELEASE:-latest}
+      DJANGO_SETTINGS_MODULE: credentials.settings.devstack
+    image: openedx/credentials:${OPENEDX_RELEASE:-latest}
     networks:
       default:
         aliases:

--- a/provision-credentials.sh
+++ b/provision-credentials.sh
@@ -13,20 +13,20 @@ port=18150
 docker-compose up -d $name
 
 echo -e "${GREEN}Installing requirements for ${name}...${NC}"
-docker-compose exec -T ${name}  bash -e -c 'source /edx/app/credentials/credentials_env && cd /edx/app/credentials/credentials && make requirements' -- "$name"
+docker-compose exec -T ${name}  bash -e -c 'cd /edx/app/credentials/credentials && make requirements' -- "$name"
 
 echo -e "${GREEN}Running migrations for ${name}...${NC}"
-docker-compose exec -T ${name}  bash -e -c 'source /edx/app/credentials/credentials_env && cd /edx/app/credentials/credentials && make migrate' -- "$name"
+docker-compose exec -T ${name}  bash -e -c 'cd /edx/app/credentials/credentials && make migrate' -- "$name"
 
 echo -e "${GREEN}Creating super-user for ${name}...${NC}"
-docker-compose exec -T ${name}  bash -e -c 'source /edx/app/credentials/credentials_env && cd /edx/app/credentials/credentials && echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser(\"edx\", \"edx@example.com\", \"edx\") if not User.objects.filter(username=\"edx\").exists() else None" | python /edx/app/$1/$1/manage.py shell' -- "$name"
+docker-compose exec -T ${name}  bash -e -c 'cd /edx/app/credentials/credentials && echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser(\"edx\", \"edx@example.com\", \"edx\") if not User.objects.filter(username=\"edx\").exists() else None" | python /edx/app/$1/$1/manage.py shell' -- "$name"
 
 echo -e "${GREEN}Configuring site for ${name}...${NC}"
-docker-compose exec -T ${name} bash -e -c 'source /edx/app/credentials/credentials_env && cd /edx/app/credentials/credentials && ./manage.py create_or_update_site --site-id=1 --site-domain=localhost:18150 --site-name="Open edX" --platform-name="Open edX" --company-name="Open edX" --lms-url-root=http://localhost:18000 --catalog-api-url=http://edx.devstack.discovery:18381/api/v1/ --tos-url=http://localhost:18000/tos --privacy-policy-url=http://localhost:18000/privacy --homepage-url=http://localhost:18000 --certificate-help-url=http://localhost:18000/faq --records-help-url=http://localhost:18000/faq --theme-name=openedx'
+docker-compose exec -T ${name} bash -e -c 'cd /edx/app/credentials/credentials && ./manage.py create_or_update_site --site-id=1 --site-domain=localhost:18150 --site-name="Open edX" --platform-name="Open edX" --company-name="Open edX" --lms-url-root=http://localhost:18000 --catalog-api-url=http://edx.devstack.discovery:18381/api/v1/ --tos-url=http://localhost:18000/tos --privacy-policy-url=http://localhost:18000/privacy --homepage-url=http://localhost:18000 --certificate-help-url=http://localhost:18000/faq --records-help-url=http://localhost:18000/faq --theme-name=openedx'
 
 ./provision-ida-user.sh ${name} ${name} ${port}
 
 # Compile static assets last since they are absolutely necessary for all services. This will allow developers to get
 # started if they do not care about static assets
 echo -e "${GREEN}Compiling static assets for ${name}...${NC}"
-docker-compose exec -T ${name}  bash -e -c ' if ! source /edx/app/credentials/credentials_env && cd /edx/app/credentials/credentials && make static 2>creds_make_static.err; then echo "------- Last 100 lines of stderr"; tail creds_make_static.err -n 100; echo "-------"; fi;' -- "$name"
+docker-compose exec -T ${name}  bash -e -c ' if ! cd /edx/app/credentials/credentials && make static 2>creds_make_static.err; then echo "------- Last 100 lines of stderr"; tail creds_make_static.err -n 100; echo "-------"; fi;' -- "$name"


### PR DESCRIPTION
The new openedx image is built by the Credentials repo. It's about half
the size of the Ansible built image. The new build does not include a
credentials_env file, but the 3 environment variables it set are now set
elsewhere:
- DJANGO_SETTINGS_MODULE: set in docker-compose
- CREDENTIALS_CFG: Not needed for non-production build
- PATH: Set by Dockerfile to include python and node virtual
environments

To test (this will not remove any data, just swap images, you can always swap back)
1. Pull this branch
2. `docker stop edx.devstack.credentials`
3. `docker rm edx.devstack.credentials`
4. `make dev.up.credentials`
5. Test credentials as you normally would

----

I've completed each of the following or determined they are not applicable:

- [ ] Made a plan to communicate any major developer interface changes (or N/A)
