### PR TITLE
fix: remove DJANGO_SETTINGS_MODULE env from lms, cms

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -455,7 +455,6 @@ services:
       LMS_CFG: "/edx/etc/lms.yml"
       CMS_CFG: "/edx/etc/studio.yml"
       PATH: "/edx/app/edxapp/venvs/edxapp/bin:/edx/app/edxapp/nodeenv/bin:/edx/app/edxapp/edx-platform/node_modules/.bin:/edx/app/edxapp/edx-platform/bin:${PATH}"
-      DJANGO_SETTINGS_MODULE: lms.envs.devstack_docker
       SERVICE_VARIANT: lms
     image: openedx/lms-dev:${OPENEDX_RELEASE:-latest}
     networks:
@@ -629,7 +628,6 @@ services:
       DJANGO_WATCHMAN_TIMEOUT: 30
       LMS_CFG: "/edx/etc/lms.yml"
       CMS_CFG: "/edx/etc/studio.yml"
-      DJANGO_SETTINGS_MODULE: cms.envs.devstack_docker
       SERVICE_VARIANT: cms
     image: openedx/lms-dev:${OPENEDX_RELEASE:-latest}
     networks:


### PR DESCRIPTION
we are using `EDX_PLATFORM_SETTINGS` env variable for picking settings file to use with Django management commands. When this env variable is set to `lms.envs.devstack_docker`, with dev image being used with devstack, it picks that settings for running tests too as it has higher precedence than the settings in ini file. So removing this, so the test settings can be picked from ini file.

----

I've completed each of the following or determined they are not applicable:

- [ ] Made a plan to communicate any major developer interface changes (or N/A)
