### PR TITLE
feat: Unify wait-ready with check.sh; implement mongo wait

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -46,7 +46,7 @@ run_check() {
     if $cmd; then  # Run the command itself and check if it succeeded.
         succeeded="$succeeded $check_name"
     else
-        docker compose logs -n30 "$service"
+        docker compose logs --tail 30 "$service"  # Just show recent logs, not all history
         failed="$failed $check_name"
     fi
     set -e  # Re-enable exit-on-error

--- a/check.sh
+++ b/check.sh
@@ -46,12 +46,35 @@ run_check() {
     if $cmd; then  # Run the command itself and check if it succeeded.
         succeeded="$succeeded $check_name"
     else
-        docker compose logs "$service"
+        docker compose logs -n30 "$service"
         failed="$failed $check_name"
     fi
     set -e  # Re-enable exit-on-error
     echo  # Newline
 }
+
+mysql_run_check() {
+    container_name="$1"
+    mysql_probe="SELECT EXISTS(SELECT 1 FROM mysql.user WHERE user = 'root')"
+    run_check "${container_name}_query" "$container_name" \
+        "docker compose exec -T $(printf %q "$container_name") mysql -uroot -se $(printf %q "$mysql_probe")"
+}
+
+if should_check mysql57; then
+    echo "Checking MySQL 5.7 query endpoint:"
+    mysql_run_check mysql57
+fi
+
+if should_check mysql80; then
+    echo "Checking MySQL 8.0 query endpoint:"
+    mysql_run_check mysql80
+fi
+
+if should_check mongo; then
+    echo "Checking MongoDB status:"
+    run_check mongo_status mongo \
+        "docker compose exec -T mongo mongo --eval \"db.serverStatus()\""
+fi
 
 if should_check registrar; then
     echo "Checking Registrar heartbeat:"
@@ -64,13 +87,15 @@ if should_check lms; then
     run_check lms_heartbeat lms \
         "curl --fail -L http://localhost:18000/heartbeat"
 
-    echo "Checking CMS heartbeat:"
-    run_check cms_heartbeat lms \
-        "curl --fail -L http://localhost:18010/heartbeat"
-
     echo "Validating LMS volume:"
     run_check lms_volume lms \
         "make validate-lms-volume"
+fi
+
+if should_check cms; then
+    echo "Checking CMS heartbeat:"
+    run_check cms_heartbeat cms \
+        "curl --fail -L http://localhost:18010/heartbeat"
 fi
 
 if should_check ecommerce; then

--- a/check.sh
+++ b/check.sh
@@ -43,7 +43,7 @@ run_check() {
     local cmd="$3"
     echo "> $cmd"
     set +e  # Disable exit-on-error
-    if $cmd; then  # Run the command itself and check if it succeeded.
+    if bash -c "$cmd"; then  # Run the command itself and check if it succeeded.
         succeeded="$succeeded $check_name"
     else
         docker compose logs --tail 30 "$service"  # Just show recent logs, not all history

--- a/provision.sh
+++ b/provision.sh
@@ -160,7 +160,7 @@ docker compose exec -T mysql80 bash -e -c "mysql -uroot mysql" < provision-mysql
 if needs_mongo "$to_provision_ordered"; then
 	echo -e "${GREEN}Waiting for MongoDB...${NC}"
 	# mongo container and mongo process/shell inside the container
-        ./wait-ready.sh mongo
+	./wait-ready.sh mongo
 	echo -e "${GREEN}MongoDB ready.${NC}"
 	echo -e "${GREEN}Creating MongoDB users...${NC}"
     docker compose exec -T mongo bash -e -c "mongo" < mongo-provision.js

--- a/provision.sh
+++ b/provision.sh
@@ -160,11 +160,7 @@ docker compose exec -T mysql80 bash -e -c "mysql -uroot mysql" < provision-mysql
 if needs_mongo "$to_provision_ordered"; then
 	echo -e "${GREEN}Waiting for MongoDB...${NC}"
 	# mongo container and mongo process/shell inside the container
-	until docker compose exec -T mongo mongo --eval "db.serverStatus()" &> /dev/null
-	do
-	  printf "."
-	  sleep 1
-	done
+        ./wait-ready.sh mongo
 	echo -e "${GREEN}MongoDB ready.${NC}"
 	echo -e "${GREEN}Creating MongoDB users...${NC}"
     docker compose exec -T mongo bash -e -c "mongo" < mongo-provision.js

--- a/wait-ready.sh
+++ b/wait-ready.sh
@@ -15,26 +15,10 @@ if [[ $# == 0 ]]; then
     exit 0
 fi
 
-function wait_db {
-    container_name="$1"
-    mysql_probe="SELECT EXISTS(SELECT 1 FROM mysql.user WHERE user = 'root')"
-    until docker compose exec -T "$container_name" mysql -uroot -se "$mysql_probe" &> /dev/null; do
+for service_name in "$@"; do
+    until ./check.sh "$service_name" >/dev/null 2>&1; do
         printf "." >&2
         sleep 1
     done
-    echo >&2 "$container_name is ready"
-}
-
-
-for service_name in "$@"; do
-    case "$service_name" in
-        mysql*)
-            wait_db "$service_name"
-            ;;
-        # TODO: Add other services...
-        *)
-            echo >&2 "Unknown service: $service_name"
-            exit 1
-            ;;
-    esac
+    echo >&2 "$service_name is ready"
 done


### PR DESCRIPTION
- Move MySQL readiness checks from wait-ready.sh to existing check.sh, and call check.sh for any service we want to wait for
- Add Mongo readiness check to check.sh, and use it from provisioning
- Give cms a separate check from lms
- Limit docker log output to 30 lines when check fails

----

I've completed each of the following or determined they are not applicable:

- [x] Made a plan to communicate any major developer interface changes (or N/A)
