### PR TITLE
docs: Update troubleshoot guide with reset info

### DIFF
--- a/docs/troubleshoot_general_tips.rst
+++ b/docs/troubleshoot_general_tips.rst
@@ -247,7 +247,7 @@ See `the github issue`_ to follow the work being done on the resolution.
 Past problems (fixed)
 =====================
 
-If you see any of the following issues, you'll need to update your repos and pull the latest images.
+If you see any of the following issues, you'll need to `update your repos and pull the latest images`_.
 
 Permission denied for copying studio-frontend JS & CSS during provisioning
 --------------------------------------------------------------------------
@@ -263,6 +263,19 @@ During ``make dev.provision``, the edx-platform script ``copy-node-modules.sh`` 
 
 This issue was introduced on edx-platform master in July 2023 and was resolved in August 2023 (without becoming part of a named release). See https://github.com/openedx/devstack/issues/1138 for more details, including a workaround for those unable to upgrade their repos or images for some reason.
 
+.. _update your repos and pull the latest images:
+Updating Devstack
+=================
+It is a good idea to periodically update your devstack to bring in new bug fixes. You can do this without losing any of your existing data or having to reprovision, although you will lose your container command history once you remove it. To update devstack to the latest images and code:
+1. `make dev.stop` This will stop all running containers
+2. `make dev.remove-containers` This will remove all stopped containers. After this you will not be able to get the command history back.
+3. `make dev.reset-repos` This will pull all the latest code into all your devstack service and MFE repos
+4. `git fetch && git pull` on the master branch in devstack. This will pull all the latest code into the devstack repo itself
+5. `make dev.pull.large-and-slow` This will pull all the latest images. If you only care about specific services/MFEs, you can replace this with `make dev.pull.lms+cms+other_service+other_MFE...`
+
+Depending on your needs, you may also want to run `make dev.migrate` to apply all the latest migrations and `make dev.static` to recompile static assets. Like with pulling images, you can also narrow these commands to specific services/MFEs with `make dev.migrate.lms+cms+...`
+
+Running `make dev.reset` will do all the above for all services, which can be useful but takes much more time. It will also run a full `docker system prune -f` to get rid of unused images and networks. 
 
 Starting From Scratch
 =====================

--- a/docs/troubleshoot_general_tips.rst
+++ b/docs/troubleshoot_general_tips.rst
@@ -273,7 +273,7 @@ To update devstack to the latest images and code:
 
 1. ``make dev.stop`` This will stop all running containers.
 2. ``make dev.reset-repos`` This will pull all the latest code into all your devstack service and MFE repos.
-3. ``git fetch && git pull`` on the master branch in devstack. This will pull all the latest code into the devstack repo itself
+3. ``git fetch && git pull`` on the master branch in devstack. This will pull all the latest code into the devstack repo itself.
 4. ``make dev.pull.lms`` This will pull the latest lms image and all its dependencies. If you need other services/MFEs, you can replace this with ``make dev.pull.lms+cms+other_service+other_MFE...`` or ``make dev.pull.large-and-slow`` if you really need everything.
 
 Depending on your needs, you may also want to run ``make dev.migrate.lms`` to apply all the latest migrations and/or ``make dev.static.lms`` to recompile static assets.

--- a/docs/troubleshoot_general_tips.rst
+++ b/docs/troubleshoot_general_tips.rst
@@ -267,7 +267,7 @@ This issue was introduced on edx-platform master in July 2023 and was resolved i
 
 Updating Devstack
 =================
-It may be that the bug you have encountered has already been resolved and you just need to update your devstack. You can do this without losing any of your existing data or having to reprovision, although you will lose your container command history once you pull new images. 
+It may be that the bug you have encountered has already been resolved and you just need to update your devstack. You can do this without losing any of your existing data or having to reprovision, although you will lose your container command history once you pull new images.
 
 To update devstack to the latest images and code:
 
@@ -276,10 +276,10 @@ To update devstack to the latest images and code:
 3. ``git fetch && git pull`` on the master branch in devstack. This will pull all the latest code into the devstack repo itself
 4. ``make dev.pull.lms`` This will pull the latest lms image and all its dependencies. If you need other services/MFEs, you can replace this with ``make dev.pull.lms+cms+other_service+other_MFE...`` or ``make dev.pull.large-and-slow`` if you really need everything.
 
-Depending on your needs, you may also want to run ``make dev.migrate.lms`` to apply all the latest migrations and/or ``make dev.static.lms`` to recompile static assets. 
+Depending on your needs, you may also want to run ``make dev.migrate.lms`` to apply all the latest migrations and/or ``make dev.static.lms`` to recompile static assets.
 Like with pulling images, you can also narrow these commands to specific services/MFEs with ``make dev.migrate.lms+cms+...,`` or run  ``make dev.migrate`` and ``make dev.static`` (no suffixes) to include everything.
 
-Running ``make dev.reset`` will do all the above for all services, which can be useful but takes much more time. It will also run a full ``docker system prune -f`` to get rid of unused images and networks. 
+Running ``make dev.reset`` will do all the above for all services, which can be useful but takes much more time. It will also run a full ``docker system prune -f`` to get rid of unused images and networks.
 
 Starting From Scratch
 =====================

--- a/docs/troubleshoot_general_tips.rst
+++ b/docs/troubleshoot_general_tips.rst
@@ -247,7 +247,7 @@ See `the github issue`_ to follow the work being done on the resolution.
 Past problems (fixed)
 =====================
 
-If you see any of the following issues, you'll need to `update your repos and pull the latest images`_.
+If you see any of the following issues, you'll need to `pull new code and images`_.
 
 Permission denied for copying studio-frontend JS & CSS during provisioning
 --------------------------------------------------------------------------
@@ -263,19 +263,23 @@ During ``make dev.provision``, the edx-platform script ``copy-node-modules.sh`` 
 
 This issue was introduced on edx-platform master in July 2023 and was resolved in August 2023 (without becoming part of a named release). See https://github.com/openedx/devstack/issues/1138 for more details, including a workaround for those unable to upgrade their repos or images for some reason.
 
-.. _update your repos and pull the latest images:
+.. _pull new code and images:
+
 Updating Devstack
 =================
-It is a good idea to periodically update your devstack to bring in new bug fixes. You can do this without losing any of your existing data or having to reprovision, although you will lose your container command history once you remove it. To update devstack to the latest images and code:
-1. `make dev.stop` This will stop all running containers
-2. `make dev.remove-containers` This will remove all stopped containers. After this you will not be able to get the command history back.
-3. `make dev.reset-repos` This will pull all the latest code into all your devstack service and MFE repos
-4. `git fetch && git pull` on the master branch in devstack. This will pull all the latest code into the devstack repo itself
-5. `make dev.pull.large-and-slow` This will pull all the latest images. If you only care about specific services/MFEs, you can replace this with `make dev.pull.lms+cms+other_service+other_MFE...`
+It may be that the bug you have encountered has already been resolved and you just need to update your devstack. You can do this without losing any of your existing data or having to reprovision, although you will lose your container command history once you pull new images. 
 
-Depending on your needs, you may also want to run `make dev.migrate` to apply all the latest migrations and `make dev.static` to recompile static assets. Like with pulling images, you can also narrow these commands to specific services/MFEs with `make dev.migrate.lms+cms+...`
+To update devstack to the latest images and code:
 
-Running `make dev.reset` will do all the above for all services, which can be useful but takes much more time. It will also run a full `docker system prune -f` to get rid of unused images and networks. 
+1. ``make dev.stop`` This will stop all running containers.
+2. ``make dev.reset-repos`` This will pull all the latest code into all your devstack service and MFE repos.
+3. ``git fetch && git pull`` on the master branch in devstack. This will pull all the latest code into the devstack repo itself
+4. ``make dev.pull.lms`` This will pull the latest lms image and all its dependencies. If you need other services/MFEs, you can replace this with ``make dev.pull.lms+cms+other_service+other_MFE...`` or ``make dev.pull.large-and-slow`` if you really need everything.
+
+Depending on your needs, you may also want to run ``make dev.migrate.lms`` to apply all the latest migrations and/or ``make dev.static.lms`` to recompile static assets. 
+Like with pulling images, you can also narrow these commands to specific services/MFEs with ``make dev.migrate.lms+cms+...,`` or run  ``make dev.migrate`` and ``make dev.static`` (no suffixes) to include everything.
+
+Running ``make dev.reset`` will do all the above for all services, which can be useful but takes much more time. It will also run a full ``docker system prune -f`` to get rid of unused images and networks. 
 
 Starting From Scratch
 =====================

--- a/docs/troubleshoot_general_tips.rst
+++ b/docs/troubleshoot_general_tips.rst
@@ -247,7 +247,7 @@ See `the github issue`_ to follow the work being done on the resolution.
 Past problems (fixed)
 =====================
 
-If you see any of the following issues, you'll need to `pull new code and images`_.
+If you see any of the following issues, you'll need to `update your repos and pull the latest images`_.
 
 Permission denied for copying studio-frontend JS & CSS during provisioning
 --------------------------------------------------------------------------
@@ -263,7 +263,7 @@ During ``make dev.provision``, the edx-platform script ``copy-node-modules.sh`` 
 
 This issue was introduced on edx-platform master in July 2023 and was resolved in August 2023 (without becoming part of a named release). See https://github.com/openedx/devstack/issues/1138 for more details, including a workaround for those unable to upgrade their repos or images for some reason.
 
-.. _pull new code and images:
+.. _update your repos and pull the latest images:
 
 Updating Devstack
 =================


### PR DESCRIPTION
Update the trouble shooting guide with more information on how to get the latest from devstack. The link doesn't work in GitHub viewer, but I checked the result of `make docs` and it works there. Will change the commit message to use "docs" instead of "feat" on merge.

I've completed each of the following or determined they are not applicable:

- [ ] Made a plan to communicate any major developer interface changes (or N/A)
