### PR TITLE
fix: add build.os to fix the failing docs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,11 @@
 # Required
 version: 2
 
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.8"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
Docs build has been failing for the last 4 months. These build details are necessary.

https://readthedocs.org/projects/open-edx-devstack/builds/?page=3

RTD Docs: https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os

----

I've completed each of the following or determined they are not applicable:

- [ ] Made a plan to communicate any major developer interface changes (or N/A)
