### PR TITLE
Remove outdated code from `analyticsapi` provisioning

### DIFF
--- a/provision-analyticsapi.sh
+++ b/provision-analyticsapi.sh
@@ -20,6 +20,3 @@ docker-compose exec -T ${name}  bash -e -c 'source /edx/app/analytics_api/analyt
 
 echo -e "${GREEN}Loading test data for ${name}...${NC}"
 docker-compose exec -T ${name}  bash -e -c 'source /edx/app/analytics_api/analytics_api_env && cd /edx/app/analytics_api/analytics_api && make loaddata' -- ${name}
-
-echo -e "${GREEN}Populating elasticsearch for ${name}...${NC}"
-docker-compose exec -T ${name}  bash -e -c 'source /edx/app/analytics_api/analytics_api_env && cd /edx/app/analytics_api/analytics_api && make create_indices' -- ${name}


### PR DESCRIPTION
Reason: [PR](https://github.com/openedx/edx-analytics-data-api/commit/d65cc89a0d679fa6580e1188a9652df13a1fc3a8#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L124) removed the target
----

I've completed each of the following or determined they are not applicable:

- [ ] Made a plan to communicate any major developer interface changes (or N/A)
