### PR TITLE
fix: Use correct name for --detach param

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,7 +302,7 @@ dev.up.with-watchers.%: ## Bring up services and their dependencies + asset watc
 dev.up.without-deps: _expects-service-list.dev.up.without-deps
 
 impl-dev.up.without-deps.%: dev.check-memory ## Bring up services by themselves.
-	docker-compose up --detach --no-deps $$(echo $* | tr + " ")
+	docker-compose up -d --no-deps $$(echo $* | tr + " ")
 
 dev.up.without-deps.%: ## Bring up services by themselves.
 	@scripts/send_metrics.py wrap "dev.up.without-deps.$*"

--- a/Makefile
+++ b/Makefile
@@ -302,7 +302,7 @@ dev.up.with-watchers.%: ## Bring up services and their dependencies + asset watc
 dev.up.without-deps: _expects-service-list.dev.up.without-deps
 
 impl-dev.up.without-deps.%: dev.check-memory ## Bring up services by themselves.
-	docker-compose up --d --no-deps $$(echo $* | tr + " ")
+	docker-compose up --detach --no-deps $$(echo $* | tr + " ")
 
 dev.up.without-deps.%: ## Bring up services by themselves.
 	@scripts/send_metrics.py wrap "dev.up.without-deps.$*"


### PR DESCRIPTION
`-d` is valid and so is `--detach`. But the `--d` that was used here (with two hyphens) only worked on some machines. I believe that was autocorrected to `--detach` on those machines because it was a unique prefix, as I was also able to use `--det`.

This might be a matter of versions, or of `docker-compose` vs. `docker compose` shims, or just difference by OS. But in any case we should use a documented version of the flag.

----

I've completed each of the following or determined they are not applicable:

- [x] Made a plan to communicate any major developer interface changes (or N/A)
