### PR TITLE
feat: implement toggles to use experimental images 

### DIFF
--- a/.github/workflows/lint-provisioning-scripts.yml
+++ b/.github/workflows/lint-provisioning-scripts.yml
@@ -1,0 +1,35 @@
+
+name: Lint experimental provisioning shell scripts
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+
+
+  lint_shell_scripts:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: install shellcheck
+        run: sudo apt-get install shellcheck
+
+      # Since we are on track to rewrite each provisioning script as we cut
+      # over to its experimental Docker image, we're only shellchecking
+      # the new scripts, instead of worrying about going back and cleaning
+      # up old provisioning scripts.
+      # That being said, there are other shell scripts in this repo
+      # (such as the ones in scripts/) that would be ideal to bring into
+      # shellchecking if somebody has time to do so.
+      - name: run shellcheck
+        run: shellcheck scripts/colors.sh provision-experimental/*
+
+      - name: inform success
+        run: |
+          echo 'shellcheck found no problems with shell scripts in provision-experimental/!'
+          echo 'Please note that other shell scripts in this repo are not checked.'

--- a/.github/workflows/lint-provisioning-scripts.yml
+++ b/.github/workflows/lint-provisioning-scripts.yml
@@ -16,6 +16,9 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+
+      - uses: actions/checkout@v2
+
       - name: install shellcheck
         run: sudo apt-get install shellcheck
 

--- a/.github/workflows/provisioning-tests.yml
+++ b/.github/workflows/provisioning-tests.yml
@@ -23,10 +23,15 @@ jobs:
       DEVSTACK_METRICS_TESTING: ci
     strategy:
       matrix:
-        os:
-          - ubuntu-20.04 # Ubuntu 20.04 "Focal Fossa"
         python-version: [ '3.8' ]
         services: [ discovery+lms+forum ,registrar+lms, ecommerce+lms, edx_notes_api+lms, credentials+lms, xqueue]
+        which-images: [ stable ]
+        os: [ ubuntu-20.04 ]
+        include:
+          - python-version: '3.8'
+            services: credentials+lms
+            which-images: experimental
+            os: ubuntu-20.04
       fail-fast: false # some services can be flaky; let others run to completion even if one fails
 
     steps:
@@ -56,6 +61,12 @@ jobs:
 
       - name: clone repositories
         run:  make dev.clone.https
+
+      - name: enable experimental images
+        run: |
+          echo 'USE_EXPERIMENTAL_EDX_PLATFORM_IMAGES = 1' >> options.local.mk
+          echo 'USE_EXPERIMENTAL_CREDENTIALS_IMAGE = 1' >> options.local.mk
+        if: ${{ matrix.which-images == 'experimental' }}
 
       - name: pull images and print
         run: |

--- a/Makefile
+++ b/Makefile
@@ -49,10 +49,10 @@
         devpi-password dev.provision dev.ps dev.pull dev.pull.without-deps \
         dev.reset dev.reset-repos dev.restart-container dev.restart-devserver \
         dev.restart-devserver.forum dev.restore dev.rm-stopped dev.shell \
-        dev.shell.credentials dev.shell.discovery \
-        dev.shell.ecommerce dev.shell.lms dev.shell.lms_watcher \
-        dev.shell.registrar dev.shell.studio \
-        dev.shell.studio_watcher dev.shell.xqueue dev.shell.xqueue_consumer \
+        dev.shell.discovery \
+        dev.shell.ecommerce \
+        dev.shell.registrar \
+        dev.shell.xqueue dev.shell.xqueue_consumer \
         dev.static dev.static.lms dev.static.studio dev.stats dev.status \
         dev.stop dev.up dev.up.attach dev.up.shell \
         dev.up.without-deps dev.up.without-deps.shell dev.up.with-programs \
@@ -412,8 +412,12 @@ dev.attach.%: ## Attach to the specified service container process for debugging
 
 dev.shell: _expects-service.dev.shell
 
+ifndef USE_EXPERIMENTAL_CREDENTIALS_IMAGES
+.PHONY: dev.shell.credentials
+
 dev.shell.credentials:
 	docker-compose exec credentials env TERM=$(TERM) bash -c 'source /edx/app/credentials/credentials_env && cd /edx/app/credentials/credentials && /bin/bash'
+endif
 
 dev.shell.discovery:
 	docker-compose exec discovery env TERM=$(TERM) /edx/app/discovery/devstack.sh open
@@ -427,6 +431,9 @@ dev.shell.registrar:
 dev.shell.xqueue:
 	docker-compose exec xqueue env TERM=$(TERM) /edx/app/xqueue/devstack.sh open
 
+ifndef USE_EXPERIMENTAL_EDX_PLATFORM_IMAGES
+.PHONY: dev.shell.lms dev.shell.lms_watcher dev.shell.studio dev.shell.studio_watcher
+
 dev.shell.lms:
 	docker-compose exec lms env TERM=$(TERM) /edx/app/edxapp/devstack.sh open
 
@@ -438,6 +445,7 @@ dev.shell.studio:
 
 dev.shell.studio_watcher:
 	docker-compose exec studio_watcher env TERM=$(TERM) /edx/app/edxapp/devstack.sh open
+endif
 
 dev.shell.xqueue_consumer:
 	docker-compose exec xqueue_consumer env TERM=$(TERM) /edx/app/xqueue/devstack.sh open
@@ -449,7 +457,7 @@ dev.shell.insights:
 	docker-compose exec insights env TERM=$(TERM) bash -c 'eval $$(source /edx/app/insights/insights_env; echo PATH="$$PATH";) && /edx/app/insights/devstack.sh open'
 
 dev.shell.%: ## Run a shell on the specified service's container.
-	docker-compose exec $* /bin/bash
+	docker-compose exec $* env TERM=$(TERM) /bin/bash
 
 dev.dbshell:
 	docker-compose exec mysql57 bash -c "mysql"

--- a/docker-compose-watchers.yml
+++ b/docker-compose-watchers.yml
@@ -7,7 +7,7 @@ services:
     environment:
       BOK_CHOY_HOSTNAME: edx.devstack.lms_watcher
       ASSET_WATCHER_TIMEOUT: 12
-    image: edxops/edxapp:${OPENEDX_RELEASE:-latest}
+    image: ${_LMS_IMAGE}
     volumes:
       - ${DEVSTACK_WORKSPACE}/edx-platform:/edx/app/edxapp/edx-platform
       - edxapp_lms_assets:/edx/var/edxapp/staticfiles/
@@ -25,7 +25,7 @@ services:
     environment:
       BOK_CHOY_HOSTNAME: edx.devstack.studio_watcher
       ASSET_WATCHER_TIMEOUT: 12
-    image: edxops/edxapp:${OPENEDX_RELEASE:-latest}
+    image: ${_CMS_IMAGE}
     volumes:
       - edxapp_studio_assets:/edx/var/edxapp/staticfiles/
       - ${DEVSTACK_WORKSPACE}/edx-platform:/edx/app/edxapp/edx-platform

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
   chrome:
     container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.chrome"
     hostname: chrome.devstack.edx
-    image: edxops/chrome:${OPENEDX_RELEASE:-latest}
+    image: ${_CHROME_IMAGE}
     shm_size: 2g
     networks:
       default:
@@ -54,7 +54,7 @@ services:
   devpi:
     container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.devpi"
     hostname: devpi.devstack.edx
-    image: edxops/devpi:${OPENEDX_RELEASE:-latest}
+    image: ${_DEVPI_IMAGE}
     networks:
       default:
         aliases:
@@ -121,7 +121,7 @@ services:
   firefox:
     container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.firefox"
     hostname: firefox.devstack.edx
-    image: edxops/firefox:${OPENEDX_RELEASE:-latest}
+    image: ${_FIREFOX_IMAGE}
     shm_size: 2g
     networks:
       default:
@@ -300,7 +300,7 @@ services:
       SOCIAL_AUTH_EDX_OIDC_URL_ROOT: http://edx.devstack.lms:18000/oauth2
       ENABLE_DJANGO_TOOLBAR: 1
       DJANGO_WATCHMAN_TIMEOUT: 30
-    image: edxops/credentials:${OPENEDX_RELEASE:-latest}
+    image: ${_CREDENTIALS_IMAGE}
     networks:
       default:
         aliases:
@@ -326,7 +326,7 @@ services:
       TEST_ELASTICSEARCH_URL: "edx.devstack.elasticsearch710"
       ENABLE_DJANGO_TOOLBAR: 1
       DJANGO_WATCHMAN_TIMEOUT: 30
-    image: edxops/discovery:${OPENEDX_RELEASE:-latest}
+    image: ${_DISCOVERY_IMAGE}
     networks:
       default:
         aliases:
@@ -351,7 +351,7 @@ services:
     environment:
       DJANGO_WATCHMAN_TIMEOUT: 30
       ENABLE_DJANGO_TOOLBAR: 1
-    image: edxops/ecommerce:${OPENEDX_RELEASE:-latest}
+    image: ${_ECOMMERCE_IMAGE}
     networks:
       default:
         aliases:
@@ -369,7 +369,7 @@ services:
       - elasticsearch710
       - lms
       - mysql57
-    image: edxops/notes:${OPENEDX_RELEASE:-latest}
+    image: ${_NOTES_IMAGE}
     networks:
       default:
         aliases:
@@ -396,7 +396,7 @@ services:
       - memcached
       - mongo
       - elasticsearch710
-    image: edxops/forum:${OPENEDX_RELEASE:-latest}
+    image: ${_FORUM_IMAGE}
     stdin_open: true
     tty: true
     networks:
@@ -428,7 +428,7 @@ services:
       EDXAPP_TEST_MONGO_HOST: edx.devstack.mongo
       NO_PYTHON_UNINSTALL: 1
       DJANGO_WATCHMAN_TIMEOUT: 30
-    image: edxops/edxapp:${OPENEDX_RELEASE:-latest}
+    image: ${_LMS_IMAGE}
     networks:
       default:
         aliases:
@@ -462,7 +462,7 @@ services:
       DB_PASSWORD: password
       LMS_HOST: http://localhost:18000
       DJANGO_SETTINGS_MODULE: analytics_dashboard.settings.devstack
-    image: edxops/insights:${OPENEDX_RELEASE:-latest}
+    image: ${_INSIGHTS_IMAGE}
     networks:
       default:
         aliases:
@@ -473,7 +473,7 @@ services:
       - /edx/var/insights/
 
   analyticsapi:
-    image: edxops/analytics_api:${OPENEDX_RELEASE:-latest}
+    image: ${_ANALYTICSAPI_IMAGE}
     container_name: edx.devstack.analyticsapi
     hostname: analyticsapi
     depends_on:
@@ -522,7 +522,7 @@ services:
       CELERY_BROKER_VHOST: 10
       CELERY_BROKER_PASSWORD: password
       DJANGO_WATCHMAN_TIMEOUT: 30
-    image: edxops/registrar:${OPENEDX_RELEASE:-latest}
+    image: ${_REGISTRAR_IMAGE}
     networks:
       default:
         aliases:
@@ -556,7 +556,7 @@ services:
       CELERY_BROKER_VHOST: 10
       CELERY_BROKER_PASSWORD: password
       DJANGO_WATCHMAN_TIMEOUT: 30
-    image: edxops/registrar:${OPENEDX_RELEASE:-latest}
+    image: ${_REGISTRAR_IMAGE}
     networks:
       default:
         aliases:
@@ -587,7 +587,7 @@ services:
       EDXAPP_TEST_MONGO_HOST: edx.devstack.mongo
       NO_PYTHON_UNINSTALL: 1
       DJANGO_WATCHMAN_TIMEOUT: 30
-    image: edxops/edxapp:${OPENEDX_RELEASE:-latest}
+    image: ${_CMS_IMAGE}
     networks:
       default:
         aliases:
@@ -603,7 +603,7 @@ services:
 
   xqueue:
     container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.xqueue"
-    image: edxops/xqueue:${OPENEDX_RELEASE:-latest}
+    image: ${_XQUEUE_IMAGE}
     command: bash -c 'source /edx/app/xqueue/xqueue_env && while true; do python /edx/app/xqueue/xqueue/manage.py runserver 0.0.0.0:18040 ; sleep 2; done'
     volumes:
       - ${DEVSTACK_WORKSPACE}/xqueue:/edx/app/xqueue/xqueue
@@ -618,7 +618,7 @@ services:
 
   xqueue_consumer:
     container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.xqueue_consumer"
-    image: edxops/xqueue:${OPENEDX_RELEASE:-latest}
+    image: ${_XQUEUE_IMAGE}
     command: bash -c 'source /edx/app/xqueue/xqueue_env && while true; do python /edx/app/xqueue/xqueue/manage.py run_consumer ; sleep 2; done'
     volumes:
       - ${DEVSTACK_WORKSPACE}/xqueue:/edx/app/xqueue/xqueue

--- a/options.mk
+++ b/options.mk
@@ -91,3 +91,53 @@ credentials+discovery+ecommerce+insights+lms+registrar+studio
 # Separated by plus signs. Listed in alphabetical order for clarity.
 THIRD_PARTY_SERVICES ?= \
 chrome+coursegraph+devpi+elasticsearch+elasticsearch7+elasticsearch710+firefox+memcached+mongo+mysql57+redis+namenode+datanode+resourcemanager+nodemanager+sparkmaster+sparkworker+vertica
+
+# The `USE_EXPERIMENTAL_*_IMAGE` toggles can be enabled to
+# use the experimental optimized images as they becomes available
+# for devstack usage.
+#
+# To enable one of these toggles, just set it to any non-whitespace string, e.g.:
+#    USE_EXPERIMENTAL_EDX_PLATFORM_IMAGES = 1
+# or:
+#    USE_EXPERIMENTAL_EDX_PLATFORM_IMAGES = false
+# or:
+#    USE_EXPERIMENTAL_EDX_PLATFORM_IMAGES = turtle
+#
+# Named release tags aren't available on experimental images, yet.
+# When we start tagging them, we will update these blocks to use the named
+# tags if OPENEDX_RELEASE is set.
+ifdef USE_EXPERIMENTAL_EDX_PLATFORM_IMAGES
+	# LMS and Studio may be defined as different images,
+	# but we put their experimental versions behind a single toggle,
+	# because it seems less risky to roll them out together.
+	_LMS_IMAGE = openedx/lms-dev:latest
+	_CMS_IMAGE = openedx/cms-dev:latest
+endif
+ifdef USE_EXPERIMENTAL_CREDENTIALS_IMAGE
+	_CREDENTIALS_IMAGE  = openedx/credentials-dev:latest
+endif
+
+# Default image values.
+# The leading underscores indicate that this is not a stable configuration
+# interface. Instead of modifying these setting directly, you are encouraged
+# to use the `USE_EXPERIMENTAL_*_PLATFORM_IMAGE(S)` or `OPENEDX_RELEASE` settings.
+#
+# These default images are from `edxops/...`, are built using Ansible from the
+# `configuration` repository.
+#
+# Note that '?=' assigns a variable iff it hasn't already been defined.
+_ANALYTICSAPI_IMAGE ?= edxops/analytics_api:$(or $(OPENEDX_RELEASE),latest)
+_CHROME_IMAGE       ?= edxops/chrome:$(or $(OPENEDX_RELEASE),latest)
+_CMS_IMAGE          ?= edxops/edxapp:$(or $(OPENEDX_RELEASE),latest)
+_CREDENTIALS_IMAGE  ?= edxops/credentials:$(or $(OPENEDX_RELEASE),latest)
+_DEVPI_IMAGE        ?= edxops/devpi:$(or $(OPENEDX_RELEASE),latest)
+_DISCOVERY_IMAGE    ?= edxops/discovery:$(or $(OPENEDX_RELEASE),latest)
+_ECOMMERCE_IMAGE    ?= edxops/ecommerce:$(or $(OPENEDX_RELEASE),latest)
+_FIREFOX_IMAGE      ?= edxops/firefox:$(or $(OPENEDX_RELEASE),latest)
+_FORUM_IMAGE        ?= edxops/forum:$(or $(OPENEDX_RELEASE),latest)
+_INSIGHTS_IMAGE     ?= edxops/insights:$(or $(OPENEDX_RELEASE),latest)
+_NOTES_IMAGE        ?= edxops/notes:$(or $(OPENEDX_RELEASE),latest)
+_LMS_IMAGE          ?= edxops/edxapp:$(or $(OPENEDX_RELEASE),latest)
+_REGISTRAR_IMAGE    ?= edxops/registrar:$(or $(OPENEDX_RELEASE),latest)
+_STUDIO_IMAGE       ?= edxops/edxapp:$(or $(OPENEDX_RELEASE),latest)
+_XQUEUE_IMAGE       ?= edxops/xqueue:$(or $(OPENEDX_RELEASE),latest)

--- a/provision-credentials.sh
+++ b/provision-credentials.sh
@@ -4,6 +4,12 @@ set -eu -o pipefail
 . scripts/colors.sh
 set -x
 
+if [[ -n "${USE_EXPERIMENTAL_CREDENTIALS_IMAGE:-}" ]] ; then
+    echo -e "${YELLOW} Using experimental credentials provisioning script...${NC}"
+    provision-experimental/credentials.sh
+    exit 0
+fi
+
 # NOTE (CCB): We do NOT call provision-ida because it expects a virtualenv.
 # The new images for Credentials do not use virtualenv.
 

--- a/provision-experimental/credentials.sh
+++ b/provision-experimental/credentials.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -xeuo pipefail
+. scripts/colors.sh
+
+# Depends on LMS and Credentials being up.
+
+docker-compose up -d credentials
+
+echo -e "${GREEN}Installing requirements for credentials...${NC}"
+docker-compose exec -T credentials bash -e -c 'make requirements'
+
+echo -e "${GREEN}Running migrations for credentials...${NC}"
+docker-compose exec -T credentials bash -e -c 'make migrate'
+
+echo -e "${GREEN}Creating super-user for credentials...${NC}"
+docker-compose exec -T credentials bash -e -c \
+	"echo \"from django.contrib.auth import get_user_model; User = get_user_model(); \
+	 User.objects.create_superuser('edx', 'edx@example.com', 'edx') \
+	 if not User.objects.filter(username='edx').exists() else None\" \
+	 | python ./manage.py shell"
+
+echo -e "${GREEN}Configuring site for credentials...${NC}"
+docker-compose exec -T credentials bash -e -c \
+	"./manage.py create_or_update_site \
+		--site-id=1 \
+		--site-domain=localhost:18150 \
+		--site-name='Open edX' \
+		--platform-name='Open edX' \
+		--company-name='Open edX' \
+		--lms-url-root=http://localhost:18000 \
+		--catalog-api-url=http://edx.devstack.discovery:18381/api/v1/ \
+		--tos-url=http://localhost:18000/tos \
+		--privacy-policy-url=http://localhost:18000/privacy \
+		--homepage-url=http://localhost:18000 \
+		--certificate-help-url=http://localhost:18000/faq \
+		--records-help-url=http://localhost:18000/faq \
+		--theme-name=openedx"
+
+./provision-experimental/lms-service-users.sh credentials 18150
+
+# Compile static assets last since they aren't absolutely necessary for all services. This will allow developers to get
+# started if they do not care about static assets	
+echo -e "${GREEN}Compiling static assets for credentials...${NC}"
+docker-compose exec -T credentials bash -e -c \
+	"if ! make static 2>creds_make_static.err ; then \
+		echo '------- Last 100 lines of stderr'; tail creds_make_static.err -n 100; echo '-------'; \
+	fi;"
+
+# Restart credentials devserver.
+make dev.restart-devserver.credentials

--- a/provision-experimental/lms-retirement-user.sh
+++ b/provision-experimental/lms-retirement-user.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -xeuo pipefail
+. scripts/colors.sh
+
+# This script depends on the LMS being up!
+
+app_name=$1
+user_name=$2
+
+echo -e "${GREEN}Creating retirement service user ${user_name} and DOT Application ${app_name} in LMS...${NC}"
+
+docker-compose exec -T lms  bash -e -c \
+	"./manage.py lms manage_user '${user_name}' '${user_name}@example.com' \
+		--staff \
+		--superuser"
+
+docker-compose exec -T lms  bash -e -c \
+	"./manage.py lms create_dot_application '${app_name}' '${user_name}'"

--- a/provision-experimental/lms-service-users.sh
+++ b/provision-experimental/lms-service-users.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -xeuo pipefail
+. scripts/colors.sh
+
+# This script depends on the LMS being up!
+
+app_name="$1"
+client_port="$2"
+
+echo -e "${GREEN}Creating service user and OAuth2 applications for ${app_name}...${NC}"
+
+# Create the service user.
+docker-compose exec -T lms bash -e -c \
+	"./manage.py lms manage_user ${app_name}_worker ${app_name}_worker@example.com \
+		--staff \
+		--superuser"
+
+# Create the DOT application for single sign-on.
+docker-compose exec -T lms bash -e -c \
+	"./manage.py lms create_dot_application '${app_name}-sso' '${app_name}_worker' \
+		--grant-type authorization-code \
+		--skip-authorization \
+		--redirect-uris 'http://localhost:${client_port}/complete/edx-oauth2/' \
+		--client-id '${app_name}-sso-key' \
+		--client-secret '${app_name}-sso-secret' \
+		--scopes user_id"
+
+# Create the DOT application for backend service IDA-to-IDA authentication.
+docker-compose exec -T lms bash -e -c \
+	"./manage.py lms create_dot_application '${app_name}-backend-service' '${app_name}_worker' \
+		--grant-type client-credentials \
+		--client-id '${app_name}-backend-service-key' \
+		--client-secret '${app_name}-backend-service-secret'"

--- a/provision-experimental/lms.sh
+++ b/provision-experimental/lms.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -xeuo pipefail
+
+# Load database dumps for the largest databases to save time
+./load-db.sh edxapp
+./load-db.sh edxapp_csmh
+
+# Bring edxapp containers online
+docker-compose up -d lms studio
+
+# Reinstall local requirements.
+# This is only necessary because edx-platform is mounted in from the host. If
+# `make requirements` hasn't yet been run from the host's edx-platform checkout, then
+# it will be missing the `.egg` files needed in order for setup.py entrypoints to
+# be found correctly. If edx-platform weren't mounted from the host, then the `.egg`
+# files from the image would suffice and this step wouldn't be necessary.
+# We only need to do this for one of {lms, studio} because the generated artifacts
+# we need are written to the host-mounted edx-platform repo, which is shared between
+# the two services.
+docker-compose exec -T lms    bash -e -c 'pip install -r requirements/edx/local.in'
+
+# Run edxapp migrations first since they are needed for the service users and OAuth clients
+docker-compose exec -T lms    bash -e -c './manage.py lms migrate'
+docker-compose exec -T studio bash -e -c './manage.py cms migrate'
+
+# Create demo course and users, including a staff and superuser.
+docker-compose exec -T studio ./scripts/provision-demo-course.sh
+docker-compose exec -T lms    ./scripts/provision-demo-users.sh
+
+# Create an enterprise service user for edxapp and give them appropriate permissions
+docker-compose exec -T lms bash -e -c \
+	'./manage.py lms manage_user enterprise_worker enterprise_worker@example.com --staff'
+docker-compose exec -T lms bash -e -c \
+	'./manage.py lms shell' \
+	< enterprise/worker_permissions.py
+
+# Enable the LMS-E-Commerce integration
+docker-compose exec -T lms bash -e -c './manage.py lms configure_commerce'
+
+# Create static assets for both LMS and Studio
+# (assets are saved to a shared volume, hence only one command).
+docker-compose exec -T lms ./scripts/update-assets-dev.sh
+
+# Allow LMS SSO for Studio
+./provision-experimental/lms-service-users.sh studio 18010
+
+# Provision a retirement service account user
+./provision-experimental/lms-retirement-user.sh retirement retirement_service_worker
+
+# Add demo program
+./programs/provision.sh lms

--- a/provision-lms.sh
+++ b/provision-lms.sh
@@ -2,6 +2,12 @@
 set -eu -o pipefail
 set -x
 
+if [[ -n "${USE_EXPERIMENTAL_EDX_PLATFORM_IMAGES:-}" ]] ; then
+    echo -e "Using experimental lms provisioning script..."
+    provision-experimental/lms.sh
+    exit 0
+fi
+
 apps=( lms studio )
 
 studio_port=18010

--- a/scripts/colors.sh
+++ b/scripts/colors.sh
@@ -1,4 +1,8 @@
+#!/usr/bin/env bash
 # Source this file to get color variables
+
+# Disable unused variable warning.
+# shellcheck disable=SC2034
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'


### PR DESCRIPTION
## Description

Previously, all Open edX services and some
supporting services were hard-coded to use docker images
from the edxops DockerHub org. This commit parameterizes those
images under Makefile variables. For example, registrar
now specifies `${_REGISTRAR_IMAGE}` instead of
`edxops/registrar`. By default, all the image variables
are still set to the same old images from
the edxops DockerHub org.

Furthermore, two toggles were introduced:
* `USE_EXPERIMENTAL_EDX_PLATFORM_IMAGES`
* `USE_EXPERIMENTAL_CREDENTIALS_IMAGE`
allowing users to test out the new, optimized
`openedx/` images for LMS, CMS, and Credentials.
Provisioning tests will be run for these three
experimental images as part of PR builds.

Our intent is to test and eventually switch
all services over to the new openedx images,
which are built using more idiomatic docker
practices and should be smaller and more resource
efficient.

Co-Authored-By: @cmuniz

## Test instructions

### Ensure: by default, the old edxops images are still used

On master: Starting with a provisioned devstack, bring containers down.

Switch to this branch. Confirm that all backend services, as well as the supporting services affected by this PR, can be brought up.
```
$ make dev.up.studio+credentials+ecommerce+edx_notes_api+registrar+xqueue
$ make dev.up.lms+discovery+devpi+forum  # Should be a no-op, as these are deps of studio et al.
$ make dev.up.analyticsapi+insights
$ make dev.up.chrome+firefox
```
Ensure that there now exist services running thirteen distinct `edxops/...` images.
```
$ docker ps --filter name="edx.devstack." --format "table {{.Names}}\t{{.Image}}\t{{.Status}}
NAMES                           IMAGE                         STATUS
edx.devstack.firefox            edxops/firefox:latest         Up 23 minutes
edx.devstack.chrome             edxops/chrome:latest          Up 23 minutes
edx.devstack.registrar          edxops/registrar:latest       Up 24 minutes
edx.devstack.xqueue             edxops/xqueue:latest          Up 24 minutes
edx.devstack.redis              redis:2.8                     Up 24 minutes
edx.devstack.insights           edxops/insights:latest        Up 25 minutes
edx.devstack.analyticsapi       edxops/analytics_api:latest   Up 25 minutes
edx.devstack.edxnotesapi        edxops/notes:latest           Up 24 minutes
edx.devstack.credentials        edxops/credentials:latest     Up 24 minutes
edx.devstack.ecommerce          edxops/ecommerce:latest       Up 24 minutes
edx.devstack.studio             edxops/edxapp:latest          Up 24 minutes
edx.devstack.lms                edxops/edxapp:latest          Up 25 minutes
edx.devstack.discovery          edxops/discovery:latest       Up 25 minutes
edx.devstack.forum              edxops/forum:latest           Up 25 minutes
edx.devstack.elasticsearch710   elasticsearch:7.10.1          Up 25 minutes
edx.devstack.devpi              edxops/devpi:latest           Up 25 minutes
edx.devstack.memcached          memcached:1.5.10-alpine       Up 25 minutes
edx.devstack.mongo              mongo:4.2.14                  Up 25 minutes
edx.devstack.mysql57            mysql:5.7                     Up 25 minutes
```
And ensure that they can be brought down:
```
$ make dev.down
$ docker ps --filter name="edx.devstack." --format "table {{.Names}}\t{{.Image}}\t{{.Status}}"
NAMES     IMAGE     STATUS
```

### Ensure: LMS, Studio and Credentials can be toggled to use the experimental openedx images

Bring containers down (`make dev.down`). Then, create or edit `options.local.mk` in the root of your devstack repo. Add:
```make
USE_EXPERIMENTAL_EDX_PLATFORM_IMAGES = 1
USE_EXPERIMENTAL_CREDENTIAL_IMAGE = 1
```

Bring up LMS, Studio and Credentials:
```
make dev.up.lms+studio+credentials
```
and ensure the `openedx/` images (or `kdmccormick96/` images, while this PR is still a draft) are used:
```
$ docker ps --filter name="edx.devstack." --format "table {{.Names}}\t{{.Image}}\t{{.Status}}"
NAMES                            IMAGE                             STATUS
edx.devstack2.studio             kdmccormick96/studio-dev:latest   Up 20 seconds
edx.devstack2.lms                kdmccormick96/lms-dev:latest      Up 21 seconds
edx.devstack2.discovery          edxops/discovery:latest           Up 21 seconds
edx.devstack2.forum              edxops/forum:latest               Up 21 seconds
edx.devstack2.mysql57            mysql:5.7                         Up 21 seconds
edx.devstack2.devpi              edxops/devpi:latest               Up 22 seconds
edx.devstack2.memcached          memcached:1.5.10-alpine           Up 22 seconds
edx.devstack2.mongo              mongo:4.2.14                      Up 22 seconds
edx.devstack2.elasticsearch710   elasticsearch:7.10.1              Up 22 seconds
~/openedx/devstack 🍀 

```
Finally, log into LMS and play around. For example, take the demo course, edit the course in Studio, publish it, export and re-import it, upload an image, view credentials, visit all three admin panels, etc.

## Supporting Information

Begins addressing ["Move off of edxops DockerHub org images"](https://github.com/edx/devstack/issues/869).

## Other information

Blocked by https://github.com/edx/devstack/pull/874

### Tentative rollout plan

* Merge the [credentials PR](https://github.com/edx/credentials/pull/1510) and let a new image be pushed to DockerHub.
* Merge the [edx-platform PR](https://github.com/edx/edx-platform/pull/29549
) and let new images be pushed to DockerHub.
* Merge this PR.
* Make a forum post informing folks that `USE_EXPERIMENTAL_EDX_PLATFORM_IMAGES` and `USE_EXPERIMENTAL_CREDENTIALS_IMAGE` are available for testing. Inform edX's Arch-BOM (~ developer experience) team so that they can circulate the information within edX
* Wait and collect feedback. Make bug fixes as necessary.
* Make the `openedx/lms-dev`, `openedx/studio-dev`, and `openedx/credentials-dev` images the default.
* Repeat the same process with the other services, probably in batches, since getting edx-platform working will probably expose most of the kinks of the new images early, allowing us to roll out more aggressively in the later stages.
* For the services that don't have experimental images: Write Dockerfiles for new images and GitHub actions to push them to the openedx DockerHub org. For third party services, try to simply switch over to the official image. If needed, repeat the same process of trying them out behind toggles and eventually making them the default.
* Once no more edxops images are used, the edX is safe to stop pushing images to the edxops DockerHub org.
* The old images in edxops should remain available for one Open edX release cycle. After that, edX is safe to decommission the edxops DockerHub org entirely if they want to.

#### Why is the plan "tentative?"

Because it reflects only one of the three possible approaches to [the greater `edxops` issue](https://github.com/edx/devstack/issues/869). Depending on how things evolve, we may switch all images over, switch only some of them over, or abandon them entirely in favor of Tutor's images. Regardless, I think this change is worthwhile, because it gives us an opportunity to see how Ansible and non-Ansible images compare in the context of devstack. 

It is part of the linked issue's acceptance criteria to clean all of this up in the event that the experimental images and/or devstack are abandoned.