### PR TITLE
fix: use a valid CELERY_BROKER_URL in discovery.yml

### DIFF
--- a/configuration_files/discovery.yml
+++ b/configuration_files/discovery.yml
@@ -13,7 +13,7 @@ CACHES:
         KEY_PREFIX: discovery
         LOCATION:
         - edx.devstack.memcached:11211
-CELERY_BROKER_URL: redis://:@127.0.0.1:6379/
+CELERY_BROKER_URL: redis://:password@edx.devstack.redis:6379/
 CORS_ORIGIN_WHITELIST: []
 CSRF_COOKIE_SECURE: false
 DATABASES:


### PR DESCRIPTION
When attempting to create a new Organization in course-discovery after a fresh provisioning of devstack, the following error was observed:

```bash
Error 111 connecting to 127.0.0.1:6379. Connection refused.
```

This PR changes the `CELERY_BROKER_URL` defined in the discovery.yml file to match what's used in edx-platform's `CELERY_BROKER_URL` ([source](https://github.com/openedx/edx-platform/commit/569403f4aefce14614c0c71e8bcaa5b1a72cbf14)). This unblocks saving the Organization in course-discovery.

----

I've completed each of the following or determined they are not applicable:

- [ ] Made a plan to communicate any major developer interface changes (or N/A)
