### PR TITLE
fix: rename leftover `dev.down` references to `dev.remove-containers`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -495,9 +495,9 @@ dev.static.%: ## Rebuild static assets for the specified service's container.
 ########################################################################################
 
 
-dev.reset: dev.down dev.reset-repos dev.prune dev.pull.large-and-slow dev.up.large-and-slow dev.static dev.migrate ## Attempt to reset the local devstack to the default branch working state without destroying data.
+dev.reset: dev.remove-containers dev.reset-repos dev.prune dev.pull.large-and-slow dev.up.large-and-slow dev.static dev.migrate ## Attempt to reset the local devstack to the default branch working state without destroying data.
 
-dev.destroy.coursegraph: dev.down.coursegraph ## Remove all coursegraph data.
+dev.destroy.coursegraph: dev.remove-containers.coursegraph ## Remove all coursegraph data.
 	docker volume rm ${COMPOSE_PROJECT_NAME}_coursegraph_data
 
 dev.destroy: ## Irreversibly remove all devstack-related containers, networks, and volumes.


### PR DESCRIPTION
Recently, as part of PR #1021, we had renamed the `dev.down` command to `dev.remove-containers` in order to try and make it a bit clearer what the command is doing behind the scenes. We still have a few commands that are trying to use the `dev.down` variant of the command. This PR updates a few remaining uses of `dev.down` to use the new syntax.

----

I've completed each of the following or determined they are not applicable:

- [ ] Made a plan to communicate any major developer interface changes (or N/A)
