### PR TITLE
fix: use old virtualbox in cli tests for mac

### DIFF
--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -24,11 +24,8 @@ jobs:
         os:
           - name: linux
             image: ubuntu-20.04 # Focal Fossa
-          # The virtual environment for mac10.15 is currently using a version of VirtualBox
-          # that is incompatible. Commenting out the mac tests until this is addressed.
-          # See https://github.com/actions/virtual-environments/issues/4466 for details
-          # - name: mac
-            # image: macos-10.15 # Catalina
+          - name: mac
+            image: macos-10.15 # Catalina
         python-version:
           - '3.8'
       fail-fast: false
@@ -69,7 +66,13 @@ jobs:
       - name: Docker installation - Mac
         if: ${{ matrix.os.name == 'mac' }}
         run: |
+          # download an old version of virtualbox (latest is incompatible with github actions)
+          brew uninstall virtualbox
+          cd $(brew --repo homebrew/cask)
+          git checkout 8670a72380c57c606d6582b645421e31dad2eee2
+          brew install --cask virtualbox
           brew install docker docker-machine
+
           docker-machine create --driver virtualbox default
           # Apply Docker environment variables to later steps.
           #

--- a/tests/metrics.py
+++ b/tests/metrics.py
@@ -263,8 +263,6 @@ def test_metrics():
         p.expect(EOF)
         assert invitation not in p.before.decode()
         metrics_json = p.before.decode()
-        print(f'metrics json {metrics_json}')
-        print('\n\n\n')
 
         data = json.loads(metrics_json)
         # These keys are defined by a central document; do not send

--- a/tests/metrics.py
+++ b/tests/metrics.py
@@ -106,7 +106,6 @@ def test_initial_opt_in_accept():
         p.expect("Send metrics info:")
         p.expect(EOF)
         metrics_json = p.before.decode()
-        print(metrics_json)
 
         data = json.loads(metrics_json)
         # These keys are defined by a central document; do not send

--- a/tests/metrics.py
+++ b/tests/metrics.py
@@ -106,6 +106,7 @@ def test_initial_opt_in_accept():
         p.expect("Send metrics info:")
         p.expect(EOF)
         metrics_json = p.before.decode()
+        print(metrics_json)
 
         data = json.loads(metrics_json)
         # These keys are defined by a central document; do not send
@@ -263,6 +264,8 @@ def test_metrics():
         p.expect(EOF)
         assert invitation not in p.before.decode()
         metrics_json = p.before.decode()
+        print(f'metrics json {metrics_json}')
+        print('\n\n\n')
 
         data = json.loads(metrics_json)
         # These keys are defined by a central document; do not send


### PR DESCRIPTION
Following the advice in this issue: https://github.com/actions/virtual-environments/issues/4431
This fixes the VirtualBox problem at least. There is still some flakiness in the CLI tests but they look to a be a separate issue.

I've completed each of the following or determined they are not applicable:

- [N/A ] Made a plan to communicate any major developer interface changes (or N/A)