### PR TITLE
build: Auto-add issues to Arch-BOM's project

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,16 @@
+name: Add new issues to appropriate GitHub Projects
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add_to_arch_bom_board:
+    uses: openedx/.github/.github/workflows/add-issue-to-a-project.yml@master
+    secrets:
+      GITHUB_APP_ID: ${{ secrets.GRAPHQL_AUTH_APP_ID }}
+      GITHUB_APP_PRIVATE_KEY: ${{ secrets.GRAPHQL_AUTH_APP_PEM }}
+    with:
+      ORGANIZATION: edx
+      PROJECT_NUMBER: 11


### PR DESCRIPTION
As maintainers, we've been missing some issues that have been filed against the repo. Hopefully this will fix that.

Ticket: https://github.com/edx/edx-arch-experiments/issues/368

----

I've completed each of the following or determined they are not applicable:

- [x] Made a plan to communicate any major developer interface changes (or N/A)
