### PR TITLE
fix: update .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,6 +15,5 @@ sphinx:
   configuration: docs/conf.py
 
 python:
-  version: 3.8
   install:
     - requirements: requirements/doc.txt


### PR DESCRIPTION
Attempt to fix the build. It is unclear why this is failing, so simply attempting to match the following as closely as possible:
https://docs.readthedocs.io/en/stable/config-file/v2.html

The failure no longer has an error (which used to be around missing os), and the raw output is missing the call:
> cat .readthedocs.yaml

It's unclear what is breaking. I'm attempting to clean-up the redundant python version reference to see what happens.

**Additional Context:**

* Here is where it went from passing to failing: https://readthedocs.org/projects/open-edx-devstack/builds/?page=3
* Last passing build details: https://readthedocs.org/projects/open-edx-devstack/builds/22194482/
  * View raw output for additional details.
* Latest failing build details: https://readthedocs.org/projects/open-edx-devstack/builds/23559660/
  * Raw output doesn't seem to provide much. It just dies.
* There was a rename from `.readthedocs.yml` to `readthedocs.yaml` not long before the failures, but the build was passing after this rename.

----

I've completed each of the following or determined they are not applicable:

- [ ] Made a plan to communicate any major developer interface changes (or N/A)
