### PR TITLE
fix: upgraded neo4j image to latest 5.15.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     hostname: coursegraph.devstack.edx
     # Try to keep this in sync with the NEO4J_VERSION declared within
     # https://github.com/openedx/configuration/blob/master/playbooks/roles/neo4j
-    image: neo4j:3.5.28
+    image: neo4j:5.15.0
     networks:
       default:
         aliases:
@@ -48,7 +48,7 @@ services:
     stdin_open: true
     tty: true
     environment:
-      NEO4J_AUTH: "neo4j/edx"  # Initial username/password for Neo4j Web interface.
+      NEO4J_AUTH: "neo4j/edxedxedx"  # Initial username/password for Neo4j Web interface.
 
   elasticsearch710:
     container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.elasticsearch710"

--- a/provision-coursegraph.sh
+++ b/provision-coursegraph.sh
@@ -17,6 +17,6 @@ docker compose up -d coursegraph cms
 sleep 10  # Give Neo4j some time to boot up.
 
 echo -e "${GREEN}   Updating CMS courses in Coursegraph...${NC}"
-docker compose exec cms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && ./manage.py cms dump_to_neo4j --host coursegraph.devstack.edx --user neo4j --password edx'
+docker compose exec cms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && ./manage.py cms dump_to_neo4j --host coursegraph.devstack.edx --user neo4j --password edxedxedx'
 
 echo -e "${GREEN}   Coursegraph is now up-to-date with CMS!${NC}"


### PR DESCRIPTION
Latest Neo4J image is 5.15.0 which has been updated in docker-compose and it requires atleast 8 characters long password that's why added `edxedxedx` to fulfill the requirements.
Issue: https://github.com/edx/edx-arch-experiments/issues/449
End of life information can be viewed [here](https://endoflife.date/neo4j)