### PR TITLE
chore: Switch from edx-sphinx-theme to sphinx-book-theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -187,7 +187,7 @@ html_theme_options = {
                 href="https://openedx.org"
                 property="cc:attributionName"
                 rel="cc:attributionURL"
-            >The Center for Reimagining Learning</a>
+            >The Axim Collaborative</a>
         are licensed under a
             <a
                 rel="license"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,9 +16,10 @@ import io
 import os
 import re
 import sys
+from datetime import datetime
 from subprocess import check_call
 
-import edx_theme
+
 
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -46,7 +47,6 @@ VERSION = 'Unversioned'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'edx_theme',
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
@@ -77,8 +77,8 @@ top_level_doc = 'index'
 
 # General information about the project.
 project = 'Open edX Devstack'
-copyright = edx_theme.COPYRIGHT  # pylint: disable=redefined-builtin
-author = edx_theme.AUTHOR
+copyright = f'{datetime.now().year}, edX Inc.'  # pylint: disable=redefined-builtin
+author = 'edX Inc.'
 project_title = 'devstack'
 documentation_title = "{project_title}".format(project_title=project_title)
 
@@ -158,16 +158,46 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 
-html_theme = 'edx_theme'
+html_theme = 'sphinx_book_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {
+    "repository_url": "https://github.com/openedx/devstack",
+    "repository_branch": "master",
+    "path_to_docs": "docs/",
+    "home_page_in_toc": True,
+    "use_repository_button": True,
+    "use_issues_button": True,
+    "use_edit_page_button": True,
+    # Please don't change unless you know what you're doing.
+    "extra_footer": """
+        <a rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/">
+            <img
+                alt="Creative Commons License"
+                style="border-width:0"
+                src="https://i.creativecommons.org/l/by-sa/4.0/80x15.png"/>
+        </a>
+        <br>
+        These works by
+            <a
+                xmlns:cc="https://creativecommons.org/ns#"
+                href="https://openedx.org"
+                property="cc:attributionName"
+                rel="cc:attributionURL"
+            >The Center for Reimagining Learning</a>
+        are licensed under a
+            <a
+                rel="license"
+                href="https://creativecommons.org/licenses/by-sa/4.0/"
+            >Creative Commons Attribution-ShareAlike 4.0 International License</a>.
+    """
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
-html_theme_path = [edx_theme.get_html_theme_path()]
+# html_theme_path = []
 
 # The name for this set of Sphinx documents.
 # "<project> v<release> documentation" by default.
@@ -181,14 +211,14 @@ html_theme_path = [edx_theme.get_html_theme_path()]
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
 #
-# html_logo = None
+html_logo = "https://logos.openedx.org/open-edx-logo-color.png"
 
 # The name of an image file (relative to this directory) to use as a favicon
 # of the docs.  This file should be a Windows icon file (.ico) being 16x16
 # or 32x32
 # pixels large.
 #
-# html_favicon = None
+html_favicon = "https://logos.openedx.org/open-edx-favicon.ico"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,9 +14,9 @@ cffi==1.15.1
     # via
     #   cryptography
     #   pynacl
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
-cryptography==39.0.1
+cryptography==40.0.0
     # via paramiko
 distro==1.8.0
     # via docker-compose
@@ -34,7 +34,7 @@ jsonschema==3.2.0
     # via docker-compose
 packaging==23.0
     # via docker
-paramiko==3.0.0
+paramiko==3.1.0
     # via docker
 pycparser==2.21
     # via cffi
@@ -59,7 +59,7 @@ six==1.16.0
     #   websocket-client
 texttable==1.6.7
     # via docker-compose
-urllib3==1.26.14
+urllib3==1.26.15
     # via
     #   docker
     #   requests

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -30,7 +30,7 @@ cffi==1.15.1
     #   -r requirements/test.txt
     #   cryptography
     #   pynacl
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
@@ -39,7 +39,7 @@ click==8.1.3
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-cryptography==39.0.1
+cryptography==40.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
@@ -70,11 +70,11 @@ docopt==0.6.2
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   docker-compose
-exceptiongroup==1.1.0
+exceptiongroup==1.1.1
     # via
     #   -r requirements/test.txt
     #   pytest
-filelock==3.9.0
+filelock==3.10.3
     # via
     #   tox
     #   virtualenv
@@ -101,16 +101,16 @@ packaging==23.0
     #   docker
     #   pytest
     #   tox
-paramiko==3.0.0
+paramiko==3.1.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   docker
 pexpect==4.8.0
     # via -r requirements/test.txt
-pip-tools==6.12.2
+pip-tools==6.12.3
     # via -r requirements/pip-tools.txt
-platformdirs==3.0.0
+platformdirs==3.1.1
     # via virtualenv
 pluggy==1.0.0
     # via
@@ -142,7 +142,7 @@ pyrsistent==0.19.3
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   jsonschema
-pytest==7.2.1
+pytest==7.2.2
     # via -r requirements/test.txt
 python-dotenv==0.21.1
     # via
@@ -188,13 +188,13 @@ tox==3.28.0
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/dev.in
-urllib3==1.26.14
+urllib3==1.26.15
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   docker
     #   requests
-virtualenv==20.20.0
+virtualenv==20.21.0
     # via tox
 websocket-client==0.59.0
     # via
@@ -202,7 +202,7 @@ websocket-client==0.59.0
     #   -r requirements/test.txt
     #   docker
     #   docker-compose
-wheel==0.38.4
+wheel==0.40.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools

--- a/requirements/doc.in
+++ b/requirements/doc.in
@@ -4,6 +4,6 @@
 -r base.txt               # Core dependencies for this package
 
 doc8                      # reStructuredText style checker
-edx_sphinx_theme          # edX theme for Sphinx output
+sphinx-book-theme         # Common theme for all Open edX projects
 readme_renderer           # Validates README.rst for usage on PyPI
 Sphinx                    # Documentation builder

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,6 +4,8 @@
 #
 #    make upgrade
 #
+accessible-pygments==0.0.4
+    # via pydata-sphinx-theme
 alabaster==0.7.13
     # via sphinx
 attrs==22.2.0
@@ -11,11 +13,15 @@ attrs==22.2.0
     #   -r requirements/base.txt
     #   jsonschema
 babel==2.12.1
-    # via sphinx
+    # via
+    #   pydata-sphinx-theme
+    #   sphinx
 bcrypt==4.0.1
     # via
     #   -r requirements/base.txt
     #   paramiko
+beautifulsoup4==4.12.0
+    # via pydata-sphinx-theme
 bleach==6.0.0
     # via readme-renderer
 certifi==2022.12.7
@@ -27,11 +33,11 @@ cffi==1.15.1
     #   -r requirements/base.txt
     #   cryptography
     #   pynacl
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via
     #   -r requirements/base.txt
     #   requests
-cryptography==39.0.1
+cryptography==40.0.0
     # via
     #   -r requirements/base.txt
     #   paramiko
@@ -58,18 +64,17 @@ docopt==0.6.2
 docutils==0.19
     # via
     #   doc8
+    #   pydata-sphinx-theme
     #   readme-renderer
     #   restructuredtext-lint
     #   sphinx
-edx-sphinx-theme==3.1.0
-    # via -r requirements/doc.in
 idna==3.4
     # via
     #   -r requirements/base.txt
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.0.0
+importlib-metadata==6.1.0
     # via sphinx
 jinja2==3.1.2
     # via sphinx
@@ -83,8 +88,9 @@ packaging==23.0
     # via
     #   -r requirements/base.txt
     #   docker
+    #   pydata-sphinx-theme
     #   sphinx
-paramiko==3.0.0
+paramiko==3.1.0
     # via
     #   -r requirements/base.txt
     #   docker
@@ -94,9 +100,13 @@ pycparser==2.21
     # via
     #   -r requirements/base.txt
     #   cffi
+pydata-sphinx-theme==0.13.1
+    # via sphinx-book-theme
 pygments==2.14.0
     # via
+    #   accessible-pygments
     #   doc8
+    #   pydata-sphinx-theme
     #   readme-renderer
     #   sphinx
 pynacl==1.5.0
@@ -132,16 +142,20 @@ six==1.16.0
     #   -r requirements/base.txt
     #   bleach
     #   dockerpty
-    #   edx-sphinx-theme
     #   jsonschema
     #   websocket-client
 snowballstemmer==2.2.0
     # via sphinx
+soupsieve==2.4
+    # via beautifulsoup4
 sphinx==5.3.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/doc.in
-    #   edx-sphinx-theme
+    #   pydata-sphinx-theme
+    #   sphinx-book-theme
+sphinx-book-theme==1.0.0
+    # via -r requirements/doc.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
@@ -162,7 +176,7 @@ texttable==1.6.7
     #   docker-compose
 tomli==2.0.1
     # via doc8
-urllib3==1.26.14
+urllib3==1.26.15
     # via
     #   -r requirements/base.txt
     #   docker

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -10,13 +10,13 @@ click==8.1.3
     # via pip-tools
 packaging==23.0
     # via build
-pip-tools==6.12.2
+pip-tools==6.12.3
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.0.0
     # via build
 tomli==2.0.1
     # via build
-wheel==0.38.4
+wheel==0.40.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-wheel==0.38.4
+wheel==0.40.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.0.1
     # via -r requirements/pip.in
-setuptools==67.4.0
+setuptools==67.6.0
     # via -r requirements/pip.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -22,11 +22,11 @@ cffi==1.15.1
     #   -r requirements/base.txt
     #   cryptography
     #   pynacl
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via
     #   -r requirements/base.txt
     #   requests
-cryptography==39.0.1
+cryptography==40.0.0
     # via
     #   -r requirements/base.txt
     #   paramiko
@@ -48,7 +48,7 @@ docopt==0.6.2
     # via
     #   -r requirements/base.txt
     #   docker-compose
-exceptiongroup==1.1.0
+exceptiongroup==1.1.1
     # via pytest
 idna==3.4
     # via
@@ -65,7 +65,7 @@ packaging==23.0
     #   -r requirements/base.txt
     #   docker
     #   pytest
-paramiko==3.0.0
+paramiko==3.1.0
     # via
     #   -r requirements/base.txt
     #   docker
@@ -87,7 +87,7 @@ pyrsistent==0.19.3
     # via
     #   -r requirements/base.txt
     #   jsonschema
-pytest==7.2.1
+pytest==7.2.2
     # via -r requirements/test.in
 python-dotenv==0.21.1
     # via
@@ -114,7 +114,7 @@ texttable==1.6.7
     #   docker-compose
 tomli==2.0.1
     # via pytest
-urllib3==1.26.14
+urllib3==1.26.15
     # via
     #   -r requirements/base.txt
     #   docker


### PR DESCRIPTION
The edx-sphinx theme is being deprecated, and replaced with sphinx-book-theme. This removes references to the deprecated theme and replaces them with the new standard theme for the platform.

**Testing instructions:** 
- Run `make docs` and see that the docs are generated properly and use the sphinx-book-theme

See https://github.com/openedx/public-engineering/issues/200
----

I've completed each of the following or determined they are not applicable:

- [x] Made a plan to communicate any major developer interface changes (or N/A)
