### PR TITLE
Support mongosh

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -174,7 +174,8 @@ services:
     # We use WiredTiger in all environments. In development environments we use small files
     # to conserve disk space, and disable the journal for a minor performance gain.
     # See https://docs.mongodb.com/v3.0/reference/program/mongod/#options for complete details.
-    command: mongod --nojournal --storageEngine wiredTiger
+    # --nojournal is not available in recent mongo versions, it's always enabled.
+    command: mongod --storageEngine wiredTiger
     container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.mongo"
     hostname: mongo.devstack.edx
     image: mongo:${MONGO_VERSION:-5.0.24}

--- a/provision.sh
+++ b/provision.sh
@@ -143,12 +143,19 @@ docker compose exec -T mysql80 bash -e -c "mysql -uroot mysql" < provision-mysql
 # If necessary, ensure the MongoDB server is online and usable
 # and create its users.
 if needs_mongo "$to_provision_ordered"; then
+	set +e
+	MONGO_SHELL=$(docker-compose exec -T mongo which mongosh)
+	set -e
 	echo -e "${GREEN}Waiting for MongoDB...${NC}"
 	# mongo container and mongo process/shell inside the container
 	make dev.wait-for.mongo
 	echo -e "${GREEN}MongoDB ready.${NC}"
 	echo -e "${GREEN}Creating MongoDB users...${NC}"
-    docker compose exec -T mongo bash -e -c "mongo" < mongo-provision.js
+	if [ -z $MONGO_SHELL ]; then
+		docker-compose exec -T mongo bash -e -c "mongo" < mongo-provision.js;
+	else
+		docker-compose exec -T mongo bash -e -c "mongosh" < mongo-provision.js;
+	fi
 else
 	echo -e "${GREEN}MongoDB preparation not required; skipping.${NC}"
 fi

--- a/upgrade_mongo_5_0.sh
+++ b/upgrade_mongo_5_0.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eu -o pipefail
 
-# This script will upgrade a devstack that was previosly running Mongo DB 4.4 to MongoDB 5.0.24
+# This script will upgrade a devstack that was previosly running Mongo DB 4.x to MongoDB 5.x
 
 . scripts/colors.sh
 

--- a/upgrade_mongo_6_0.sh
+++ b/upgrade_mongo_6_0.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+# This script will upgrade a devstack that was previosly running Mongo DB 5.x to MongoDB 6.x
+
+. scripts/colors.sh
+
+# Upgrade to mongo 6.0
+export MONGO_VERSION=6.0.12
+
+echo
+echo -e "${GREEN}Restarting Mongo on version ${MONGO_VERSION}${NC}"
+make dev.up.mongo
+mongo_container="$(make --silent --no-print-directory dev.print-container.mongo)"
+
+echo -e "${GREEN}Waiting for MongoDB...${NC}"
+until docker exec "$mongo_container" mongosh --eval 'db.serverStatus()' &> /dev/null
+do
+    printf "."
+    sleep 1
+done
+
+echo -e "${GREEN}MongoDB ready.${NC}"
+MONGO_VERSION_LIVE=$(docker exec -it "$mongo_container" mongosh --quiet --eval "printjson(db.version())")
+MONGO_VERSION_COMPAT=$(docker exec -it "$mongo_container" mongosh --quiet \
+    --eval "printjson(db.adminCommand( { getParameter: 1, featureCompatibilityVersion: 1 } )['featureCompatibilityVersion'])")
+echo -e "${GREEN}Mongo Server version: ${MONGO_VERSION_LIVE}${NC}"
+echo -e "${GREEN}Mongo FeatureCompatibilityVersion version: ${MONGO_VERSION_COMPAT}${NC}"
+
+echo -e "${GREEN}Upgrading FeatureCompatibilityVersion to 6.0${NC}"
+docker exec -it "$mongo_container" mongosh --eval "db.adminCommand( { setFeatureCompatibilityVersion: \"6.0\" } )"

--- a/upgrade_mongo_7_0.sh
+++ b/upgrade_mongo_7_0.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+# This script will upgrade a devstack that was previosly running Mongo DB 6.x to MongoDB 7.x
+
+. scripts/colors.sh
+
+# Upgrade to mongo 7.0
+export MONGO_VERSION=7.0.5
+
+echo
+echo -e "${GREEN}Restarting Mongo on version ${MONGO_VERSION}${NC}"
+make dev.up.mongo
+mongo_container="$(make --silent --no-print-directory dev.print-container.mongo)"
+
+echo -e "${GREEN}Waiting for MongoDB...${NC}"
+until docker exec "$mongo_container" mongosh --eval 'db.serverStatus()' &> /dev/null
+do
+    printf "."
+    sleep 1
+done
+
+echo -e "${GREEN}MongoDB ready.${NC}"
+MONGO_VERSION_LIVE=$(docker exec -it "$mongo_container" mongosh --quiet --eval "printjson(db.version())")
+MONGO_VERSION_COMPAT=$(docker exec -it "$mongo_container" mongosh --quiet \
+    --eval "printjson(db.adminCommand( { getParameter: 1, featureCompatibilityVersion: 1 } )['featureCompatibilityVersion'])")
+echo -e "${GREEN}Mongo Server version: ${MONGO_VERSION_LIVE}${NC}"
+echo -e "${GREEN}Mongo FeatureCompatibilityVersion version: ${MONGO_VERSION_COMPAT}${NC}"
+
+echo -e "${GREEN}Upgrading FeatureCompatibilityVersion to 7.0${NC}"
+docker exec -it "$mongo_container" mongosh --eval "db.adminCommand( { setFeatureCompatibilityVersion: \"7.0\" } )"


### PR DESCRIPTION
# Description

The `mongo` CLI utility is being deprecated in 5.0 and fully removed in mongo 6.0, and replaced with `mongosh`. This PR adds `mongosh` compatibility and also adds upgrade scripts up to 7.0.

# Testing

- Run the `upgrade_mongo_5_0.sh` scripts up until `upgrade_mongo_7_0.sh`.
- Make sure LMS and CMS works smoothly.

----

I've completed each of the following or determined they are not applicable:

- [x] Made a plan to communicate any major developer interface changes (or N/A)
