### PR TITLE
fix: Halt if `npm install` fails; switch to `npm ci` as well

### DIFF
--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -61,7 +61,7 @@ Although several micro-frontends (MFEs) are built into devstack (the full list i
 
   make dev.down.frontend-app-learning  # Bring down the devstack version of the Learning MFE.
   cd <path-to-frontend-app-learning>   # Navigate to the Learning MFE's repository.
-  npm install && npm start             # Install JS packages, and start the NPM devserver on your local host.
+  npm ci && npm start                  # Install JS packages, and start the NPM devserver on your local host.
 
 Of course ``learning`` can be replaced with ``gradebook``, ``payment``, or another frontend-app name.
 

--- a/microfrontend.yml
+++ b/microfrontend.yml
@@ -1,10 +1,22 @@
-# This file contains configuration common too all microfrontends
+# This file contains configuration common to all microfrontends
 
 version: "2.1"
 
 services:
   microfrontend:
-    command: bash -c 'npm install; while true; do npm start; sleep 2; done'
+    # Use `npm ci` rather than `npm install` for a few reasons:
+    #
+    # - Repeatability: Respect the currently checked out package
+    #   versions rather than upgrading when package.json and
+    #   package-lock.json don't match. (Two people using this at
+    #   different times on the same commit should get the same
+    #   results.)
+    # - Immutability: Don't change the repo's working directory
+    #   unexpectedly when there's a lock mismatch.
+    #
+    # Fail fast if package install fails to avoid mysterious
+    # errors later.
+    command: bash -c 'npm ci || exit 1; while true; do npm start; sleep 2; done'
     stdin_open: true
     tty: true
     image: node:16

--- a/provision-insights.sh
+++ b/provision-insights.sh
@@ -13,7 +13,7 @@ echo -e "${GREEN}Installing requirements for ${name}...${NC}"
 docker-compose exec -T ${name}  bash -e -c 'source /edx/app/insights/insights_env && cd /edx/app/insights/insights && make develop' -- ${name}
 
 # # Install Insights npm dependencies
-docker-compose exec -T ${name} bash -e -c 'source /edx/app/insights/insights_env && cd /edx/app/insights/insights/ && npm install && ./npm-post-install.sh'
+docker-compose exec -T ${name} bash -e -c 'source /edx/app/insights/insights_env && cd /edx/app/insights/insights/ && npm ci && ./npm-post-install.sh'
 
 echo -e "${GREEN}Running migrations for ${name}...${NC}"
 docker-compose exec -T ${name}  bash -e -c 'source /edx/app/insights/insights_env && export DJANGO_SETTINGS_MODULE="analytics_dashboard.settings.devstack" && cd /edx/app/insights/insights && make migrate' -- ${name}


### PR DESCRIPTION
We've seen a few cases where npm package installation fails, but the server continues to try to start up, and then developers get very mysterious errors that are hard to debug. Fail fast on MFE startup to avoid this.

Also switch to `npm ci` so that:

1. Two developers on the same repo commit get the same version
2. Repository working directories are not modified by just running an MFE

(Also, fix a typo.)

See https://github.com/edx/edx-arch-experiments/issues/335

----

I've completed each of the following or determined they are not applicable:

- [x] Made a plan to communicate any major developer interface changes (or N/A)
  - Will check in a frontends Slack channel before merging, and announce in usual ways afterwards (following arch team's "How We Announce")
