### PR TITLE
fix: fix insights port typo in provision script

### DIFF
--- a/provision-insights.sh
+++ b/provision-insights.sh
@@ -5,7 +5,7 @@ set -eu -o pipefail
 set -x
 
 name=insights
-port=18011
+port=18110
 
 docker-compose up -d insights
 


### PR DESCRIPTION
There was a typo in the port variable in the Insights provision script. It was 18011, but it should have been 18110. 18110 is what is used in the port mapping for the Docker container.

This bug was observed when developers were unable to login to Insights. This was due to a mismatch in the redirect URIs as configured in the LMS's insights-sso Django OAuth Toolkit Application, which uses the port variable in the provision script. The actual redirect URI being used was using port 18110.

The oauth2 standard requires strict equality of the redirect_uris, causing a failure.

----

I've completed each of the following or determined they are not applicable:

- [ ] Made a plan to communicate any major developer interface changes (or N/A)
