### PR TITLE
chore: upgrade coursegraph's neo4j image from 3.2 to 3.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     hostname: coursegraph.devstack.edx
     # Try to keep this in sync with the NEO4J_VERSION declared within
     # https://github.com/edx/configuration/blob/master/playbooks/roles/neo4j
-    image: neo4j:3.2
+    image: neo4j:3.5.28
     networks:
       default:
         aliases:

--- a/provision-coursegraph.sh
+++ b/provision-coursegraph.sh
@@ -4,20 +4,19 @@ set -eu -o pipefail
 . scripts/colors.sh
 set -x
 
-echo -e "${GREEN}   Ensuring Coursegraph image is up to date...${NC}"
-
 # Pulling the image will almost always be a no-op, but will be important
 # when we bump the version in docker-compose.yml or when Neo4j releases a patch.
 # Also, this gives us a chance to refresh the container in case it's gotten into
 # a weird state.
+echo -e "${GREEN}   Ensuring Coursegraph image is up to date...${NC}"
 docker-compose rm --force --stop coursegraph
 docker-compose pull coursegraph
-docker-compose up -d coursegraph
 
+echo -e "${GREEN}   Starting Coursegraph and LMS...${NC}"
+docker-compose up -d coursegraph lms
 sleep 10  # Give Neo4j some time to boot up.
 
 echo -e "${GREEN}   Updating LMS courses in Coursegraph...${NC}"
-
-docker-compose run lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && ./manage.py lms dump_to_neo4j --host coursegraph.devstack.edx --user neo4j --password edx'
+docker-compose exec lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && ./manage.py lms dump_to_neo4j --host coursegraph.devstack.edx --user neo4j --password edx'
 
 echo -e "${GREEN}   Coursegraph is now up-to-date with LMS!${NC}"


### PR DESCRIPTION
This coincides with our upgrade of Neo4j in
edx/configuration.

Other notes:
* We are specifically pinning 3.5.28 (instead of simply
  3.5) to ensure that we're using the exact same patch
  release as what's deployed from edx/configuration.
* In the provisioning script, we now specifically start lms
  and then `exec` the management command. Before, we
  used the `run` command, which started lms automatically.
  This worked; however,  it would create a *second* lms
  container if one was already running, which was very confusing.
  With this change, we will either (a) start a new lms container
  and use it, or (b) use the existing lms container.

Ticket: https://openedx.atlassian.net/browse/TNL-8386
Upgrade of deployed neo4j version in configuration: https://github.com/edx/configuration/pull/6502
Upgrade of py2neo driver in edx-platform: https://github.com/edx/edx-platform/pull/28480
