### PR TITLE
feat: remove JWT_AUTH_REFRESH_COOKIE depr190

### DIFF
--- a/configuration_files/analytics_api.yml
+++ b/configuration_files/analytics_api.yml
@@ -47,7 +47,6 @@ EXTRA_APPS: []
 JWT_AUTH:
     JWT_AUTH_COOKIE_HEADER_PAYLOAD: edx-jwt-cookie-header-payload
     JWT_AUTH_COOKIE_SIGNATURE: edx-jwt-cookie-signature
-    JWT_AUTH_REFRESH_COOKIE: edx-jwt-refresh-cookie
     JWT_ISSUERS:
     -   AUDIENCE: SET-ME-PLEASE
         ISSUER: http://127.0.0.1:8000/oauth2

--- a/configuration_files/discovery.yml
+++ b/configuration_files/discovery.yml
@@ -62,7 +62,6 @@ EXTRA_APPS:
 JWT_AUTH:
     JWT_AUTH_COOKIE_HEADER_PAYLOAD: edx-jwt-cookie-header-payload
     JWT_AUTH_COOKIE_SIGNATURE: edx-jwt-cookie-signature
-    JWT_AUTH_REFRESH_COOKIE: edx-jwt-refresh-cookie
     JWT_ISSUERS:
     -   AUDIENCE: lms-key
         ISSUER: http://edx.devstack.lms:18000/oauth2


### PR DESCRIPTION
**Description:**
The setting JWT_AUTH_REFRESH_COOKIE is meaningless and unused and should be cleaned up to avoid confusion.
In the very early days of introducing MFEs, we thought we were going to need this cookie in addition to the JWT cookie. However, it turned out we didn't need it, but the setting stuck around the contagion of it (being in cookiecutter and other template libraries) has resulted in it uselessly being copied to many repos.

**Supporting information:**
as per the original ticket https://github.com/openedx/public-engineering/issues/190, this setting is removed.

**Rationale**
The setting JWT_AUTH_REFRESH_COOKIE is meaningless and unused, and should be cleaned up to avoid confusion.

In the very early days of introducing MFEs, we thought we were going to need this cookie in addition to the JWT cookie. However, it turned out we didn't need it, but the setting stuck around the contagion of it (being in cookiecutter and other template libraries) has resulted in it uselessly being copied to many repos.

**Removal**
The setting JWT_AUTH_REFRESH_COOKIE can simply be removed with no ramifications.