### PR TITLE
fix: bump node image for microfrontends for mozjpeg-bin

### DIFF
--- a/microfrontend.yml
+++ b/microfrontend.yml
@@ -7,6 +7,6 @@ services:
     command: bash -c 'npm install; while true; do npm start; sleep 2; done'
     stdin_open: true
     tty: true
-    image: node:12
+    image: node:12-bullseye
     environment:
       - NODE_ENV=development


### PR DESCRIPTION
### Description

Our microfrontends depend on mozjpeg-bin, which requires zlib 1.2.9 as of mozjpeg-bin@7.1.1.

This PR bumps the OS image used by the microfrontends from [Debian release](https://www.debian.org/releases/) 9 (`stretch` or _oldoldstable_) to 11 (`bullseye` or _stable_) to upgrade zlib to a better version. 

The bump is from:

* standard `node:12` image
  * [defaults](https://github.com/nodejs/docker-node/blob/main/versions.json#L228) to `stretch`
  * [packed with](https://packages.debian.org/stretch/zlib1g) zlib 1.2.8

To:

* `node:12-bullseye` image
  *  [packed with](https://packages.debian.org/bullseye/zlib1g) zlib 1.2.11

This should fix errors like "Error: Cannot find module 'mozjpeg'".

### Research

* *Other options*: Here are all the Docker node image options: [Docker Hub](https://hub.docker.com/_/node/)
* *What we use in prod*: We use Ubuntu bionic (18.04 LTS) right now in GoCD to do our builds for staging & production: [internal-dockerfiles](https://github.com/edx/internal-dockerfiles/blob/master/gocd-agents/Dockerfile#L111-L113) (sorry non-edX folks, this is a private repo).
* *What zlib prod uses*: Ubuntu bionic (18.04 LTS) is [packed with](https://packages.ubuntu.com/bionic/zlib1g) zlib 1.2.11.
* *Why can't we use bionic?*: Node on [Docker Hub](https://hub.docker.com/_/node/) doesn't seem to offer Ubuntu Node images.
* *On choice of image*: We could technically use the `buster` Debian image since it also is [packed with](https://packages.debian.org/buster/zlib1g) zlib 1.2.11, but the thought is to upgrade further if possible.
* *On disadvantage of this PR*: This does pin the image to `bullseye`, so if the default changes in the future that will not be picked up.
* *On testing*: I have been using devstack with `node:12-bullseye` with no problems for the past two days.
* *On usage*: To use this change:
    * `git pull` this change into your devstack folder
    * Clear out any `node_modules` folders in your `frontend-app-*` Git repositories
    * `git pull` in your `frontend-app-*` Git repositories
    * Run `make dev.up.frontend-app-gradebook+frontend-app-payment+frontend-app-publisher+frontend-app-learning` in your devstack folder to recreate your containers.

----

I've completed each of the following or determined they are not applicable:

- ~~[ ] Made a plan to communicate any major developer interface changes (or N/A)~~
  - N/A
