### PR TITLE
fix: Run CMS migrations on Studio container (for real this time)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,8 +259,8 @@ $(foreach db_service,$(DB_SERVICES_LIST),\
 dev.migrate: | $(_db_migration_targets) ## Run migrations for applicable default services.
 
 dev.migrate.studio:
-	docker-compose exec -T -u root cms bash -e -c '/edx/app/edxapp/venvs/edxapp/bin/python manage.py cms showmigrations --database default --traceback --pythonpath=. --settings devstack_docker'
-	docker-compose exec -T -u root cms bash -e -c '/edx/app/edxapp/venvs/edxapp/bin/python manage.py cms migrate --database default --noinput --traceback --pythonpath=. --settings devstack_docker'
+	docker-compose exec -T -u root studio bash -e -c '/edx/app/edxapp/venvs/edxapp/bin/python manage.py cms showmigrations --database default --traceback --pythonpath=. --settings devstack_docker'
+	docker-compose exec -T -u root studio bash -e -c '/edx/app/edxapp/venvs/edxapp/bin/python manage.py cms migrate --database default --noinput --traceback --pythonpath=. --settings devstack_docker'
 
 dev.migrate.lms:
 	docker-compose exec -T -u root lms bash -e -c '/edx/app/edxapp/venvs/edxapp/bin/python manage.py lms showmigrations --database default --traceback --pythonpath=. --settings devstack_docker'


### PR DESCRIPTION
This is a correction to https://github.com/openedx/devstack/pull/1048 (commit 4be61464846). I know I had previously tested the change, but I must have had to back out and re-do the change before committing, and got it wrong the second time. -.-

----

I've completed each of the following or determined they are not applicable:

- [x] Made a plan to communicate any major developer interface changes (or N/A)
