### PR TITLE
fix: create reports_v1 db as well for analytics-data-api service

### DIFF
--- a/provision.sql
+++ b/provision.sql
@@ -30,5 +30,8 @@ GRANT ALL ON `analytics-api`.* TO 'analytics001'@'%' IDENTIFIED BY 'password';
 CREATE DATABASE IF NOT EXISTS `reports`;
 GRANT ALL ON `reports`.* TO 'analytics001'@'%' IDENTIFIED BY 'password';
 
+CREATE DATABASE IF NOT EXISTS `reports_v1`;
+GRANT ALL ON `reports_v1`.* TO 'analytics001'@'%' IDENTIFIED BY 'password';
+
 
 FLUSH PRIVILEGES;


### PR DESCRIPTION
When provisioning the analytics-data-api service, the database `reports` was created, but the `reports_v1` db was not.
This is not a true reflection of the analytics-data-api's needs on multiple databases.

Make sure we also create the `reports_v1` db on devstack to ensure `make dev.provision.analyticsapi` command is going to be successful.

@openedx/masters-devs-cosmonauts Please review
