### PR TITLE
chore: Update MySQL container to use edxops/mysql:5.7 container image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -244,7 +244,7 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: ""
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
-    image: mysql:5.7
+    image: edxops/mysql:5.7
     networks:
       default:
         aliases:


### PR DESCRIPTION
The new MySQL 5.7 images uses Docker Buildx to build container image for multiple platforms. Currently the image is built for amd64 and arm64 CPU architectures.