### PR TITLE
fix: remove escapes from demo_hash_password

### DIFF
--- a/provision-lms.sh
+++ b/provision-lms.sh
@@ -57,9 +57,9 @@ for user in honor audit verified staff ; do
   email="$user@example.com"
   # Set staff flag for staff user
   if [[ $user == "staff" ]] ; then
-    docker-compose exec -T lms bash -e -c "source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker --service-variant lms manage_user $user $email --initial-password-hash \'$demo_hashed_password\' --staff"
+    docker-compose exec -T lms bash -e -c "source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker --service-variant lms manage_user $user $email --initial-password-hash '$demo_hashed_password' --staff"
   else
-    docker-compose exec -T lms bash -e -c "source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker --service-variant lms manage_user $user $email --initial-password-hash \'$demo_hashed_password\'"
+    docker-compose exec -T lms bash -e -c "source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker --service-variant lms manage_user $user $email --initial-password-hash '$demo_hashed_password'"
   fi
   # Enroll users in the demo course
   docker-compose exec -T lms bash -e -c "source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker --service-variant lms enroll_user_in_course -e $email -c course-v1:edX+DemoX+Demo_Course"


### PR DESCRIPTION
Leaving the escapes in results in `CommandError: The password hash provided for user honor is invalid.` when trying to provision for the first time. See https://github.com/openedx/devstack/pull/997.

----

I've completed each of the following or determined they are not applicable:

- [ ] Made a plan to communicate any major developer interface changes (or N/A)
