### PR TITLE
feat: add frontend-app-ora-grading to devstack as an extra service

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,7 @@ It also includes the following extra components:
 * The Library Authoring micro-frontend
 * edX Registrar service.
 * The course-authoring micro-frontend
+* The enhanced staff grader (ora-grading) micro-frontend
 
 
 .. contents:: **Table of Contents:**
@@ -321,6 +322,8 @@ Instead of a service name or list, you can also run commands like ``make dev.pro
 +------------------------------------+-------------------------------------+----------------+--------------+
 | `insights`                         | http://localhost:18110              | Python/Django  | Extra        |
 +------------------------------------+-------------------------------------+----------------+--------------+
+| `frontend-app-ora-grading`         | http://localhost:1993               | MFE (React.js) | Extra        |
++------------------------------------+-------------------------------------+----------------+--------------+
 
 Some common service combinations include:
 
@@ -347,6 +350,7 @@ Some common service combinations include:
 .. _frontend-app-account: https://github.com/edx/frontend-app-account
 .. _xqueue: https://github.com/edx/xqueue
 .. _coursegraph: https://github.com/edx/edx-platform/tree/master/openedx/core/djangoapps/coursegraph
+.. _frontend-app-ora-grading: https://github.com/edx/frontend-app-ora-grading
 
 
 Known Issues

--- a/docker-compose-host.yml
+++ b/docker-compose-host.yml
@@ -72,6 +72,11 @@ services:
       - ${DEVSTACK_WORKSPACE}/frontend-app-gradebook:/edx/app/frontend-app-gradebook
       - frontend_app_gradebook_node_modules:/edx/app/frontend-app-gradebook/node_modules
       - ${DEVSTACK_WORKSPACE}/src:/edx/app/src
+  frontend-app-ora-grading:
+    volumes:
+      - ${DEVSTACK_WORKSPACE}/frontend-app-ora-grading:/edx/app/frontend-app-ora-grading
+      - frontend_app_ora_grading_node_modules:/edx/app/frontend-app-ora-grading/node_modules
+      - ${DEVSTACK_WORKSPACE}/src:/edx/app/src
   frontend-app-learning:
     volumes:
       - ${DEVSTACK_WORKSPACE}/frontend-app-learning:/edx/app/frontend-app-learning
@@ -109,6 +114,7 @@ volumes:
   frontend_app_account_node_modules:
   frontend_app_course_authoring_node_modules:
   frontend_app_gradebook_node_modules:
+  frontend_app_ora_grading_node_modules:
   frontend_app_learning_node_modules:
   frontend_app_library_authoring_node_modules:
   frontend_app_payment_node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -568,6 +568,21 @@ services:
       - "1994:1994"
     depends_on:
       - lms
+  
+  frontend-app-ora-grading:
+    extends:
+      file: microfrontend.yml
+      service: microfrontend
+    working_dir: '/edx/app/frontend-app-ora-grading'
+    container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.frontend-app-ora-grading"
+    networks:
+      default:
+        aliases:
+          - edx.devstack.frontend-app-ora-grading
+    ports:
+      - "1993:1993"
+    depends_on:
+      - lms
 
   frontend-app-learning:
     extends:

--- a/options.mk
+++ b/options.mk
@@ -67,7 +67,7 @@ credentials+discovery+ecommerce+edx_notes_api+forum+frontend-app-gradebook+front
 # Separated by plus signs.
 # Separated by plus signs. Listed in alphabetical order for clarity.
 EDX_SERVICES ?= \
-credentials+discovery+ecommerce+edx_notes_api+forum+frontend-app-account+frontend-app-course-authoring+frontend-app-gradebook+frontend-app-learning+frontend-app-library-authoring+frontend-app-payment+frontend-app-program-console+frontend-app-publisher+insights+lms+lms_watcher+registrar+registrar-worker+studio+studio_watcher+xqueue+xqueue_consumer
+credentials+discovery+ecommerce+edx_notes_api+forum+frontend-app-account+frontend-app-course-authoring+frontend-app-gradebook+frontend-app-ora-grading+frontend-app-learning+frontend-app-library-authoring+frontend-app-payment+frontend-app-program-console+frontend-app-publisher+insights+lms+lms_watcher+registrar+registrar-worker+studio+studio_watcher+xqueue+xqueue_consumer
 
 # Services with database migrations.
 # Should be a subset of $(EDX_SERVICES).

--- a/repo.sh
+++ b/repo.sh
@@ -42,6 +42,7 @@ non_release_repos=(
     "https://github.com/edx/registrar.git"
     "https://github.com/edx/frontend-app-program-console.git"
     "https://github.com/edx/frontend-app-account.git"
+    "https://github.com/edx/frontend-app-ora-grading.git"
 )
 
 ssh_repos=(
@@ -66,6 +67,7 @@ non_release_ssh_repos=(
     "git@github.com:edx/registrar.git"
     "git@github.com:edx/frontend-app-program-console.git"
     "git@github.com:edx/frontend-app-account.git"
+    "git@github.com:edx/frontend-app-ora-grading.git"
 )
 
 private_repos=(


### PR DESCRIPTION
add frontend-app-ora-grading to devstack as an extra service

Ticket: [AU-321](https://openedx.atlassian.net/browse/AU-321)
Related PR: [frontend-app-ora-grading](https://github.com/edx/frontend-app-ora-grading/pull/14)

- [x] add docker configuration
- [x] update document in README
- [x] update git repo url

### Test

- [x] `make dev.up` should not spin up `frontend-app-ora-grading`
- [x] `make dev.up.frontend-app-ora-grading` should spin up the `esg-mfe`
- [x] Basic make command
  - [x] `make dev.attach.frontend-app-ora-grading` work
  - [x] `make dev.shell.frontend-app-ora-grading` work
  - [x] `make dev.clone.frontend-app-ora-grading` work