### PR TITLE
Add basic support for Apple Silicon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,15 @@ COMPOSE_FILE := docker-compose-host.yml
 COMPOSE_FILE := $(COMPOSE_FILE):docker-compose-themes.yml
 COMPOSE_FILE := $(COMPOSE_FILE):docker-compose-watchers.yml
 COMPOSE_FILE := docker-compose.yml:$(COMPOSE_FILE)
+ifdef COMPOSE_OVERRIDES_FILE
+	COMPOSE_FILE := $(COMPOSE_FILE):$(COMPOSE_OVERRIDES_FILE)
+endif
+
+# Check system architecture, e.g. use arm64v8 on Apple Silicon / M1
+OS_ARCH := $(shell uname -p)
+ifeq ($(OS_ARCH),arm)
+    COMPOSE_FILE := $(COMPOSE_FILE):docker-compose-arm64v8.yml
+endif
 
 # Tell Docker Compose that the Compose file list uses a colon as the separator.
 COMPOSE_PATH_SEPARATOR := :

--- a/docker-compose-arm64v8.yml
+++ b/docker-compose-arm64v8.yml
@@ -1,0 +1,86 @@
+# These overrides allow Open edX devstack to run on ARM64 systems like the M1 Macs (Apple Silicon)
+# However, these amd64 images are likely to be very slow. We should replace them with ARM64 versions
+# as much as possible.
+version: "2.1"
+
+services:
+
+  chrome:
+    platform: linux/amd64
+
+  coursegraph:
+    platform: linux/amd64
+
+  devpi:
+    platform: linux/amd64
+
+  elasticsearch:
+    platform: linux/amd64
+
+  # elasticsearch7:
+  # image: elasticsearch:7.8.1 is available in linux/arm64/v8
+
+  # elasticsearch710:
+  # image: elasticsearch:7.10.1 is available in linux/arm64/v8
+
+  firefox:
+    platform: linux/amd64
+
+  # memcached:
+  # image: memcached:1.5.10-alpine is available in linux/arm64/v8
+
+  # mongo:
+  # image: mongo:4.2.14 is available in linux/arm64/v8
+
+  mysql57:
+    #image: mysql:5.7 doesn't support linux/arm64/v8
+    image: mariadb:10.4
+
+  redis:
+    # image: redis:2.8 is ancient and doesn't support linux/arm64/v8
+    image: redis:5
+
+  # ================================================
+  # edX services
+  # ================================================
+
+  credentials:
+    platform: linux/amd64
+
+  discovery:
+    platform: linux/amd64
+
+  ecommerce:
+    platform: linux/amd64
+
+  edx_notes_api:
+    platform: linux/amd64
+
+  forum:
+    platform: linux/amd64
+
+  lms:
+    platform: linux/amd64
+
+  insights:
+    platform: linux/amd64
+
+  analyticsapi:
+    platform: linux/amd64
+ 
+  registrar:
+    platform: linux/amd64
+
+  registrar-worker:
+    platform: linux/amd64
+
+  studio:
+    platform: linux/amd64
+
+  xqueue:
+    platform: linux/amd64
+
+  xqueue_consumer:
+    platform: linux/amd64
+
+  # edX Microfrontends all use node:12 which has linux/arm64/v8 builds.


### PR DESCRIPTION
This PR changes the Makefile to automatically detect if the developer is using an ARM system like Apple's M1 notebooks. It will then adjust the docker-compose file so that devstack can run.

Without this PR, attempting to run devstack on an ARM mac will display the error `no matching manifest for linux/arm64/v8 in the manifest list entries`

## Does it work?

Yes but slowly.

What I have confirmed works:
* Provisioning the default set of services
* Basic usage of the LMS. It seems to work perfectly fine, just quite a bit more slowly than I'm used to.

I am still in the process of testing this out and setting up my devstack so I will update this with more information.

## How it works
* Any services whose docker image already includes ARM support are unchanged (e.g. the MFE `node` containers, `mongo`, `memcached`)
* Any services whose current docker image doesn't support ARM but where there is a compatible image that does support ARM are changed to use the compatible image (e.g. `mysql:5.7` → `mariadb:10.4`, `redis:2.8` → `redis:5`)
* The rest of the containers/services use custom images published by `edxops` that currently don't support ARM. These ones are just configured to run as `x86_64` (`amd64`) images with qemu emulation. This works fine but is slow.
    * As/if more developers get apple silicon, we should find a way to [build multi-arch images](https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/) for these which will solve the performance problem.

## How can I test this?

You need to use either an M1 Mac, an ARM linux system like a Raspberry Pi, or an ARM virtual machine (e.g. use [UTM](https://mac.getutm.app/) to run arm64 linux on an Intel Mac).