### PR TITLE
build: Remove angle brackets from workflow error message

### DIFF
--- a/.github/workflows/provisioning-tests.yml
+++ b/.github/workflows/provisioning-tests.yml
@@ -92,7 +92,8 @@ jobs:
            to: devstack-provisioning-tests@2u-internal.opsgenie.net
            from: github-actions <github-actions@edx.org>
            body: |
-             Devstack provisioning tests in ${{github.repository}} for ${{matrix.services}} failed! For details see <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}>.
+             Devstack provisioning tests in ${{github.repository}} for ${{matrix.services}} failed!
+             For details, see https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
              Runbook url: https://2u-internal.atlassian.net/wiki/spaces/AT/pages/16384920/Failure+Devstack+provisioning+tests+-+Runbook
 
       - name: close alerts on success


### PR DESCRIPTION
Opsgenie doesn't handle angle brackets properly, so work around them by removing all punctuation from around the URL. (I already raised this with their support folks, but they consider this a wontfix.)

Also move it to another line for readability in diffs.

----

I've completed each of the following or determined they are not applicable:

- [x] Made a plan to communicate any major developer interface changes (or N/A)
