### PR TITLE
fix: Moving learning app to release section.

### DIFF
--- a/repo.sh
+++ b/repo.sh
@@ -33,11 +33,11 @@ repos=(
     "https://github.com/edx/frontend-app-gradebook.git"
     "https://github.com/edx/frontend-app-payment.git"
     "https://github.com/edx/frontend-app-publisher.git"
+    "https://github.com/edx/frontend-app-learning.git"
 )
 
 non_release_repos=(
     "https://github.com/edx/frontend-app-course-authoring.git"
-    "https://github.com/edx/frontend-app-learning.git"
     "https://github.com/edx/frontend-app-library-authoring.git"
     "https://github.com/edx/registrar.git"
     "https://github.com/edx/frontend-app-program-console.git"
@@ -57,11 +57,11 @@ ssh_repos=(
     "git@github.com:edx/frontend-app-gradebook.git"
     "git@github.com:edx/frontend-app-payment.git"
     "git@github.com:edx/frontend-app-publisher.git"
+    "git@github.com:edx/frontend-app-learning.git"
 )
 
 non_release_ssh_repos=(
     "git@github.com:edx/frontend-app-course-authoring.git"
-    "git@github.com:edx/frontend-app-learning.git"
     "git@github.com:edx/frontend-app-library-authoring.git"
     "git@github.com:edx/registrar.git"
     "git@github.com:edx/frontend-app-program-console.git"


### PR DESCRIPTION
Separated this out from #880 

Made `frontend-app-learning` as a default repo to install on devstack.

@cmltaWt0 