### PR TITLE
fix: add `redis` as a service dependency for the course-discovery service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -336,6 +336,7 @@ services:
       - memcached
       - mysql57
       - opensearch12
+      - redis
     # Allows attachment to the discovery service using 'docker attach <containerID>'.
     stdin_open: true
     tty: true


### PR DESCRIPTION
The Discovery service uses redis but it is not currently listed as a service dependency in our `docker-compose.yml` file. This results in errors when adding/updating/removing data in Devstack's version of Discovery (e.g. adding a new organization).

Without this change, the Redis service will not start alongside the Discovery service, and this can result in errors like the following happening when using Discovery:
<img width="979" alt="image" src="https://user-images.githubusercontent.com/3229735/227004139-e5052735-07bc-4ec8-a0d1-cd325ade8a27.png">


----

I've completed each of the following or determined they are not applicable:

- [ ] Made a plan to communicate any major developer interface changes (or N/A)
