### PR TITLE
docs: switch prune to make command

### DIFF
--- a/docs/troubleshoot_general_tips.rst
+++ b/docs/troubleshoot_general_tips.rst
@@ -64,7 +64,7 @@ Try this first to clean up dangling images:
 
 .. code:: sh
 
-   docker system prune -f  # (This is very safe, so try this first.)
+   make dev.prune  # (This is very safe, so try this first.)
 
 If you are still seeing issues, you can try cleaning up dangling volumes.
 


### PR DESCRIPTION
Switch doc to `make dev.prune`, which is simpler to  remember should the issue recur, rather than always having to read these docs.

Note: I didn't know the make command existed for this, and it was useful to learn about.

----

I've completed each of the following or determined they are not applicable:

- [ ] Made a plan to communicate any major developer interface changes (or N/A)
