### PR TITLE
chore: add mysql8 upgrade instructions

### DIFF
--- a/docs/manual_upgrades.rst
+++ b/docs/manual_upgrades.rst
@@ -7,6 +7,45 @@ Please add new instructions to the top, include a date, and make a post in the `
 
 (If you just need to update your devstack to the latest version of everything, see :doc:`updating_devstack`.)
 
+2023-10-05 - MySQL upgrade from version 5.7 to 8.0
+**************************************************
+
+The MySQL service has been upgraded from version 5.7 to 8.0. Developers will need to follow the following instructions.
+
+1. Stop the running containers ::
+
+    make dev.stop
+
+2. Take latest ``git pull`` of ``devstack`` and ``edx-platform``
+3. Take the latest pull of images ::
+
+    make dev.pull
+
+4. Run provisioning command ::
+
+    make dev.provision
+
+5. [Optional] Additionally, there is a database copy command to help you transfer data from MySQL 5.7 to 8.0. After provisioning use the following command ::
+
+    make dev.dbcopyall8
+
+This command copies the following databases:
+
+- credentials
+- discovery
+- ecommerce
+- registrar
+- notes
+- edxapp
+- xqueue
+- edxapp_csmh
+- dashboard
+- analytics-api
+- reports
+- reports_v1
+
+If you prefer not to copy all databases, update ``DB_NAMES_LIST`` in the ``Makefile`` of devstack before running the dbcopy command.
+
 2023-08-02 - Forum upgrade from Ruby 2 to 3
 *******************************************
 


### PR DESCRIPTION
Added instructions to upgrade mysql version from 5.7 to 8.0.

**Related PR**
- https://github.com/openedx/devstack/pull/1189