### PR TITLE
docs: include M1 Chip Workaround

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -370,7 +370,7 @@ because services are in the process of being upgraded to Elasticsearch 7, but no
 support Elasticsearch 7 yet. As we complete these migrations, we will update the dependencies
 of these containers.
 
-
+Currently, Devstack and MYSQL interact poorly with newer Apple Machines which use "M1" Chips. An error causes provisioning to fail. A workaround is to specify ``platform: linux/amd64`` under the heading ``mysql57`` in ``docker-compose.yml`` and attempting to provision again.
 
 Advanced Configuration Options
 ------------------------------


### PR DESCRIPTION
Currently, Devstack and MYSQL interact poorly with newer Apple Machines which use "M1" Chips. An error causes provisioning to fail. A workaround is to specify ``platform: linux/amd64`` under the heading ``mysql57`` in ``docker-compose.yml`` and attempting to provision again. Solution found in: https://onexlab-io.medium.com/apple-m1-chip-no-matching-manifest-for-linux-arm64-v8-docker-mysql-5142060a9309 . Update a result of https://docs.google.com/document/d/1XU0z92O_OvVczFavhsxhj-7beWXOc1_4SPPzwwexKho/edit

----

I've completed each of the following or determined they are not applicable:

- [ ] Made a plan to communicate any major developer interface changes (or N/A)
