### PR TITLE
Upgrade redis to 7.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -239,7 +239,7 @@ services:
   redis:
     container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.redis"
     hostname: redis.devstack.edx
-    image: redis:6.2.12
+    image: redis:7.2
     command: redis-server --requirepass password
     networks:
       default:


### PR DESCRIPTION
**Description**
- Upgrading redis to 7.2. 
- Redis 7.2 has already been upgraded and tested in sandbox ([configuration-PR#7020](https://github.com/openedx/configuration/pull/7020))

**Issue link**
- https://github.com/openedx/platform-roadmap/issues/283

