### PR TITLE
Use Ansible free image from original edxops repo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -489,7 +489,7 @@ services:
       LMS_HOST: http://localhost:18000
       DJANGO_SETTINGS_MODULE: analytics_dashboard.settings.devstack
       ANALYTICS_DASHBOARD_CFG: /edx/etc/insights.yml
-    image: edxops/insights-dev:${OPENEDX_RELEASE:-latest}
+    image: edxops/insights:${OPENEDX_RELEASE:-latest}
     working_dir: /edx/app/insights/insights
     networks:
       default:


### PR DESCRIPTION
----

**Issue**: https://github.com/openedx/edx-analytics-dashboard/issues/1387

This PR will be merged after https://github.com/openedx/edx-analytics-dashboard/pull/1388 is merged and ansible free image is available on edxops/insights repo

I've completed each of the following or determined they are not applicable:

- [x] Made a plan to communicate any major developer interface changes (or N/A)
