### PR TITLE
feat: forward mongo and mysql ports by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -156,8 +156,8 @@ services:
       default:
         aliases:
           - edx.devstack.mongo
-    # ports:
-    #  - "27017:27017"
+    ports:
+     - "27017:27017"
     volumes:
       - mongo_data:/data/db
 
@@ -173,8 +173,8 @@ services:
       default:
         aliases:
           - edx.devstack.mysql57
-    # ports:
-    #   - "3506:3306"
+    ports:
+      - "3506:3306"
     volumes:
       - mysql57_data:/var/lib/mysql
 


### PR DESCRIPTION
It seems to me there's no reason to keep these commented out anymore.

Port forwarding for these services was originally removed due to port clashes when running vagrant devstack. Since that is no longer relevant we should add these back.

context from when this is added in 2016: https://github.com/edx/devstack/pull/20
