### PR TITLE
build: Don't run provisioning tests on docs-only PRs and pushes

### DIFF
--- a/.github/workflows/provisioning-tests.yml
+++ b/.github/workflows/provisioning-tests.yml
@@ -5,9 +5,11 @@ name: Provisioning tests
 on:
   push:
     branches: [master]
+    paths-ignore:
+      - '**.rst'
   pull_request:
-    branches:
-      - '**'
+    paths-ignore:
+      - '**.rst'
   schedule:
     # run at 7:30 am M-F
     - cron: '30 11 * * 1-5'


### PR DESCRIPTION
NB: This approach will only works so long as the provisioning tests are not required.

Also, drop the `branches: **` directive, which looks like a no-op.

- See https://github.com/openedx/devstack/pull/1174 for an example of a docs-only PR with this change in effect.
- https://github.com/openedx/devstack/pull/1175 shows a mix of doc and non-doc changes

----

I've completed each of the following or determined they are not applicable:

- [x] Made a plan to communicate any major developer interface changes (or N/A)
