### PR TITLE
chore: Add comment to bug reports.

### DIFF
--- a/.github/workflows/follow-up-devstack-bugs.yml
+++ b/.github/workflows/follow-up-devstack-bugs.yml
@@ -1,0 +1,24 @@
+name: Add comment
+on:
+  issues:
+    types:
+      - labeled
+jobs:
+  add-comment:
+    if: github.event.label.name == 'bug'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Add comment
+        uses: peter-evans/create-or-update-comment@5f728c3dae25f329afbe34ee4d08eef25569d79f
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            Follow-up checklist (for Arch-BOM usage)
+            - [ ] Is the issue flaky or consistent?
+            - [ ] Does it affect multiple people or multiple types of systems?
+            - [ ] Update the devstack troubleshooting documentation page if necessary
+              - [ ] Do we need a new troubleshooting section?
+              - [ ] Did a troubleshooting section already exist, but it wasn't easy to find given the symptoms?
+              - [ ] If a recurring issue, should we ticket an automated resolution in place of the doc?


### PR DESCRIPTION
This workflow adds a follow-up checklist for arch-bom developers to use when triaging bugs.

https://github.com/edx/edx-arch-experiments/issues/310

----

I've completed each of the following or determined they are not applicable:

- [ ] Made a plan to communicate any major developer interface changes (or N/A)
