### PR TITLE
fix: enable `frontend-app-learning` by default

### DIFF
--- a/microfrontend.yml
+++ b/microfrontend.yml
@@ -7,6 +7,6 @@ services:
     command: bash -c 'npm install; while true; do npm start; sleep 2; done'
     stdin_open: true
     tty: true
-    image: node:12
+    image: node:12-bullseye
     environment:
       - NODE_ENV=development

--- a/repo.sh
+++ b/repo.sh
@@ -33,11 +33,11 @@ repos=(
     "https://github.com/edx/frontend-app-gradebook.git"
     "https://github.com/edx/frontend-app-payment.git"
     "https://github.com/edx/frontend-app-publisher.git"
+    "https://github.com/edx/frontend-app-learning.git"
 )
 
 non_release_repos=(
     "https://github.com/edx/frontend-app-course-authoring.git"
-    "https://github.com/edx/frontend-app-learning.git"
     "https://github.com/edx/frontend-app-library-authoring.git"
     "https://github.com/edx/registrar.git"
     "https://github.com/edx/frontend-app-program-console.git"
@@ -57,11 +57,11 @@ ssh_repos=(
     "git@github.com:edx/frontend-app-gradebook.git"
     "git@github.com:edx/frontend-app-payment.git"
     "git@github.com:edx/frontend-app-publisher.git"
+    "git@github.com:edx/frontend-app-learning.git"
 )
 
 non_release_ssh_repos=(
     "git@github.com:edx/frontend-app-course-authoring.git"
-    "git@github.com:edx/frontend-app-learning.git"
     "git@github.com:edx/frontend-app-library-authoring.git"
     "git@github.com:edx/registrar.git"
     "git@github.com:edx/frontend-app-program-console.git"


### PR DESCRIPTION
Ran into this issue when trying to access the new `frontend-app-learning` from the `maple.master` devstack install. Used #865 to fix the issue.

![microfrontend-issue-mozjpeg](https://user-images.githubusercontent.com/5641338/149156427-e8197b9c-9754-4354-9875-8f7811a2a546.png)

Made `frontend-app-learning` as a default repo to install on devstack.