### PR TITLE
fix: Run CMS migrations on CMS container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,8 +259,8 @@ $(foreach db_service,$(DB_SERVICES_LIST),\
 dev.migrate: | $(_db_migration_targets) ## Run migrations for applicable default services.
 
 dev.migrate.studio:
-	docker-compose exec -T -u root lms bash -e -c '/edx/app/edxapp/venvs/edxapp/bin/python manage.py cms showmigrations --database default --traceback --pythonpath=. --settings devstack_docker'
-	docker-compose exec -T -u root lms bash -e -c '/edx/app/edxapp/venvs/edxapp/bin/python manage.py cms migrate --database default --noinput --traceback --pythonpath=. --settings devstack_docker'
+	docker-compose exec -T -u root cms bash -e -c '/edx/app/edxapp/venvs/edxapp/bin/python manage.py cms showmigrations --database default --traceback --pythonpath=. --settings devstack_docker'
+	docker-compose exec -T -u root cms bash -e -c '/edx/app/edxapp/venvs/edxapp/bin/python manage.py cms migrate --database default --noinput --traceback --pythonpath=. --settings devstack_docker'
 
 dev.migrate.lms:
 	docker-compose exec -T -u root lms bash -e -c '/edx/app/edxapp/venvs/edxapp/bin/python manage.py lms showmigrations --database default --traceback --pythonpath=. --settings devstack_docker'


### PR DESCRIPTION
I think this was just a copy-paste error. It worked OK most of the time, but it failed for me recently. I had only run `make requirements` in `make studio-shell` and then tried to `make studio-migrate`. It failed because the management command ran on lms and the migration depended on newer requirements.

----

I've completed each of the following or determined they are not applicable:

- [x] Made a plan to communicate any major developer interface changes (or N/A)
