### PR TITLE
build: use mysqldump to backup/restore databases

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -418,7 +418,6 @@ services:
       - memcached
       - mongo
       - mysql80
-      - mysql57
     # Allows attachment to the LMS service using 'docker attach <containerID>'.
     stdin_open: true
     tty: true


### PR DESCRIPTION
Use `mysqldump` to backup and restore mysql data.

Helps avoid the risk of data corruption trying to tar `/var/lib/mysql` and copying back to some other virtualization/filesystem/whatever.
