### PR TITLE
fix: provisioning tests

### DIFF
--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -46,7 +46,7 @@ jobs:
           curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
           sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu focal test"
           sudo apt update
-          sudo apt install docker-ce
+          sudo apt install docker-ce containerd.io
           docker version
           docker-compose --version
 

--- a/.github/workflows/provisioning-tests.yml
+++ b/.github/workflows/provisioning-tests.yml
@@ -44,7 +44,7 @@ jobs:
           curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
           sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu focal test"
           sudo apt update
-          sudo apt install docker-ce
+          sudo apt install docker-ce containerd.io
           docker version
           docker-compose --version
 


### PR DESCRIPTION
The provisioning tests were failing with the following error:
> The following packages have unmet dependencies:
>  docker-ce : Depends: containerd.io (>= 1.6.4)

 This change attempts to fix the error by installing
 containerd.io.

----

I've completed each of the following or determined they are not applicable:

- [ ] Made a plan to communicate any major developer interface changes (or N/A)
