### PR TITLE
chore: upgrade devstack redis to 6.2.12

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -257,7 +257,7 @@ services:
   redis:
     container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.redis"
     hostname: redis.devstack.edx
-    image: redis:6.2.7
+    image: redis:6.2.9
     command: redis-server --requirepass password
     networks:
       default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -257,7 +257,7 @@ services:
   redis:
     container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.redis"
     hostname: redis.devstack.edx
-    image: redis:6.2.9
+    image: redis:6.2.12
     command: redis-server --requirepass password
     networks:
       default:


### PR DESCRIPTION
Upgrade the devstack `redis` to `6.2.12`. Its most recent version.
https://github.com/edx/edx-arch-experiments/issues/201


https://raw.githubusercontent.com/redis/redis/6.2/00-RELEASENOTES