### PR TITLE
fix: fix forum provisioning after upgrade to ruby 3.0.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -431,7 +431,7 @@ services:
       ELASTICSEARCH_DSL: "http://edx.devstack.elasticsearch710:9200"
 
   forum:
-    command: bash -c 'source /edx/app/forum/ruby_env && source /edx/app/forum/devstack_forum_env && cd /edx/app/forum/cs_comments_service && bundle install && while true; do ruby app.rb -o 0.0.0.0 ; sleep 2; done'
+    command: bash -c 'source /edx/app/forum/ruby_env && source /edx/app/forum/devstack_forum_env && cd /edx/app/forum/cs_comments_service && bundle install && while true; do ./bin/unicorn -c config/unicorn_tcp.rb -I .; sleep 2; done'
     container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.forum"
     hostname: forum.devstack.edx
     depends_on:

--- a/provision-forum.sh
+++ b/provision-forum.sh
@@ -3,4 +3,4 @@ set -eu -o pipefail
 set -x
 
 docker-compose up -d forum
-docker-compose exec -T forum bash -e -c 'source /edx/app/forum/ruby_env && cd /edx/app/forum/cs_comments_service && bundle install --deployment --path /edx/app/forum/.gem/'
+docker-compose exec -T forum bash -e -c 'source /edx/app/forum/ruby_env && source /edx/app/forum/devstack_forum_env && cd /edx/app/forum/cs_comments_service && bundle install --deployment --path /edx/app/forum/.gem/ && bin/rake search:initialize'


### PR DESCRIPTION
### [INF-938](https://2u-internal.atlassian.net/browse/INF-938)

### Description

Upgrade to Ruby 3.0.4 resulted in the following error when provisioning the forum service:
```python
pick': Couldn't find handler for: thin, falcon, puma, HTTP, webrick
```

----

I've completed each of the following or determined they are not applicable:

- [ ] Made a plan to communicate any major developer interface changes (or N/A)
