### PR TITLE
fix: launch opensearch container without SSL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,7 @@ services:
       - discovery.type=single-node
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - "plugins.security.disabled=true"
 
   firefox:
     container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.firefox"


### PR DESCRIPTION
Leaving security on in devstack results in openseach freaking out as it fails to get its TLS running. With this change OS is running and usable.

Actually using opensearch requires changes in lms/cms private.py or other settings files.

Tested locally where OS didn't work, and now it does.

----

I've completed each of the following or determined they are not applicable:

- [x] Made a plan to communicate any major developer interface changes (N/A)
