### PR TITLE
fix: Update insights port for provisioning.

### DIFF
--- a/provision-insights.sh
+++ b/provision-insights.sh
@@ -5,7 +5,7 @@ set -eu -o pipefail
 set -x
 
 name=insights
-port=18011
+port=18110
 
 docker-compose up -d insights
 


### PR DESCRIPTION
The port for insights on devstack was updated, but
the provisioning script still pointed to the old port.

This was a bug pointed out on the open edX Slack:
https://openedx.slack.com/archives/CDAG4KN2C/p1636442134001000