### PR TITLE
feat: Remove redundant `seed_permissions_roles` call for demo course

### DIFF
--- a/provision-lms.sh
+++ b/provision-lms.sh
@@ -53,8 +53,6 @@ then
 else
     docker-compose exec -T lms bash -e -c 'git clone https://github.com/openedx/edx-demo-course.git /tmp/edx-demo-course'
     docker-compose exec -T lms bash -e -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py cms --settings=devstack_docker import /edx/var/edxapp/data /tmp/edx-demo-course && rm -rf /tmp/edx-demo-course'
-    # Seed forums for the demo course
-    docker-compose exec -T lms bash -e -c "source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker seed_permissions_roles course-v1:edX+DemoX+Demo_Course"
 fi
 
 demo_hashed_password='pbkdf2_sha256$20000$TjE34FJjc3vv$0B7GUmH8RwrOc/BvMoxjb5j8EgnWTt3sxorDANeF7Qw='


### PR DESCRIPTION
The `import` management command (from cms contentstore) is called right before the `seed_permissions_roles` command (from lms discussions). However, the import command already performs the seeding.

See https://github.com/openedx/devstack/issues/1129 for archaeological notes.

Confirmation that the call doesn't add anything:

- Provisioned LMS with `DEVSTACK_SKIP_DEMO=true`
- Manually ran first two commands for importing demo course (git clone, `import` management command)
- Took MySQL DB dumps
- Ran final demo course command, `seed_permissions_roles`
- Took new DB dumps
- Diff of SQL files showed only a change in the dump dates

----

I've completed each of the following or determined they are not applicable:

- [x] Made a plan to communicate any major developer interface changes (or N/A)
  - None
