### PR TITLE
docs: No longer recommend that devs use devstack in a virtualenv

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -52,8 +52,6 @@ You should run all ``make`` commands described below on your local machinge, *no
 from within a Virtual Machine, as these commands are meant to stand up a VM-like environment using
 Docker containers.
 
-For basic development purposes, you will not need a virtualenv. (You will only need to set up a virtualenv and run ``make requirements`` if you are working on devstack itself.)
-
 Directions to setup devstack
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -8,10 +8,12 @@ You will need to have the following installed:
 
 - make
 - Python 3.8
-- Docker
+- Docker, including ``docker-compose``
 
 This project requires **Docker 17.06+ CE**.  We recommend Docker Stable, but
-Docker Edge should work as well.
+Docker Edge should work as well. Ensure that your Docker installation includes
+``docker-compose``; on some operating systems (e.g. Ubuntu Linux) this may require
+a separate package.
 
 **NOTE:** Switching between Docker Stable and Docker Edge will remove all images and
 settings.  Don't forget to restore your memory setting and be prepared to
@@ -50,9 +52,7 @@ You should run all ``make`` commands described below on your local machinge, *no
 from within a Virtual Machine, as these commands are meant to stand up a VM-like environment using
 Docker containers.
 
-However, you may want to run the ``make`` commands from within a Python 3 virtual
-environment. This will keep the Python packages required for Devstack separate from
-the ones installed globally on your system.
+For basic development purposes, you will not need a virtualenv. (You will only need to set up a virtualenv and run ``make requirements`` if you are working on devstack itself.)
 
 Directions to setup devstack
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -60,14 +60,6 @@ Directions to setup devstack
 The default devstack services can be run by following the steps below.
 
 **Note:** This will set up a large number of services, more than you are likely to need to work with, but that's only necessary for first-time provisioning. See :doc:`service_list` and the :doc:`most common development workflow <workflow>` for how to run and update devstack with just the services you need, rather than the ``large-and-slow`` default set.
-
-#. Install the requirements inside of a `Python virtualenv`_.
-
-   .. code:: sh
-
-       make requirements
-
-   This will install docker-compose and other utilities into your virtualenv.
 
 #. The Docker Compose file mounts a host volume for each service's executing
    code. The host directory defaults to be a sibling of this directory. For
@@ -170,5 +162,3 @@ This data collection is behind a consent flag, so please help devstack's maintai
    make metrics-opt-in
 
 Now that you're up and running, read about the :doc:`most common development workflow <workflow>`.
-
-.. _Python virtualenv: https://docs.python-guide.org/en/latest/dev/virtualenvs/#lower-level-virtualenv

--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -11,7 +11,6 @@ These instructions are written using the LMS as an example. Replace ``lms`` with
 
    - Make sure your IDA's repo is checked out to the commit you want to use for development, and that that commit is based on an up to date branch, so that it matches the disk images devstack will pull.
 
-#. Activate your devstack virtualenv. See the main Getting Started instructions if you don't already have one.
 #. Launch your service in a clean state:
 
    #. Run ``make dev.remove-containers dev.pull.lms dev.up.lms`` to halt any running services and remove their containers, pull the latest disk images, and launch your service.


### PR DESCRIPTION
The only thing that most developers use from the devstack requirements file
is docker-compose, and that's already provided by a Docker installation on
some operating systems. So just change the Docker installation instructions
to mention docker-compose, and then drop virtualenvs from the getting
started and main workflow docs.

This commit does not change `docs/developing_on_named_release_branches.rst`
as that file is for an uncommon use-case. Removing virtualenv instructions
from that file would require getting multi-devstack set up in the first
place and then removing all the virtualenv referenves from the scripts that
are laid out in the doc. If it's worth doing that, it's best done by
someone who already uses those instructions.

Issue: https://github.com/openedx/devstack/issues/1076


----

I've completed each of the following or determined they are not applicable:

- [x] Made a plan to communicate any major developer interface changes (or N/A)
