### PR TITLE
chore: Upgrade MFEs to Node 16

### DIFF
--- a/microfrontend.yml
+++ b/microfrontend.yml
@@ -7,6 +7,6 @@ services:
     command: bash -c 'npm install; while true; do npm start; sleep 2; done'
     stdin_open: true
     tty: true
-    image: node:12-bullseye
+    image: node:16
     environment:
       - NODE_ENV=development


### PR DESCRIPTION
We are upgrading MFEs to Node 16 so devstack should also run them on Node 16 based container
