### PR TITLE
feat: allow manual triggering of provisioning tests and alert OpsGenie on failure

### DIFF
--- a/.github/workflows/provisioning-tests.yml
+++ b/.github/workflows/provisioning-tests.yml
@@ -9,8 +9,8 @@ on:
     branches:
       - '**'
   schedule:
-    # run at 9:30 am M-F
-    - cron: '30 13 * * 1-5'
+    # run at 7:30 am M-F
+    - cron: '30 11 * * 1-5'
 
 jobs:
 

--- a/.github/workflows/provisioning-tests.yml
+++ b/.github/workflows/provisioning-tests.yml
@@ -8,6 +8,12 @@ on:
   pull_request:
     branches:
       - '**'
+  workflow_dispatch:
+      inputs:
+          calling_repo:
+              description: 'Name of the repository triggering this action'
+              required: false
+              default: '@edx/devstack'
 
 jobs:
 
@@ -32,6 +38,15 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: set calling repository variable
+        run: |
+          if [ -z ${{ github.events.inputs.calling_repo }} ]
+          then
+            echo "CALLING_REPOSITORY=@edx/devstack" >> $GITHUB_ENV
+          else
+            echo "CALLING_REPOSITORY=${{ github.events.inputs.calling_repo }}" >> $GITHUB_ENV
+          fi
 
       - name: installations and version upgrades
         run: |
@@ -65,6 +80,32 @@ jobs:
 
       - name: dev.check
         run:  make dev.check.${{matrix.services}}
+
+      - name: notify on failure
+        if: ${{ failure() && github.ref == 'refs/heads/master' }}
+        uses: dawidd6/action-send-mail@v3
+        with:
+           server_address: email-smtp.us-east-1.amazonaws.com
+           server_port: 465
+           username: ${{secrets.EDX_SMTP_USERNAME}}
+           password: ${{secrets.EDX_SMTP_PASSWORD}}
+           subject: 'Failure: Devstack provisioning tests for ${{matrix.services}} #${{github.run_id}}'
+           to: devstack-provisioning-tests@edx.opsgenie.net
+           from: github-actions <github-actions@edx.org>
+           body: 'Devstack provisioning tests in ${{github.repository}} for ${{matrix.services}} failed! For details see "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}". Run triggered by ${{ env.CALLING_REPOSITORY }}. \n Runbook url: https://openedx.atlassian.net/l/c/zoEcLk2z .'
+
+      - name: close alerts on success
+        if: ${{ !failure() && github.ref == 'refs/heads/master' }}
+        uses: dawidd6/action-send-mail@v3
+        with:
+           server_address: email-smtp.us-east-1.amazonaws.com
+           server_port: 465
+           username: ${{secrets.EDX_SMTP_USERNAME}}
+           password: ${{secrets.EDX_SMTP_PASSWORD}}
+           subject: 'Back to normal: Devstack provisioning tests for ${{matrix.services}} #${{github.run_id}}'
+           to: devstack-provisioning-tests@edx.opsgenie.net
+           from: github-actions <github-actions@edx.org>
+           body: Devstack provisioning tests in ${{github.repository}} are back to normal for ${{matrix.services}}
 
       - name: docs
         run:  make docs

--- a/.github/workflows/provisioning-tests.yml
+++ b/.github/workflows/provisioning-tests.yml
@@ -8,12 +8,9 @@ on:
   pull_request:
     branches:
       - '**'
-  workflow_dispatch:
-      inputs:
-          calling_repo:
-              description: 'Name of the repository triggering this action'
-              required: false
-              default: '@edx/devstack'
+  schedule:
+    # run at 9:30 am M-F
+    - cron: '30 13 * * 1-5'
 
 jobs:
 
@@ -38,15 +35,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: set calling repository variable
-        run: |
-          if [ -z ${{ github.events.inputs.calling_repo }} ]
-          then
-            echo "CALLING_REPOSITORY=@edx/devstack" >> $GITHUB_ENV
-          else
-            echo "CALLING_REPOSITORY=${{ github.events.inputs.calling_repo }}" >> $GITHUB_ENV
-          fi
 
       - name: installations and version upgrades
         run: |
@@ -92,7 +80,7 @@ jobs:
            subject: 'Failure: Devstack provisioning tests for ${{matrix.services}} #${{github.run_id}}'
            to: devstack-provisioning-tests@edx.opsgenie.net
            from: github-actions <github-actions@edx.org>
-           body: 'Devstack provisioning tests in ${{github.repository}} for ${{matrix.services}} failed! For details see "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}". Run triggered by ${{ env.CALLING_REPOSITORY }}. \n Runbook url: https://openedx.atlassian.net/l/c/zoEcLk2z .'
+           body: 'Devstack provisioning tests in ${{github.repository}} for ${{matrix.services}} failed! For details see "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}". \n Runbook url: https://openedx.atlassian.net/l/c/zoEcLk2z .'
 
       - name: close alerts on success
         if: ${{ !failure() && github.ref == 'refs/heads/master' }}


### PR DESCRIPTION
Allow the provisioning-tests workflow to be triggered manually for eventual use by other repositories (so they can trigger devstack tests on updates). Also set up OpsGenie alerts for test failures on master that autoclose if the build subsequently succeeds.

I've completed each of the following or determined they are not applicable:

- [N/A ] Made a plan to communicate any major developer interface changes (or N/A)
