### PR TITLE
fix: coursegraph dump should come from cms, not lms

### DIFF
--- a/provision-coursegraph.sh
+++ b/provision-coursegraph.sh
@@ -12,11 +12,11 @@ echo -e "${GREEN}   Ensuring Coursegraph image is up to date...${NC}"
 docker-compose rm --force --stop coursegraph
 docker-compose pull coursegraph
 
-echo -e "${GREEN}   Starting Coursegraph and LMS...${NC}"
-docker-compose up -d coursegraph lms
+echo -e "${GREEN}   Starting Coursegraph and CMS...${NC}"
+docker-compose up -d coursegraph studio
 sleep 10  # Give Neo4j some time to boot up.
 
-echo -e "${GREEN}   Updating LMS courses in Coursegraph...${NC}"
-docker-compose exec lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && ./manage.py lms dump_to_neo4j --host coursegraph.devstack.edx --user neo4j --password edx'
+echo -e "${GREEN}   Updating CMS courses in Coursegraph...${NC}"
+docker-compose exec studio bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && ./manage.py cms dump_to_neo4j --host coursegraph.devstack.edx --user neo4j --password edx'
 
-echo -e "${GREEN}   Coursegraph is now up-to-date with LMS!${NC}"
+echo -e "${GREEN}   Coursegraph is now up-to-date with CMS!${NC}"


### PR DESCRIPTION
In support of https://github.com/openedx/edx-platform/pull/29156. See that PR for context and testing instructions.