### PR TITLE
feat: main branch support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,13 +149,13 @@ selfcheck: ## Check that the Makefile is free of Make syntax errors.
 # Developer interface: Repository management.
 ########################################################################################
 
-dev.reset-repos: ## Attempt to reset the local repo checkouts to the master working state.
+dev.reset-repos: ## Attempt to reset the local repo checkouts to the default branch working state.
 	$(WINPTY) bash ./repo.sh reset
 
 dev.status: ## Prints the status of all git repositories.
 	$(WINPTY) bash ./repo.sh status
 
-dev.checkout: ## Check out "openedx-release/$OPENEDX_RELEASE" in each repo if set, "master" otherwise.
+dev.checkout: ## Check out "openedx-release/$OPENEDX_RELEASE" in each repo if set, use default branch otherwise.
 	./repo.sh checkout
 
 dev.clone: dev.clone.ssh ## Clone service repos to the parent directory.
@@ -482,7 +482,7 @@ dev.static.%: ## Rebuild static assets for the specified service's container.
 ########################################################################################
 
 
-dev.reset: dev.down dev.reset-repos dev.prune dev.pull.large-and-slow dev.up.large-and-slow dev.static dev.migrate ## Attempt to reset the local devstack to the master working state without destroying data.
+dev.reset: dev.down dev.reset-repos dev.prune dev.pull.large-and-slow dev.up.large-and-slow dev.static dev.migrate ## Attempt to reset the local devstack to the default branch working state without destroying data.
 
 dev.destroy.coursegraph: dev.down.coursegraph ## Remove all coursegraph data.
 	docker volume rm ${COMPOSE_PROJECT_NAME}_coursegraph_data


### PR DESCRIPTION
Adding support for main branch.

This problem arise from [this pr](https://github.com/edx/devstack/pull/841). The new mfe `frontend-app-ora-grading` is having main branch as default.

# TEST

1. Add "git@github.com:edx/frontend-app-ora-grading.git" to `non_release_ssh_repos`
2. **Optional** Add ""https://github.com/edx/frontend-app-ora-grading.git" to `non_release_repos`
3. Run `make dev.clone`
    - [ ] `make dev.clone` should clone `frontend-app-ora-grading` main branch.
4. Go to frontend-app-ora-grading and checkout another branch.
    - [ ] `make dev.clone` should checkout the main branch and update for `frontend-app-ora-grading`.
5. Open release should still be working
    - [ ] run `OPENEDX_RELEASE=maple.master make dev.clone` and it should still checkout all of the released repo as it used to do.

