### PR TITLE
fix: Update OpsGenie Email.

### DIFF
--- a/.github/workflows/provisioning-tests.yml
+++ b/.github/workflows/provisioning-tests.yml
@@ -80,7 +80,7 @@ jobs:
            username: ${{secrets.EDX_SMTP_USERNAME}}
            password: ${{secrets.EDX_SMTP_PASSWORD}}
            subject: 'Failure: Devstack provisioning tests for ${{matrix.services}} #${{github.run_id}}'
-           to: devstack-provisioning-tests@edx.opsgenie.net
+           to: devstack-provisioning-tests@2u-internal.opsgenie.net
            from: github-actions <github-actions@edx.org>
            body: 'Devstack provisioning tests in ${{github.repository}} for ${{matrix.services}} failed! For details see "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}". \n Runbook url: https://openedx.atlassian.net/l/c/zoEcLk2z .'
 
@@ -93,7 +93,7 @@ jobs:
            username: ${{secrets.EDX_SMTP_USERNAME}}
            password: ${{secrets.EDX_SMTP_PASSWORD}}
            subject: 'Back to normal: Devstack provisioning tests for ${{matrix.services}} #${{github.run_id}}'
-           to: devstack-provisioning-tests@edx.opsgenie.net
+           to: devstack-provisioning-tests@2u-internal.opsgenie.net
            from: github-actions <github-actions@edx.org>
            body: Devstack provisioning tests in ${{github.repository}} are back to normal for ${{matrix.services}}
 


### PR DESCRIPTION
The email account to alert the owning team of
test failures has changed.

----

I've completed each of the following or determined they are not applicable:

- [ ] Made a plan to communicate any major developer interface changes (or N/A)
