### PR TITLE
feat: Add matching IDA-name-first commands for dev.remove-containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -539,6 +539,7 @@ $(addsuffix -restart-container, $(ALL_SERVICES_LIST)): %-restart-container: dev.
 $(addsuffix -stop, $(ALL_SERVICES_LIST)): %-stop: dev.stop.%
 $(addsuffix -kill, $(ALL_SERVICES_LIST)): %-kill: dev.kill.%
 $(addsuffix -down, $(ALL_SERVICES_LIST)): %-down: dev.down.%
+$(addsuffix -remove-containers, $(ALL_SERVICES_LIST)): %-remove-containers: dev.remove-containers.%
 $(addsuffix -check, $(EDX_SERVICES_LIST)): %-check: dev.check.%
 $(addsuffix -restart-devserver, $(EDX_SERVICES_LIST)): %-restart-devserver: dev.restart-devserver.%
 $(addsuffix -logs, $(ALL_SERVICES_LIST)): %-logs: dev.logs.%


### PR DESCRIPTION
This should bring it to parity with dev.down.

(For example, `lms-down` == `dev.down.lms`, and now `lms-remove-containers` == `dev.remove-containers.lms`.)

----

I've completed each of the following or determined they are not applicable:

- [x] Made a plan to communicate any major developer interface changes (or N/A)
  - Will briefly announce in Slack on 2u-internal and openedx
