### PR TITLE
fix: use oracle mysql80 image in devstack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -259,7 +259,7 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: ""
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
-    image: mysql:8.0-oracle
+    image: mysql:8.0.33-oracle
     networks:
       default:
         aliases:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -253,6 +253,7 @@ services:
       - mysql57_data:/var/lib/mysql
 
   mysql80:
+    platform: linux/amd64
     command: mysqld --character-set-server=utf8 --collation-server=utf8_general_ci
     container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.mysql80"
     hostname: mysql80.devstack.edx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -259,6 +259,8 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: ""
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+    # Oracle-packaged version includes an `linux/arm64/v8` version, needed for
+    # machines with Apple Silicon CPUs (Mac M1, M2)
     image: mysql:8.0.33-oracle
     networks:
       default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -253,14 +253,13 @@ services:
       - mysql57_data:/var/lib/mysql
 
   mysql80:
-    platform: linux/amd64
     command: mysqld --character-set-server=utf8 --collation-server=utf8_general_ci
     container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.mysql80"
     hostname: mysql80.devstack.edx
     environment:
       MYSQL_ROOT_PASSWORD: ""
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
-    image: mysql:8.0.26
+    image: mysql:8.0-oracle
     networks:
       default:
         aliases:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -259,7 +259,7 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: ""
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
-    # Oracle-packaged version includes an `linux/arm64/v8` version, needed for
+    # Oracle-packaged version includes a `linux/arm64/v8` version, needed for
     # machines with Apple Silicon CPUs (Mac M1, M2)
     image: mysql:8.0.33-oracle
     networks:


### PR DESCRIPTION
Oracle's mysql80 image has arm64 builds. Tested on both Apple Silicon (M2) and Intel. Successfully brought up container on both.

I've completed each of the following or determined they are not applicable:

- [ ] Made a plan to communicate any major developer interface changes (or N/A)
