### PR TITLE
fix: in coursegraph provision, run lms command instead of exec'ing 

### DIFF
--- a/provision-coursegraph.sh
+++ b/provision-coursegraph.sh
@@ -18,6 +18,6 @@ sleep 10  # Give Neo4j some time to boot up.
 
 echo -e "${GREEN}   Updating LMS courses in Coursegraph...${NC}"
 
-docker-compose exec lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && ./manage.py lms dump_to_neo4j --host coursegraph.devstack.edx --user neo4j --password edx'
+docker-compose run lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && ./manage.py lms dump_to_neo4j --host coursegraph.devstack.edx --user neo4j --password edx'
 
 echo -e "${GREEN}   Coursegraph is now up-to-date with LMS!${NC}"


### PR DESCRIPTION
```
This ensures that the provisioning script
works whether or not the lms was already started.
If an lms container doesn't exist, then `docker-compose run`
ensures that one is created to run the management
command.

Using `docker-compose exec`, the script would fail with
"no container lms_1" if lms wasn't already running.
```

quick fix to https://github.com/edx/devstack/pull/820