### PR TITLE
test: Fix provisioning tests by ignoring maybe-missing google-cloud-sdk

### DIFF
--- a/.github/workflows/provisioning-tests.yml
+++ b/.github/workflows/provisioning-tests.yml
@@ -51,7 +51,10 @@ jobs:
           docker compose --version
 
       - name: free up disk space
-        run:  sudo apt remove --purge -y ghc-* azure-cli google-cloud-sdk hhvm llvm-* dotnet-* powershell mono-* php* ruby*
+        # 2023-09-28: google-cloud-sdk removed from this list because it was intermittently
+        #   unavailable as an apt package to remove, and might be migrating to snap. If more
+        #   disk space is needed, see if the snap is installed, and remove that.
+        run:  sudo apt remove --purge -y ghc-* azure-cli hhvm llvm-* dotnet-* powershell mono-* php* ruby*
 
       - name: set up requirements
         run:  make requirements


### PR DESCRIPTION
We're seeing intermittent provisioning failures with this message:

```
No apt package "google-cloud-sdk", but there is a snap with that name.
Try "snap install google-cloud-sdk"

E: Unable to locate package google-cloud-sdk
Error: Process completed with exit code 100.
```

I couldn't figure out why, but all we care about is that it's gone, so I'm adding a wildcard. (It is also unlikely that there are any packages that we *do* want that have that prefix.)

----

I've completed each of the following or determined they are not applicable:

- [x] Made a plan to communicate any major developer interface changes (or N/A)
