### PR TITLE
feat: add frontend-app-profile to DevStack

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -320,6 +320,8 @@ Instead of a service name or list, you can also run commands like ``make dev.pro
 +------------------------------------+-------------------------------------+----------------+--------------+
 | `frontend-app-account`_            | http://localhost:1997/              | MFE (React.js) | Extra        |
 +------------------------------------+-------------------------------------+----------------+--------------+
+| `frontend-app-profile`_            | http://localhost:1995/              | MFE (React.js) | Extra        |
++------------------------------------+-------------------------------------+----------------+--------------+
 | `xqueue`_                          | http://localhost:18040/api/v1/      | Python/Django  | Extra        |
 +------------------------------------+-------------------------------------+----------------+--------------+
 | `coursegraph`                      | http://localhost:7474/browser       | Tooling (Java) | Extra        |
@@ -354,6 +356,7 @@ Some common service combinations include:
 .. _frontend-app-library-authoring: https://github.com/edx/frontend-app-library-authoring
 .. _frontend-app-course-authoring: https://github.com/edx/frontend-app-course-authoring
 .. _frontend-app-account: https://github.com/edx/frontend-app-account
+.. _frontend-app-profile: https://github.com/openedx/frontend-app-profile
 .. _frontend-app-authn: https://github.com/openedx/frontend-app-authn
 .. _xqueue: https://github.com/edx/xqueue
 .. _coursegraph: https://github.com/edx/edx-platform/tree/master/openedx/core/djangoapps/coursegraph

--- a/docker-compose-host.yml
+++ b/docker-compose-host.yml
@@ -65,6 +65,12 @@ services:
       - frontend_app_account_node_modules:/edx/app/frontend-app-account/node_modules
       - ${DEVSTACK_WORKSPACE}/src:/edx/app/src
 
+  frontend-app-profile:
+    volumes:
+      - ${DEVSTACK_WORKSPACE}/frontend-app-profile:/edx/app/frontend-app-profile
+      - frontend_app_profile_node_modules:/edx/app/frontend-app-profile/node_modules
+      - ${DEVSTACK_WORKSPACE}/src:/edx/app/src
+
   frontend-app-authn:
     volumes:
       - ${DEVSTACK_WORKSPACE}/frontend-app-authn:/edx/app/frontend-app-authn
@@ -121,6 +127,7 @@ volumes:
   edxapp_node_modules:
   edxapp_uploads:
   frontend_app_account_node_modules:
+  frontend_app_profile_node_modules:
   frontend_app_authn_node_modules:
   frontend_app_course_authoring_node_modules:
   frontend_app_gradebook_node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -654,6 +654,21 @@ services:
     depends_on:
       - lms
 
+  frontend-app-profile:
+    extends:
+      file: microfrontend.yml
+      service: microfrontend
+    working_dir: '/edx/app/frontend-app-profile'
+    container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.frontend-app-profile"
+    networks:
+      default:
+        aliases:
+          - edx.devstack.frontend-app-profile
+    ports:
+      - "1995:1995"
+    depends_on:
+      - lms
+
   frontend-app-authn:
     extends:
       file: microfrontend.yml

--- a/options.mk
+++ b/options.mk
@@ -67,7 +67,7 @@ credentials+discovery+ecommerce+edx_notes_api+forum+frontend-app-authn+frontend-
 # Separated by plus signs.
 # Separated by plus signs. Listed in alphabetical order for clarity.
 EDX_SERVICES ?= \
-analyticsapi+credentials+discovery+ecommerce+edx_notes_api+forum+frontend-app-account+frontend-app-authn+frontend-app-course-authoring+frontend-app-gradebook+frontend-app-ora-grading+frontend-app-learning+frontend-app-library-authoring+frontend-app-payment+frontend-app-program-console+frontend-app-publisher+insights+lms+lms_watcher+registrar+registrar-worker+studio+studio_watcher+xqueue+xqueue_consumer
+analyticsapi+credentials+discovery+ecommerce+edx_notes_api+forum+frontend-app-account+frontend-app-profile+frontend-app-authn+frontend-app-course-authoring+frontend-app-gradebook+frontend-app-ora-grading+frontend-app-learning+frontend-app-library-authoring+frontend-app-payment+frontend-app-program-console+frontend-app-publisher+insights+lms+lms_watcher+registrar+registrar-worker+studio+studio_watcher+xqueue+xqueue_consumer
 
 # Services with database migrations.
 # Should be a subset of $(EDX_SERVICES).

--- a/repo.sh
+++ b/repo.sh
@@ -45,6 +45,7 @@ non_release_repos=(
     "https://github.com/edx/registrar.git"
     "https://github.com/edx/frontend-app-program-console.git"
     "https://github.com/edx/frontend-app-account.git"
+    "https://github.com/openedx/frontend-app-profile.git"
     "https://github.com/edx/frontend-app-ora-grading.git"
 )
 
@@ -73,6 +74,7 @@ non_release_ssh_repos=(
     "git@github.com:edx/registrar.git"
     "git@github.com:edx/frontend-app-program-console.git"
     "git@github.com:edx/frontend-app-account.git"
+    "git@github.com:openedx/frontend-app-profile.git"
     "git@github.com:edx/frontend-app-ora-grading.git"
 )
 


### PR DESCRIPTION
Changes:
- update README
- add frontend-app-account service to docker-compose.yml
- add frontend-app-account service to docker-compose-host.yml
- add frontend-app-account to EDX_SERVICES in options.mk
- add frontend-app-account repo to non_release_* repos in repo.sh

Since Profile MFE is a part of Lilac+ release - there is clear demand to have it in default Devstack suit.

Issues:
- enabling Profile MFE in LMS UI requires following actions which can be done in lms provision step but probably must be done in configuration repo during docker image preparation step

Enabling Profile MFE in UI:
```
diff --git a/provision-lms.sh b/provision-lms.sh
index cd162ee..4caf868 100755
--- a/provision-lms.sh
+++ b/provision-lms.sh
 # Enable MFE
+docker-compose exec -T lms bash -e -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms waffle_flag --list --settings=devstack_docker | grep learner_profile.redirect_to_microfrontend || python /edx/app/edxapp/edx-platform/manage.py lms waffle_flag --create --everyone learner_profile.redirect_to_microfrontend --settings=devstack_docker'
```
Site Configuration must be updated with this:
```
{
  "ENABLE_PROFILE_MICROFRONTEND": true
}
```
Also we have to add `PROFILE_MICROFRONTEND_URL = 'http://localhost:1995/u/'` to lms.yml to `devstack.py`