### PR TITLE
docs: Update Docker links in Getting Started docs

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -40,10 +40,10 @@ If you are using Linux, use the ``overlay2`` storage driver, kernel version
 
    docker info | grep -i 'storage driver'
 
-.. _Docker for Mac: https://docs.docker.com/docker-for-mac/
+.. _Docker for Mac: https://docs.docker.com/desktop/install/mac-install/
 .. _licensing terms: https://www.docker.com/pricing/faq
-.. _configuring Docker for Mac: https://docs.docker.com/docker-for-mac/#/advanced
-.. _Docker for Windows: https://docs.docker.com/docker-for-windows/
+.. _configuring Docker for Mac: https://docs.docker.com/desktop/settings/mac/#advanced
+.. _Docker for Windows: https://docs.docker.com/desktop/install/windows-install/
 
 Please note
 ~~~~~~~~~~~


### PR DESCRIPTION
Links currently redirect to:
https://docs.docker.com/desktop/get-started/

Archive of Mac Install link:
https://web.archive.org/web/20220328231039/https://docs.docker.com/desktop/mac/

Archive of Windows Install link:
https://web.archive.org/web/20220629164719/https://docs.docker.com/desktop/windows/

----

I've completed each of the following or determined they are not applicable:

- [ ] Made a plan to communicate any major developer interface changes (or N/A)
