### PR TITLE
feat: add more base data during discovery provisioning

### DIFF
--- a/provision-discovery.sh
+++ b/provision-discovery.sh
@@ -3,6 +3,11 @@
 set -eu -o pipefail
 set -x
 
+docker-compose up -d lms
+docker-compose up -d studio
+docker-compose up -d ecommerce
+sleep 5 # Give above services some time to boot up
+
 ./provision-ida.sh discovery discovery 18381
 
 docker-compose exec -T discovery bash -e -c 'rm -rf /edx/var/discovery/*'
@@ -12,6 +17,7 @@ set +e
 # FIXME[bash-e]: Bash scripts should use -e -- but this script fails
 # (after many retries) when trying to talk to ecommerce
 docker-compose exec -T discovery bash -e -c 'source /edx/app/discovery/discovery_env && python /edx/app/discovery/discovery/manage.py refresh_course_metadata'
+docker-compose exec -T discovery bash -e -c 'source /edx/app/discovery/discovery_env && python /edx/app/discovery/discovery/manage.py add_provisioning_data'
 set -e
 
 docker-compose exec -T discovery bash -e -c 'source /edx/app/discovery/discovery_env && python /edx/app/discovery/discovery/manage.py update_index --disable-change-limit'


### PR DESCRIPTION
## Description

Add a command to populate discovery with base data (level_types, subjects, courses, etc.) during provisioning.
[(Related PR)](https://github.com/openedx/course-discovery/pull/3861)

## Testing 
Note that this requires the related PR to be merged first.

1. Provision course-discovery.
2. Confirm that a number of courses, subjects, programs and level_types exist by default in the discovery database. 




----

I've completed each of the following or determined they are not applicable:

- [ ] Made a plan to communicate any major developer interface changes (or N/A)
