### PR TITLE
fix: don't enable Authn MFE by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -418,7 +418,6 @@ services:
       - memcached
       - mongo
       - mysql57
-      - frontend-app-authn
     # Allows attachment to the LMS service using 'docker attach <containerID>'.
     stdin_open: true
     tty: true
@@ -429,7 +428,6 @@ services:
       EDXAPP_TEST_MONGO_HOST: edx.devstack.mongo
       NO_PYTHON_UNINSTALL: 1
       DJANGO_WATCHMAN_TIMEOUT: 30
-      EDXAPP_ENABLE_AUTHN_MFE: 1
     image: edxops/edxapp:${OPENEDX_RELEASE:-latest}
     networks:
       default:
@@ -666,6 +664,8 @@ services:
           - edx.devstack.frontend-app-authn
     ports:
       - "1999:1999"
+    depends_on:
+      - lms
 
   frontend-app-course-authoring:
     extends:


### PR DESCRIPTION
Removing it as Authn MFE has not been officially released for openedX. 
----

I've completed each of the following or determined they are not applicable:

- [x] Made a plan to communicate any major developer interface changes (or N/A)
