### PR TITLE
fix: import devstack env vars when provisioning ida's

### DIFF
--- a/provision-ida.sh
+++ b/provision-ida.sh
@@ -9,7 +9,7 @@ client_name=$2  # The name of the Oauth client stored in the edxapp DB.
 client_port=$3  # The port corresponding to this IDA service in devstack.
 container_name=${4:-$1} # (Optional) The name of the container.  If missing, will use app_name.
 
-docker-compose up -d $app_name
+make dev.up.$app_name
 
 echo -e "${GREEN}Installing requirements for ${app_name}...${NC}"
 docker-compose exec -T ${container_name}  bash -e -c 'source /edx/app/$1/$1_env && cd /edx/app/$1/$1/ && make requirements' -- "$app_name"


### PR DESCRIPTION
## Description

Change provision-ida.sh so that on provision it imports environmental variables like:

- `COMPOSE_FILE`
- `COMPOSE_PATH_SEPARATOR`

that are defined in Makefile:

https://github.com/openedx/devstack/blob/fac68ae85b49cc6186d4872c0f3e2bfbc64f98db/Makefile#L72-L79

and:

- `COMPOSE_PROJECT_NAME`
- `DEVSTACK_WORKSPACE`

that are defined in options.mk [[GitHub lines](https://github.com/openedx/devstack/blob/fac68ae85b49cc6186d4872c0f3e2bfbc64f98db/options.mk#L16-L39)].

### Motivation

Before this change, provision-ida.sh would just run `docker-compose up` [[GitHub line](https://github.com/openedx/devstack/blob/fac68ae85b49cc6186d4872c0f3e2bfbc64f98db/provision-ida.sh#L12)].

That missed out on including docker-compose-host.yml from `COMPOSE_FILE`.

That caused a fail on requirements gathering for course-discovery [[here, GitHub line](https://github.com/openedx/devstack/blob/fac68ae85b49cc6186d4872c0f3e2bfbc64f98db/provision-ida.sh#L15)] due to:

- Outdated BASIC authentication credentials provided by the configuration repository by default in our devstack images, and

- Not having the user's .git/config file for the repo mapped into the container by `COMPOSE_FILE`

Solution is to use `make dev.up`, which sets `COMPOSE_FILE` and other environmental variables, instead of `docker-compose up`, which does not.

## Testing Instructions

To replicate the problem that started this PR, before pulling this PR run:

```
% make dev.remove-containers.discovery && make dev.up.discovery && docker-compose exec -T discovery bash -e -c 'source /edx/app/discovery/discovery_env && cd /edx/app/discovery/discovery/ && make requirements.js'
(success #1)

% make dev.up.discovery && docker-compose exec -T discovery bash -e -c 'source /edx/app/discovery/discovery_env && cd /edx/app/discovery/discovery/ && make requirements.js'
(success #2)

% docker-compose up -d discovery && docker-compose exec -T discovery bash -e -c 'source /edx/app/discovery/discovery_env && cd /edx/app/discovery/discovery/ && make requirements.js'
(failure)
```

To compare difference in the Git config:

* On `success #2` container:

  ```
  % make dev.shell.discovery
  # git config --list
  core.ignorecase=true
  core.precomposeunicode=true
  core.symlinks=true
  remote.origin.url=git@github.com:edx/course-discovery.git
  remote.origin.gh-resolved=openedx/course-discovery
  <plus other common config>
  ```

* On `failure` container:

  ```
  % make dev.shell.discovery
  # git config --list
  remote.origin.url=https://github.com/openedx/course-discovery
  gc.auto=0
  http.https://github.com/.extraheader=AUTHORIZATION: basic <base64 string>
  <plus other common config>
  ```

To compare effective configurations between `dev.up` and `docker-compose up`:

```
devstack % make dev.validate > makefile_effective_compose.yml
devstack % docker-compose config > local_effective_compose.yml
devstack % diff local_effective_compose.yml makefile_effective_compose.yml
...
>     - <local machine path to DEVSTACK_WORKSPACE>/course-discovery:/edx/app/discovery/discovery:rw
...
```

To test this PR, run after pulling this PR's branch:

```
bash provision.sh discovery
```

----

I've completed each of the following or determined they are not applicable:

- [x] Made a plan to communicate any major developer interface changes (or N/A)
