### PR TITLE
chore: update dbcopyall8 command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -469,8 +469,8 @@ dev.dbcopyall8: ## Clean mysql80 container and copy data from old mysql 5.7 cont
 	$(MAKE) dev.remove-containers.mysql80
 	docker volume rm devstack_mysql80_data
 	$(MAKE) dev.up.mysql57+mysql80
-	sleep 10
 	$(MAKE) dev.wait-for.mysql57+mysql80
+	sleep 10
 	docker compose exec -T mysql80 mysql -uroot mysql < provision-mysql80.sql
 	$(MAKE) $(_db_copy8_targets)
 	$(MAKE) stop

--- a/Makefile
+++ b/Makefile
@@ -462,21 +462,16 @@ dev.shell.%: ## Run a shell on the specified service's container.
 dev.dbshell:
 	docker compose exec mysql80 bash -c "mysql"
 
-dev.dbsetupmysql8:
-	docker compose exec -T mysql80 bash -e -c "mysql -uroot mysql" < provision-mysql80.sql
-
-dev.dbcleanmysql8:
-	docker container rm edx.devstack.mysql80
-	docker volume rm devstack_mysql80_data
-
 DB_NAMES_LIST = credentials discovery ecommerce notes registrar xqueue edxapp edxapp_csmh dashboard analytics-api reports reports_v1
 _db_copy8_targets = $(addprefix dev.dbcopy8.,$(DB_NAMES_LIST))
 dev.dbcopyall8: ## Clean mysql80 container and copy data from old mysql 5.7 containers into new mysql8 dbs
 	$(MAKE) stop
-	$(MAKE) dev.dbcleanmysql8
+	$(MAKE) dev.remove-containers.mysql80
+	docker volume rm devstack_mysql80_data
 	$(MAKE) dev.up.mysql57+mysql80
+	sleep 10
 	$(MAKE) dev.wait-for.mysql57+mysql80
-	$(MAKE) dev.dbsetupmysql8
+	docker compose exec -T mysql80 mysql -uroot mysql < provision-mysql80.sql
 	$(MAKE) $(_db_copy8_targets)
 	$(MAKE) stop
 

--- a/Makefile
+++ b/Makefile
@@ -462,12 +462,23 @@ dev.shell.%: ## Run a shell on the specified service's container.
 dev.dbshell:
 	docker compose exec mysql80 bash -c "mysql"
 
+dev.dbsetupmysql8:
+	docker compose exec -T mysql80 bash -e -c "mysql -uroot mysql" < provision-mysql80.sql
+
+dev.dbcleanmysql8:
+	docker container rm edx.devstack.mysql80
+	docker volume rm devstack_mysql80_data
+
 DB_NAMES_LIST = credentials discovery ecommerce notes registrar xqueue edxapp edxapp_csmh dashboard analytics-api reports reports_v1
 _db_copy8_targets = $(addprefix dev.dbcopy8.,$(DB_NAMES_LIST))
-dev.dbcopyall8: ## Copy data from old mysql 5.7 containers into new mysql8 dbs
+dev.dbcopyall8: ## Clean mysql80 container and copy data from old mysql 5.7 containers into new mysql8 dbs
+	$(MAKE) stop
+	$(MAKE) dev.dbcleanmysql8
 	$(MAKE) dev.up.mysql57+mysql80
 	$(MAKE) dev.wait-for.mysql57+mysql80
+	$(MAKE) dev.dbsetupmysql8
 	$(MAKE) $(_db_copy8_targets)
+	$(MAKE) stop
 
 dev.dbcopy8.%: ## Copy data from old mysql 5.7 container into a new 8 db
 	docker compose exec mysql57 mysqldump "$*" > .dev/$*.sql

--- a/docs/manual_upgrades.rst
+++ b/docs/manual_upgrades.rst
@@ -12,20 +12,17 @@ Please add new instructions to the top, include a date, and make a post in the `
 
 The MySQL service has been upgraded from version 5.7 to 8.0. Developers will need to follow the following instructions.
 
-1. Stop the running containers ::
+1. Take latest ``git pull`` of ``devstack`` and ``edx-platform``.
 
-    make dev.stop
-
-2. Take latest ``git pull`` of ``devstack`` and ``edx-platform``
-3. Take the latest pull of images ::
+2. Take the latest pull of images ::
 
     make dev.pull
 
-4. Run provisioning command ::
+3. Run provisioning command ::
 
     make dev.provision
 
-5. [Optional] Additionally, there is a database copy command to help you transfer data from MySQL 5.7 to 8.0. After provisioning use the following command ::
+4. [Optional] Additionally, there is a database copy command to help you transfer data from MySQL 5.7 to 8.0. After provisioning use the ``dev.dbcopyall8`` command. This command will stop all of your services. Will clean your ``mysql80`` container and copy all of your databases from ``mysql57`` to ``mysql80``. ::
 
     make dev.dbcopyall8
 
@@ -45,6 +42,15 @@ This command copies the following databases:
 - reports_v1
 
 If you prefer not to copy all databases, update ``DB_NAMES_LIST`` in the ``Makefile`` of devstack before running the dbcopy command.
+
+5. Now start your desired services again using ``dev.up`` command. For example running following command will start ``lms``, ``cms`` ::
+
+    make dev.up.lms+cms
+
+6. You might need to apply latest migrations to your ``mysql80`` container for some services. To do that, you can use ``dev.migrate`` command. For example for ``lms`` you can run ::
+
+    make dev.migrate.lms
+
 
 2023-08-02 - Forum upgrade from Ruby 2 to 3
 *******************************************

--- a/docs/manual_upgrades.rst
+++ b/docs/manual_upgrades.rst
@@ -22,7 +22,7 @@ The MySQL service has been upgraded from version 5.7 to 8.0. Developers will nee
 
     make dev.provision
 
-4. [Optional] Additionally, there is a database copy command to help you transfer data from MySQL 5.7 to 8.0. After provisioning use the ``dev.dbcopyall8`` command. This command will stop all of your services. Will clean your ``mysql80`` container and copy all of your databases from ``mysql57`` to ``mysql80``. ::
+4. [Optional] Additionally, there is a database copy command to help you transfer data from MySQL 5.7 to 8.0. After provisioning use the ``dev.dbcopyall8`` command. This command will stop all of your services, clean your ``mysql80`` container, and copy all of your databases from ``mysql57`` to ``mysql80``. ::
 
     make dev.dbcopyall8
 


### PR DESCRIPTION
The previous `dbcoopyall8` command causing `operational errors`

The occurrence of the `operational errors: table already exists issue` can be traced to the following:
- During the `provisioning` process, the `mysql80 container` is populated with the `most recent data`, (new migrations/tables).
- When `data is transferred` from `mysql57` using `dbcopyall8` command, the `newly created tables persist` in the mysql80 container. But, the `django_migrations` table becomes `outdated` in this process.
- Consequently, the `records` for any new migration `are removed` from the `django_migrations` table. This leads to a failure when attempting to execute dev.migrate.

This PR is to fix the above-mentioned issue.
It will wipe out all the data of `mysql8` before actually dumping `mysql57` data inside `mysql80` container.