### PR TITLE
feat: Add the microfrontend account to the devstack on port 1997

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -310,6 +310,8 @@ Instead of a service name or list, you can also run commands like ``make dev.pro
 +------------------------------------+-------------------------------------+----------------+--------------+
 | `frontend-app-course-authoring`_   | http://localhost:2001/              | MFE (React.js) | Extra        |
 +------------------------------------+-------------------------------------+----------------+--------------+
+| `frontend-app-account`_            | http://localhost:1997/              | MFE (React.js) | Extra        |
++------------------------------------+-------------------------------------+----------------+--------------+
 | `xqueue`_                          | http://localhost:18040/api/v1/      | Python/Django  | Extra        |
 +------------------------------------+-------------------------------------+----------------+--------------+
 | `coursegraph`                      | http://localhost:7474/browser       | Tooling (Java) | Extra        |
@@ -337,6 +339,7 @@ Some common service combinations include:
 .. _frontend-app-learning: https://github.com/edx/frontend-app-learning
 .. _frontend-app-library-authoring: https://github.com/edx/frontend-app-library-authoring
 .. _frontend-app-course-authoring: https://github.com/edx/frontend-app-course-authoring
+.. _frontend-app-account: https://github.com/edx/frontend-app-account
 .. _xqueue: https://github.com/edx/xqueue
 .. _coursegraph: https://github.com/edx/edx-platform/tree/master/openedx/core/djangoapps/coursegraph
 

--- a/docker-compose-host.yml
+++ b/docker-compose-host.yml
@@ -53,6 +53,12 @@ services:
 
   # Note that frontends mount `src` to /edx/app/src instead of /edx/src.
   # See ADR #5 for rationale.
+  frontend-app-account:
+    volumes:
+      - ${DEVSTACK_WORKSPACE}/frontend-app-account:/edx/app/frontend-app-account:cached
+      - frontend_app_account_node_modules:/edx/app/frontend-app-account/node_modules
+      - ${DEVSTACK_WORKSPACE}/src:/edx/app/src:cached
+
   frontend-app-course-authoring:
     volumes:
       - ${DEVSTACK_WORKSPACE}/frontend-app-course-authoring:/edx/app/frontend-app-course-authoring:cached
@@ -96,6 +102,7 @@ volumes:
   edxapp_media:
   edxapp_node_modules:
   edxapp_uploads:
+  frontend_app_account_node_modules:
   frontend_app_course_authoring_node_modules:
   frontend_app_gradebook_node_modules:
   frontend_app_learning_node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -512,6 +512,21 @@ services:
   # for micro-frontends in devtack.
   # ==========================================================================
 
+  frontend-app-account:
+    extends:
+      file: microfrontend.yml
+      service: microfrontend
+    working_dir: '/edx/app/frontend-app-account'
+    container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.frontend-app-account"
+    networks:
+      default:
+        aliases:
+          - edx.devstack.frontend-app-account
+    ports:
+      - "1997:1997"
+    depends_on:
+      - lms
+  
   frontend-app-course-authoring:
     extends:
       file: microfrontend.yml

--- a/options.mk
+++ b/options.mk
@@ -74,7 +74,7 @@ credentials+discovery+ecommerce+edx_notes_api+forum+frontend-app-gradebook+front
 # Separated by plus signs.
 # Separated by plus signs. Listed in alphabetical order for clarity.
 EDX_SERVICES ?= \
-credentials+discovery+ecommerce+edx_notes_api+forum+frontend-app-course-authoring+frontend-app-gradebook+frontend-app-learning+frontend-app-library-authoring+frontend-app-payment+frontend-app-program-console+frontend-app-publisher+lms+lms_watcher+registrar+registrar-worker+studio+studio_watcher+xqueue+xqueue_consumer
+credentials+discovery+ecommerce+edx_notes_api+forum+frontend-app-account+frontend-app-course-authoring+frontend-app-gradebook+frontend-app-learning+frontend-app-library-authoring+frontend-app-payment+frontend-app-program-console+frontend-app-publisher+lms+lms_watcher+registrar+registrar-worker+studio+studio_watcher+xqueue+xqueue_consumer
 
 # Services with database migrations.
 # Should be a subset of $(EDX_SERVICES).

--- a/repo.sh
+++ b/repo.sh
@@ -40,6 +40,7 @@ non_release_repos=(
     "https://github.com/edx/frontend-app-library-authoring.git"
     "https://github.com/edx/registrar.git"
     "https://github.com/edx/frontend-app-program-console.git"
+    "https://github.com/edx/frontend-app-account.git"
 )
 
 ssh_repos=(
@@ -62,6 +63,7 @@ non_release_ssh_repos=(
     "git@github.com:edx/frontend-app-library-authoring.git"
     "git@github.com:edx/registrar.git"
     "git@github.com:edx/frontend-app-program-console.git"
+    "git@github.com:edx/frontend-app-account.git"
 )
 
 private_repos=(


### PR DESCRIPTION
Currently, the MFE frontend-app-account is not part of the optional microfrontends devstack can quickly help develop run. Add this devstack container for development

