### PR TITLE
feat: upgrade mongo to 4.2 in devstack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -148,10 +148,10 @@ services:
     # We use WiredTiger in all environments. In development environments we use small files
     # to conserve disk space, and disable the journal for a minor performance gain.
     # See https://docs.mongodb.com/v3.0/reference/program/mongod/#options for complete details.
-    command: mongod --smallfiles --nojournal --storageEngine wiredTiger
+    command: mongod --nojournal --storageEngine wiredTiger
     container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.mongo"
     hostname: mongo.devstack.edx
-    image: mongo:${MONGO_VERSION:-4.0.22}
+    image: mongo:${MONGO_VERSION:-4.2.14}
     networks:
       default:
         aliases:


### PR DESCRIPTION
This PR will update the mongo in devstack to 4.2. For already running devstack installations we need to take the pull and run this [script](https://github.com/edx/devstack/blob/master/upgrade_mongo_4_2.sh) to upgrade mongo to 4.2 after the changes in this PR will be merged. I will inform via email and slack about this change.